### PR TITLE
perf(screenshot): crop watermark inward to cut VRAM instead of expanding the window

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -878,11 +878,10 @@ app.on('ready', async () => {
 			workerWindow?.webContents.send('session-info', iracing.sessionInfo);
 			workerWindow?.webContents.send('telemetry', iracing.telemetry);
 			// Forward targetWidth/targetHeight so saveReshadeImage in the worker
-			// can crop to the user-chosen resolution. Without these, the crop
-			// branches in Worker.vue fall through and the saved image keeps the
-			// 6%-expanded dimensions used to generate the watermark margin
-			// (regression introduced in 2cf3ccf — non-ReShade path was wired,
-			// ReShade path was missed).
+			// can crop the watermark out. Without these, the crop branches in
+			// Worker.vue fall through and the saved image keeps the full render
+			// size with the watermark still in it (regression introduced in
+			// 2cf3ccf — non-ReShade path was wired, ReShade path was missed).
 			workerWindow?.webContents.send('screenshot-reshade', {
 				file: reshadeFile,
 				targetWidth: data.targetWidth,

--- a/src/renderer/components/SettingsModal.vue
+++ b/src/renderer/components/SettingsModal.vue
@@ -181,8 +181,8 @@
 								>Prefer top-left watermark crop</span
 							>
 							<span class="description"
-								>Crops only the bottom-right corner (3% expansion). When
-								off, the screenshot is expanded by 6% and cropped
+								>Crops only the bottom-right corner (3%). When
+								off, the screenshot is cropped (6% total)
 								equally from all sides for a centered result.</span
 							>
 						</label>

--- a/src/renderer/components/SideBar.vue
+++ b/src/renderer/components/SideBar.vue
@@ -387,21 +387,32 @@ export default {
 			// Custom is selected with empty inputs (matches the legacy default
 			// branch in the previous switch-based implementation).
 			const target = this.targetDimensions || { width: 1920, height: 1080 };
-			let w = target.width;
-			let h = target.height;
 
-			const targetWidth = w;
-			const targetHeight = h;
+			// iRacing's window is resized to EXACTLY the selected resolution —
+			// never larger — so its DX11 framebuffer/VRAM cost is bounded by the
+			// chosen resolution. The watermark is removed by cropping INWARD from
+			// the captured frame (targetWidth/targetHeight below), so the saved
+			// image ends up slightly smaller than the nominal resolution. The old
+			// approach expanded the window 6%/3% and cropped back to the full
+			// nominal size, forcing iRacing to render ~12% more pixels at exactly
+			// the high resolutions where it OOM-crashes.
+			const w = target.width;
+			const h = target.height;
+
+			// Crop output = render size minus the watermark margin. Worker.vue
+			// extracts a (targetWidth x targetHeight) region from the w x h frame.
+			let targetWidth = w;
+			let targetHeight = h;
 
 			const cropTopLeft = config.get('cropTopLeft');
 			if (this.crop && cropTopLeft) {
-				// Legacy: expand 3% so cropping bottom-right removes watermark
-				w += Math.ceil(w * 0.03);
-				h += Math.ceil(h * 0.03);
+				// Legacy: crop 3% off the bottom-right corner to remove the watermark
+				targetWidth = w - Math.ceil(w * 0.03);
+				targetHeight = h - Math.ceil(h * 0.03);
 			} else if (this.crop) {
-				// Default: expand 6% so cropping 3% from each side removes watermark
-				w += Math.ceil(w * 0.06);
-				h += Math.ceil(h * 0.06);
+				// Default: crop 3% from each side (6% total) to remove the watermark
+				targetWidth = w - Math.ceil(w * 0.06);
+				targetHeight = h - Math.ceil(h * 0.06);
 			}
 			this.takingScreenshot = true;
 			this.$emit('screenshot', {

--- a/src/renderer/components/SideBar.vue
+++ b/src/renderer/components/SideBar.vue
@@ -16,10 +16,14 @@
 			<o-input v-model="customHeight" type="number" min="0" max="10000" />
 		</o-field>
 
-		<p v-if="targetDimensions" class="sidebar-target-hint">
-			Target:
+		<p v-if="outputDimensions" class="sidebar-target-hint">
+			Output:
 			<span class="sidebar-target-hint__value"
-				>{{ targetDimensions.width }} ×
+				>{{ outputDimensions.width }} ×
+				{{ outputDimensions.height }}</span
+			>
+			<span v-if="crop" class="sidebar-target-hint__render"
+				>· renders at {{ targetDimensions.width }} ×
 				{{ targetDimensions.height }}</span
 			>
 		</p>
@@ -232,6 +236,7 @@ export default {
 			takingScreenshot: false,
 			disableTooltips: config.get('disableTooltips'),
 			reshade: config.get('reshade'),
+			cropTopLeft: config.get('cropTopLeft'),
 			configWarnings: checkIracingConfig(),
 		};
 	},
@@ -269,6 +274,20 @@ export default {
 				return base;
 			}
 			return { width: base.width, height: adjustedHeight };
+		},
+		// Dimensions of the SAVED image. iRacing renders at targetDimensions
+		// (the selected resolution); when Crop Watermark is on, the watermark is
+		// cropped off so the file ends up slightly smaller. Mirrors the crop math
+		// in takeScreenshot so the hint matches what is actually written to disk.
+		outputDimensions() {
+			const base = this.targetDimensions;
+			if (!base) return null;
+			if (!this.crop) return base;
+			const factor = this.cropTopLeft ? 0.03 : 0.06;
+			return {
+				width: base.width - Math.ceil(base.width * factor),
+				height: base.height - Math.ceil(base.height * factor),
+			};
 		},
 	},
 	created() {
@@ -335,6 +354,10 @@ export default {
 
 		config.onDidChange('reshade', (newValue, oldValue) => {
 			this.reshade = newValue;
+		});
+
+		config.onDidChange('cropTopLeft', (newValue) => {
+			this.cropTopLeft = newValue;
 		});
 	},
 	mounted() {
@@ -445,6 +468,11 @@ export default {
 .sidebar-target-hint__value {
 	color: rgba(255, 255, 255, 0.9);
 	font-weight: 600;
+	font-variant-numeric: tabular-nums;
+}
+
+.sidebar-target-hint__render {
+	color: rgba(255, 255, 255, 0.45);
 	font-variant-numeric: tabular-nums;
 }
 

--- a/src/renderer/views/Worker.vue
+++ b/src/renderer/views/Worker.vue
@@ -44,11 +44,12 @@ let captureTargetDiagnostics = null;
 let preResolvedSourceId = null;
 let targetWidth = null;
 let targetHeight = null;
-// Expanded window dimensions (= what SetWindowPos actually resized iRacing to).
-// Used by fullscreenScreenshot to verify the captured stream came back at the
-// new size and not the prior native dimensions. NOT to be confused with
-// targetWidth/targetHeight, which are the un-expanded user-facing values used
-// for crop output sizing.
+// Window dimensions = what SetWindowPos actually resized iRacing to, which is
+// now the selected resolution itself (no expansion). Used by fullscreenScreenshot
+// to verify the captured stream came back at the new size and not the prior
+// native dimensions. NOT to be confused with targetWidth/targetHeight, which are
+// the smaller post-crop output dimensions (window size minus the watermark
+// margin) used for crop output sizing.
 let windowWidth = null;
 let windowHeight = null;
 function isPlainObject(value) {
@@ -294,7 +295,8 @@ async function saveReshadeImage(sourceFile) {
 
 		const reshadeProcessStart = performance.now();
 		if (crop && cropTopLeftFlag && targetWidth && targetHeight) {
-			// Legacy: crop bottom-right — output is the original target resolution
+			// Legacy: crop the bottom-right corner off — output is the render size
+			// minus the watermark margin
 			await image
 				.extract({
 					left: 0,
@@ -304,7 +306,8 @@ async function saveReshadeImage(sourceFile) {
 				})
 				.toFile(fileName);
 		} else if (crop && targetWidth && targetHeight) {
-			// Default: crop from each side — center-extract the original target resolution
+			// Default: center-crop each side off — output is the render size minus
+			// the watermark margin
 			const cropX = Math.round((metadata.width - targetWidth) / 2);
 			const cropY = Math.round((metadata.height - targetHeight) / 2);
 			await image
@@ -410,13 +413,15 @@ async function fullscreenScreenshot(callback) {
 
 				let outputWidth, outputHeight, srcX, srcY;
 				if (crop && cropTopLeft && targetWidth && targetHeight) {
-					// Legacy: crop bottom-right — output is the original target resolution
+					// Legacy: crop the bottom-right corner off — output is the render
+					// size minus the watermark margin
 					outputWidth = targetWidth;
 					outputHeight = targetHeight;
 					srcX = captureRect.x;
 					srcY = captureRect.y;
 				} else if (crop && targetWidth && targetHeight) {
-					// Default: crop from each side — center-extract the original target resolution
+					// Default: center-crop each side off — output is the render size
+					// minus the watermark margin
 					outputWidth = targetWidth;
 					outputHeight = targetHeight;
 					const cropX = Math.round((captureRect.width - outputWidth) / 2);


### PR DESCRIPTION
## Summary

Flips the watermark-removal logic from **expand-then-crop-back** to **capture-at-target-then-crop-inward**, so iRacing's DX11 framebuffer/VRAM cost is bounded by the resolution the user actually selected.

Previously, to remove the iRacing watermark, the tool expanded the requested resolution by 6% (or 3% for the legacy top-left crop), resized the game window to that **larger** size, then cropped back to the full nominal resolution. That forced iRacing to render ~12% more pixels than selected — extra VRAM at exactly the 4K–8K resolutions where it OOM-crashes.

Now the window is resized to **exactly** the selected resolution and the watermark is cropped **inward** from the captured frame. The saved image ends up slightly smaller than the nominal size.

### Example (8K, default crop)
| | Window / render size | Saved image |
|---|---|---|
| **Before** | 8141 × 4580 (37.3 MP) | 7680 × 4320 |
| **After** | **7680 × 4320 (33.2 MP, −11%)** | 7219 × 4060 |

## Changes
- **`SideBar.vue`** — `takeScreenshot()` no longer expands the window; it emits the selected resolution as the render size and `selected − margin` as the crop target. `Worker.vue`'s existing crop math (extract `targetWidth × targetHeight` from the `width × height` capture) is unchanged.
- **`SideBar.vue`** — the resolution hint now shows the **saved-image** size with the render size as muted context (e.g. `Output: 7219 × 4060 · renders at 7680 × 4320`), via a new `outputDimensions` computed that mirrors the crop math. `cropTopLeft` is now reactive so the hint tracks the 3%/6% margin live.
- Updated now-stale comments/UI text in `Worker.vue`, `index.ts`, and `SettingsModal.vue` ("expanded by 6%" → "cropped 6% total").

## Behavior change to note
An "8K" capture now produces a ~7219 × 4060 file rather than 7680 × 4320. The trade-off is intentional: VRAM is bounded by the selected resolution. The sidebar hint surfaces both numbers so it isn't surprising.

## Incidental fix
A Custom resolution above ~9433 px no longer hangs: it previously expanded past the `getUserMedia` 10000 px cap, so the stream dimensions could never match the window and the capture spun for the full 8 s retry budget. With no expansion, the request stays within the cap.

## Testing
- `npm run type-check` — clean
- `npm test` — 264 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)