### PR TITLE
fix(long-exposure): stop refusing shots taken near the live edge

### DIFF
--- a/docs/design/long-exposure.md
+++ b/docs/design/long-exposure.md
@@ -395,6 +395,14 @@ supplies the *continuous* position used for weighting (§5). `ReplayFrameNumEnd`
 `ReplayPlaySpeed`, `ReplayPlaySlowMotion` and `IsReplayPlaying` are read to
 pre-flight and to restore.
 
+`ReplayFrameNumEnd` is **not** an end index. The SDK defines it as the replay frame
+number *from the end of the tape* — the frames still AHEAD of the cursor. It counts
+down as `ReplayFrameNum` counts up, and only their sum is fixed. Always convert
+through `tapeEndFrame(state)` before comparing it to a frame. Read raw, it made the
+pre-flight refuse shots as "past the end of the replay" from anywhere past the
+midpoint of a tape — including every live session, where the cursor sits at the live
+edge so the count is ~0 while the anchor is the whole session (v3.2.2).
+
 **Wall-clock time is never used to decide replay position or termination. It is
 used as a timeout on operations that can fail, and — since sub-replay-frame windows
 — to place the START of a window shorter than one replay frame.** A stalled frame or

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -50,6 +50,7 @@ import {
 import {
 	ReplayController,
 	readReplayState,
+	tapeEndFrame,
 	type ReplayState,
 } from './long-exposure/replay-control';
 import {
@@ -1024,7 +1025,11 @@ ipcMain.handle('long-exposure:availability', () => {
 		// means no telemetry at all.
 		hasReplayData: state !== null,
 		anchorFrame: state?.replayFrameNum ?? null,
-		replayFrameNumEnd: state?.replayFrameNumEnd ?? null,
+		// The ABSOLUTE last frame of the tape, not the raw `ReplayFrameNumEnd`
+		// countdown this used to forward — see `tapeEndFrame`. Handing a renderer a
+		// field named like a position but holding a remaining-frames count is how the
+		// refusal below it got written backwards in the first place.
+		replayEndFrame: state ? tapeEndFrame(state) : null,
 		sessionNum: state?.replaySessionNum ?? null,
 		frameRate: state?.frameRate ?? null,
 		busy: longExposureActive || takingScreenshot,
@@ -1331,7 +1336,7 @@ ipcMain.handle('long-exposure:preview', (event, rawRecipe: unknown) => {
 		validation: validatePlan({
 			plan,
 			recipe,
-			replayFrameNumEnd: live?.replayFrameNumEnd ?? null,
+			replayEndFrame: live ? tapeEndFrame(live) : null,
 			currentSessionNum: live?.replaySessionNum ?? null,
 			lossyInterpolationLoad:
 				config.get('longExposureLossyInterpolationLoad') || null,

--- a/src/main/long-exposure/capture-session.ts
+++ b/src/main/long-exposure/capture-session.ts
@@ -43,7 +43,11 @@ import {
 import { assessLongExposureVram } from '../../utilities/long-exposure/vram-budget';
 import type { Dimensions, VramInfo } from '../../utilities/vram-prediction';
 import type { PlaybackSnapshot, ReplayState } from './replay-control';
-import { ReplayController, capturePlaybackSnapshot } from './replay-control';
+import {
+	ReplayController,
+	capturePlaybackSnapshot,
+	tapeEndFrame,
+} from './replay-control';
 import { createLogger } from '../../utilities/logger';
 
 const log = createLogger('long-exposure/session');
@@ -477,11 +481,28 @@ export async function executeRecipe(
 	const validation = validatePlan({
 		plan,
 		recipe,
-		replayFrameNumEnd: live.replayFrameNumEnd,
+		replayEndFrame: tapeEndFrame(live),
 		currentSessionNum: live.replaySessionNum,
 		lossyInterpolationLoad: deps.lossyInterpolationLoad?.() ?? null,
 	});
 	if (validation.errors.length > 0) {
+		// Log the readings the refusal was computed FROM, not just its wording. Every
+		// error here is a claim about where the anchor sits relative to the tape, and
+		// the first field report of one ("past the end of the replay", in a live
+		// session, where it was plainly not) could not be adjudicated from the log
+		// because none of these numbers were in it.
+		log.warn('Long exposure refused before starting', {
+			errors: validation.errors,
+			anchorFrame: recipe.anchorFrame,
+			startFrame: plan.startFrame,
+			replayFrameNum: live.replayFrameNum,
+			// The raw countdown AND the position derived from it, because confusing the
+			// two is exactly the mistake this pair exists to make visible.
+			replayFrameNumEnd: live.replayFrameNumEnd,
+			replayEndFrame: tapeEndFrame(live),
+			recipeSessionNum: recipe.sessionNum,
+			replaySessionNum: live.replaySessionNum,
+		});
 		return failure('invalid-recipe', validation.errors.join(' '), { plan });
 	}
 

--- a/src/main/long-exposure/replay-control.test.ts
+++ b/src/main/long-exposure/replay-control.test.ts
@@ -7,6 +7,7 @@ import {
 	SEEK_LEAD_FRAMES,
 	capturePlaybackSnapshot,
 	readReplayState,
+	tapeEndFrame,
 	type ReplayControlDeps,
 	type ReplayState,
 } from './replay-control';
@@ -121,6 +122,44 @@ describe('readReplayState', () => {
 		expect(state?.replaySessionTime).toBeNull();
 		expect(state?.replayPlaySlowMotion).toBe(false);
 		expect(state?.isReplayPlaying).toBe(false);
+	});
+});
+
+describe('tapeEndFrame', () => {
+	const state = (
+		replayFrameNum: number,
+		replayFrameNumEnd: number | null
+	): ReplayState => ({
+		replayFrameNum,
+		replayFrameNumEnd,
+		replaySessionTime: null,
+		replaySessionNum: 1,
+		replayPlaySpeed: 0,
+		replayPlaySlowMotion: false,
+		isReplayPlaying: false,
+		frameRate: 60,
+	});
+
+	// The whole point of the helper: ReplayFrameNumEnd counts frames REMAINING, so
+	// the end of the tape is the sum and never the variable on its own.
+	it('adds the remaining count to the cursor', () => {
+		expect(tapeEndFrame(state(1000, 50000))).toBe(51000);
+		expect(tapeEndFrame(state(0, 51000))).toBe(51000);
+	});
+
+	// THE LIVE-SESSION REGRESSION. At the live edge the cursor is deep into the tape
+	// and the remaining count is ~0 — the exact reading that made validatePlan refuse
+	// every live shot as "past the end of the replay" when it compared the anchor
+	// against the raw countdown.
+	it('puts the live edge at or after the cursor, never before it', () => {
+		const live = state(11106, 0);
+		const end = tapeEndFrame(live);
+		expect(end).toBe(11106);
+		expect(end).toBeGreaterThanOrEqual(live.replayFrameNum);
+	});
+
+	it('is null when the sim does not report the remaining count', () => {
+		expect(tapeEndFrame(state(1000, null))).toBeNull();
 	});
 });
 

--- a/src/main/long-exposure/replay-control.ts
+++ b/src/main/long-exposure/replay-control.ts
@@ -116,6 +116,25 @@ export function readReplayState(
 	};
 }
 
+// The ABSOLUTE frame the tape ends at, or null when telemetry cannot say.
+//
+// `ReplayFrameNumEnd` is not an end index, however much the name reads like one.
+// The SDK documents it as "Integer replay frame number from END of tape" — a
+// countdown of the frames still AHEAD of the cursor. So the two variables move in
+// opposite directions and only their SUM is fixed.
+//
+// Reading it as an absolute index refuses every shot taken from the back half of a
+// tape, and every shot in a live session — where the cursor sits at the live edge,
+// so `ReplayFrameNumEnd` is ~0 while `ReplayFrameNum` is however many frames the
+// session has run. That is the bug this helper exists to make unrepeatable: the
+// countdown must never reach a comparison without being turned into a position
+// first.
+export function tapeEndFrame(state: ReplayState): number | null {
+	return state.replayFrameNumEnd === null
+		? null
+		: state.replayFrameNum + state.replayFrameNumEnd;
+}
+
 // The playback state we owe the user back, captured before anything moves.
 export interface PlaybackSnapshot {
 	anchorFrame: number;

--- a/src/utilities/long-exposure/shot-recipe.test.ts
+++ b/src/utilities/long-exposure/shot-recipe.test.ts
@@ -475,7 +475,7 @@ describe('validatePlan', () => {
 	const validate = (
 		overrides: Partial<LongExposureRecipe>,
 		bounds: {
-			replayFrameNumEnd?: number | null;
+			replayEndFrame?: number | null;
 			currentSessionNum?: number | null;
 		} = {}
 	) => {
@@ -483,7 +483,7 @@ describe('validatePlan', () => {
 		return validatePlan({
 			plan: resolvePlan(recipe, { renderFps: 60 }),
 			recipe,
-			replayFrameNumEnd: bounds.replayFrameNumEnd ?? 100000,
+			replayEndFrame: bounds.replayEndFrame ?? 100000,
 			currentSessionNum: bounds.currentSessionNum ?? 2,
 		});
 	};
@@ -564,7 +564,7 @@ describe('validatePlan', () => {
 			validatePlan({
 				plan: resolvePlan(recipe),
 				recipe,
-				replayFrameNumEnd: 100000,
+				replayEndFrame: 100000,
 				currentSessionNum: 2,
 			}).errors
 		).toEqual([]);
@@ -575,7 +575,7 @@ describe('validatePlan', () => {
 		const result = validatePlan({
 			plan: resolvePlan(recipe),
 			recipe,
-			replayFrameNumEnd: 100000,
+			replayEndFrame: 100000,
 			currentSessionNum: 2,
 		});
 		expect(result.errors.join(' ')).toMatch(
@@ -587,9 +587,19 @@ describe('validatePlan', () => {
 		expect(
 			validate(
 				{ anchorFrame: 200000 },
-				{ replayFrameNumEnd: 100000 }
+				{ replayEndFrame: 100000 }
 			).errors.join(' ')
 		).toMatch(/past the end/);
+	});
+
+	// A LIVE session parks the cursor at the live edge, so the anchor IS the end of
+	// the tape. That has to pass: this check exists for a sidecar re-shot into a
+	// shorter replay, and it once refused every live shot because it was handed the
+	// raw `ReplayFrameNumEnd` countdown — ~0 at the edge — as if it were a position.
+	it('accepts an anchor sitting exactly at the live edge', () => {
+		expect(
+			validate({ anchorFrame: 11106 }, { replayEndFrame: 11106 }).errors
+		).toEqual([]);
 	});
 
 	// Re-shooting into a different session would silently produce a shot of
@@ -688,15 +698,14 @@ describe('validatePlan', () => {
 	it('refuses a long exposure that reaches past the start of the replay', () => {
 		const result = validate(
 			{ shutter: '10', anchorFrame: 120 },
-			{ replayFrameNumEnd: 100000, currentSessionNum: 2 }
+			{ replayEndFrame: 100000, currentSessionNum: 2 }
 		);
 		expect(result.errors.join(' ')).toMatch(/600 replay frames/);
 	});
 
 	it('fails open when replay bounds are unknown', () => {
 		expect(
-			validate({}, { replayFrameNumEnd: null, currentSessionNum: null })
-				.errors
+			validate({}, { replayEndFrame: null, currentSessionNum: null }).errors
 		).toEqual([]);
 	});
 });
@@ -718,7 +727,7 @@ describe('validatePlan — interpolation load', () => {
 			const { warnings } = validatePlan({
 				plan,
 				recipe,
-				replayFrameNumEnd: null,
+				replayEndFrame: null,
 				currentSessionNum: null,
 				lossyInterpolationLoad,
 			});
@@ -738,7 +747,7 @@ describe('validatePlan — interpolation load', () => {
 		const { warnings } = validatePlan({
 			plan,
 			recipe,
-			replayFrameNumEnd: null,
+			replayEndFrame: null,
 			currentSessionNum: null,
 			lossyInterpolationLoad: load,
 		});
@@ -754,7 +763,7 @@ describe('validatePlan — interpolation load', () => {
 		const { warnings } = validatePlan({
 			plan,
 			recipe,
-			replayFrameNumEnd: null,
+			replayEndFrame: null,
 			currentSessionNum: null,
 			// A limit measured at a much heavier configuration.
 			lossyInterpolationLoad: 100,
@@ -769,7 +778,7 @@ describe('validatePlan — interpolation load', () => {
 		const { warnings } = validatePlan({
 			plan,
 			recipe,
-			replayFrameNumEnd: null,
+			replayEndFrame: null,
 			currentSessionNum: null,
 			lossyInterpolationLoad: 0.0001,
 		});

--- a/src/utilities/long-exposure/shot-recipe.ts
+++ b/src/utilities/long-exposure/shot-recipe.ts
@@ -623,8 +623,11 @@ export function interpolationLoad(opts: {
 export function validatePlan(opts: {
 	plan: ResolvedPlan;
 	recipe: LongExposureRecipe;
-	// Live replay bounds from telemetry.
-	replayFrameNumEnd: number | null;
+	// Live replay bounds from telemetry. `replayEndFrame` is the ABSOLUTE last frame
+	// of the tape — deliberately not the raw `ReplayFrameNumEnd` telemetry variable,
+	// which counts frames REMAINING ahead of the cursor rather than indexing one.
+	// Callers convert through `tapeEndFrame`.
+	replayEndFrame: number | null;
 	currentSessionNum: number | null;
 	// The smallest interpolation load THIS MACHINE has been observed to choke on,
 	// learned from previous captures. Null until there is evidence.
@@ -635,7 +638,7 @@ export function validatePlan(opts: {
 	// demonstrated a limit.
 	lossyInterpolationLoad?: number | null;
 }): RecipeValidation {
-	const { plan, recipe, replayFrameNumEnd, currentSessionNum } = opts;
+	const { plan, recipe, replayEndFrame, currentSessionNum } = opts;
 	const errors: string[] = [];
 	const warnings: string[] = [];
 	// Whether this recipe actually resolves to more than one accumulator. Asked once,
@@ -657,10 +660,13 @@ export function validatePlan(opts: {
 		);
 	}
 
+	// Only reachable for a recipe carrying an anchor from somewhere else — a sidecar
+	// re-shot into a shorter tape. A FRESH shot anchors on the live cursor, which is
+	// on the tape by construction, so this must never fire for one.
 	if (
-		typeof replayFrameNumEnd === 'number' &&
-		replayFrameNumEnd > 0 &&
-		recipe.anchorFrame > replayFrameNumEnd
+		typeof replayEndFrame === 'number' &&
+		replayEndFrame > 0 &&
+		recipe.anchorFrame > replayEndFrame
 	) {
 		errors.push('The selected moment is past the end of the replay.');
 	}


### PR DESCRIPTION
## The bug

Long exposure refused every shot with **"The selected moment is past the end of the replay."** — in a live session, with the cursor plainly inside the replay. First hit in v3.2.2.

`validatePlan` compared the anchor against `ReplayFrameNumEnd` as though it were the index of the last frame on the tape. It isn't. The SDK defines it as *"Integer replay frame number from **END** of tape"* — a countdown of the frames still **ahead** of the cursor. It falls as `ReplayFrameNum` rises; only their sum is fixed.

So the check reduced to:

> refuse when `anchor > tapeLength / 2`

The failure zone was the entire **back half of the tape**, and being at the live edge is its extreme — remaining ≈ 0, so it fires regardless of session length. Opening a replay parks the cursor exactly there, which is how the report landed on it.

It also contradicted the comment sitting directly above it, which already stated the intended behaviour:

> A trailing window means an anchor near the END of the replay is always safe — we never need frames after it. Only an anchor closer than the window length to the START is constrained.

## The fix

`tapeEndFrame(state)` converts the countdown to an absolute position; `validatePlan` now takes that absolute frame as `replayEndFrame`. Both callers (`executeRecipe`, the `long-exposure:preview` IPC) go through it, and the availability IPC no longer forwards the raw countdown to the renderer under a position-sounding name.

A fresh shot becomes structurally immune: its anchor **is** the cursor, and `cursor + remaining >= cursor`. The refusal survives only for what it was written for — a sidecar re-shot into a shorter tape.

Nothing else in the capture path is live-edge sensitive: the pre-roll seek only moves backward (`Math.max(0, startFrame - SEEK_LEAD_FRAMES)`), playback stops **at** the anchor, and `restoreAnchor` seeks back to it. Every constraint points at the *start* of the tape.

## Observability

Pre-flight refusals now log the telemetry they were computed from — anchor, start frame, cursor, the raw countdown *and* the derived position, and both session numbers. The field report couldn't be adjudicated from the log because the message shipped without any of the numbers behind it.

## Verification

Hardware A/B, same sim session and replay, cursor untouched:

| Time | Build | Result |
|---|---|---|
| 18:17:49 | packaged 3.2.2 | refused |
| 18:18:50 | packaged 3.2.2 (restart) | refused |
| 18:19:06 | packaged 3.2.2 (restart) | refused |
| 18:20:15 | packaged 3.2.2 (restart) | refused |
| **18:21:12** | **with this fix** | **saved** — anchor 25198, 47 samples over 8 passes, 7219x4060, anchor restored with 0 corrections |

Three restarts on the shipped build refused every time, confirming the restart-clears-it theory was a red herring — moving the cursor was what changed the answer.

756 tests pass, `tsc --noEmit` clean, `format:check` clean, `lint:check` 0 errors. New regression tests cover `tapeEndFrame` and a `validatePlan` anchor sitting exactly at the live edge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)