### PR TITLE
fix(updater): make auto-update actually reach users

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,8 +111,17 @@ jobs:
                     } > "$notes"
                   fi
 
+                  # --prerelease=false is load-bearing, not tidiness. With
+                  # allowPrerelease at its default, electron-updater resolves the
+                  # newest version through https://github.com/<owner>/<repo>/releases/latest
+                  # (GitHubProvider.getLatestTagName), and GitHub never points that
+                  # at a release flagged pre-release — nor does --latest override
+                  # the flag. v3.1.0, v3.2.1 and v3.2.2 all shipped pre-release, so
+                  # that redirect sat on v3.1.1, which predates latest.yml: every
+                  # update check would have 404'd on the channel file.
                   gh release edit "$tag" \
                     --draft=false \
+                    --prerelease=false \
                     --latest \
                     --title "$tag" \
                     --notes-file "$notes"

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -95,6 +95,16 @@ import {
 	normalizeFileKey,
 	parseCameraState as parseCameraStateFromArray,
 } from './main-utils';
+import {
+	applyUpdateEvent,
+	canInstallNow,
+	canStartDownload,
+	initialUpdateState,
+	shouldCheckNow,
+	UPDATE_POLL_INTERVAL_MS,
+	type UpdateEvent,
+	type UpdateState,
+} from '../utilities/update-decisions';
 
 let width: number;
 let height: number;
@@ -762,6 +772,14 @@ function createWindow(): void {
 			mainWindow.show();
 			mainWindow.focus();
 		}
+	});
+
+	// Coming back to the app is the moment a stale answer is most likely and most
+	// worth refreshing — the user has probably been in iRacing for a while. Cheap
+	// because shouldCheckNow rations it to the same six-hour policy as the timer, so
+	// alt-tabbing between the sim and here cannot turn into a request per switch.
+	mainWindow.on('focus', () => {
+		runUpdateCheck();
 	});
 
 	mainWindow.on('close', () => {
@@ -2060,10 +2078,6 @@ app.on('ready', async () => {
 			resize(width, height, left, top);
 		}
 	});
-
-	ipcMain.on('install-update', () => {
-		autoUpdater.quitAndInstall();
-	});
 });
 
 app.on('window-all-closed', () => {
@@ -2078,45 +2092,246 @@ app.on('activate', () => {
 	}
 });
 
-// Auto-update observability (obs-lifecycle-telemetry#2 == obs-error-visibility#3):
-// previously only 'update-downloaded' was wired and checkForUpdates() was a
-// floating promise, so a failed update check (offline, 404 feed, signature error)
-// produced no app.log line and rejected unhandled. Wire the full event set; the
-// 'error' event and the checkForUpdates rejection log at ERROR so field triage can
-// filter them.
+// --- auto-update ----------------------------------------------------------
+//
+// The renderer never talks to electron-updater. Main owns one UpdateState, every
+// autoUpdater event is folded into it through the pure reducer in
+// update-decisions.ts, and each transition is both logged and broadcast. The
+// renderer can therefore be a pure view of `update:state` — and, because the state
+// is HELD rather than only announced, a window that mounts after the interesting
+// event still sees it (`update:state` invoke). The old code sent a single
+// fire-and-forget 'update-available' on download completion, so a renderer that was
+// not listening at that instant lost the notification for the whole session.
+//
+// Observability (obs-lifecycle-telemetry#2 == obs-error-visibility#3) is preserved:
+// every event still writes its app.log line, errors at ERROR.
+let updateState = initialUpdateState();
+let updatePollTimer: ReturnType<typeof setInterval> | null = null;
+
+// A capture in flight is the only thing that makes an update action unsafe. Asked
+// fresh at every decision point rather than cached, because it flips without any
+// update event to hang a recompute off.
+function updateBusy(): boolean {
+	return longExposureActive || takingScreenshot;
+}
+
+// The renderer's view of the state: the reduced state plus the busy flag it needs
+// to phrase things honestly. Sent on every transition and returned by the query.
+function updateStatePayload(): UpdateState & {
+	busy: boolean;
+	currentVersion: string;
+} {
+	return {
+		...updateState,
+		busy: updateBusy(),
+		currentVersion: app.getVersion(),
+	};
+}
+
+function pushUpdateEvent(event: UpdateEvent): void {
+	updateState = applyUpdateEvent(updateState, event, Date.now());
+	broadcastToWindows('update:state', updateStatePayload());
+}
+
 autoUpdater.on('checking-for-update', () => {
 	log.info('Auto-update checking');
+	pushUpdateEvent({ type: 'checking' });
 });
 
 autoUpdater.on('update-available', (info) => {
 	log.info('Auto-update available', { version: info?.version });
+	pushUpdateEvent({ type: 'available', version: info?.version ?? null });
 });
 
 autoUpdater.on('update-not-available', (info) => {
 	log.info('Auto-update not available', { version: info?.version });
+	pushUpdateEvent({ type: 'not-available', version: info?.version ?? null });
+});
+
+// Wired at last, so a 114 MB transfer is a progress bar instead of an unexplained
+// stall. Logged at DEBUG — one line per chunk would drown app.log.
+autoUpdater.on('download-progress', (progress) => {
+	log.debug('Auto-update download progress', {
+		percent: progress?.percent,
+		bytesPerSecond: progress?.bytesPerSecond,
+	});
+	pushUpdateEvent({ type: 'progress', percent: progress?.percent });
 });
 
 autoUpdater.on('error', (error) => {
 	log.error('Auto-update error', {
 		error: (error as Error)?.message || String(error),
 	});
+	pushUpdateEvent({
+		type: 'error',
+		message: (error as Error)?.message || String(error),
+	});
 });
 
 autoUpdater.on('update-downloaded', (info) => {
 	log.info('Auto-update downloaded', { version: info?.version });
-	if (mainWindow && !mainWindow.isDestroyed()) {
-		mainWindow.webContents.send('update-available', '');
+	pushUpdateEvent({ type: 'downloaded', version: info?.version ?? null });
+});
+
+// Consent, not surprise. autoDownload defaults to true, which meant the installer
+// started transferring the moment the app was ready — competing with iRacing for
+// bandwidth and disk while the user might be on track, with nothing on screen to
+// say so. Now the check runs freely (cheap: one atom feed + one small yml) and the
+// user decides when the bytes move.
+//
+// autoInstallOnAppQuit is deliberately LEFT at its default of true: once the user
+// has consented to the download, installing it on the next normal quit is the
+// least-interrupting way to finish, and it is what canInstallNow's busy message
+// promises.
+autoUpdater.autoDownload = false;
+
+// `app.isPackaged`, NOT `process.env.NODE_ENV === 'production'`. Nothing sets
+// NODE_ENV in a packaged build: Electron does not, and electron-vite — unlike the
+// webpack config it replaced in 13d84e1, whose `mode: 'production'` inlined the
+// value through optimization.nodeEnv — leaves `process.env.NODE_ENV` as a runtime
+// read in out/main/index.js. So this gate was dead from the migration onward and
+// no shipped build ever checked for an update; app.log across packaged v3.2.2 runs
+// has not one 'Auto-update checking' line. `!isDev` would be wrong too — it is
+// also true for an unpacked --dir run, where electron-updater has no app-update.yml
+// and only logs a skip. isPackaged is the condition electron-updater itself gates
+// on (AppUpdater.isUpdaterActive), so this asks exactly what it will answer.
+function runUpdateCheck({ force = false } = {}): boolean {
+	if (!app.isPackaged) {
+		return false;
+	}
+	if (
+		!shouldCheckNow({
+			phase: updateState.phase,
+			checkedAt: updateState.checkedAt,
+			nowMs: Date.now(),
+			force,
+		})
+	) {
+		return false;
+	}
+
+	autoUpdater.checkForUpdates().catch((error) => {
+		log.error('checkForUpdates failed', {
+			error: (error as Error)?.message || String(error),
+		});
+		// checkForUpdates can reject WITHOUT emitting 'error' (a malformed feed
+		// rejects out of getLatestVersion), so the reducer has to be told here too
+		// or the UI would sit on 'checking' forever.
+		pushUpdateEvent({
+			type: 'error',
+			message: (error as Error)?.message || String(error),
+		});
+	});
+	return true;
+}
+
+app.on('ready', () => {
+	runUpdateCheck();
+
+	// The app is left open for whole evenings alongside iRacing, so a startup-only
+	// check meant a release that landed at 8pm stayed invisible until the next
+	// launch. The timer ticks far more often than the policy allows a check, so a
+	// machine that slept through its slot re-checks shortly after waking instead of
+	// waiting for the next exact multiple; shouldCheckNow does the real rationing.
+	updatePollTimer = setInterval(() => {
+		runUpdateCheck();
+	}, UPDATE_POLL_INTERVAL_MS);
+});
+
+app.on('will-quit', () => {
+	if (updatePollTimer) {
+		clearInterval(updatePollTimer);
+		updatePollTimer = null;
 	}
 });
 
-app.on('ready', () => {
-	if (process.env.NODE_ENV === 'production') {
-		autoUpdater.checkForUpdates().catch((error) => {
-			log.error('checkForUpdates failed', {
-				error: (error as Error)?.message || String(error),
-			});
-		});
+// The current state, computed fresh. Called by every renderer on mount, which is
+// what makes the notification impossible to miss.
+ipcMain.handle('update:state', () => updateStatePayload());
+
+// The Settings button. `force` skips the six-hour interval but not the phase guard
+// — there is nothing useful to do mid-check or mid-download.
+ipcMain.handle('update:check', () => {
+	// Said out loud rather than failing silently: in a dev or --dir run
+	// electron-updater has no app-update.yml and the button would otherwise look
+	// broken to whoever is testing it.
+	if (!app.isPackaged) {
+		return {
+			started: false,
+			reason: 'Update checks only run in an installed build.',
+			state: updateStatePayload(),
+		};
 	}
+	const started = runUpdateCheck({ force: true });
+	// No reason when we declined: the state itself already reads "vX is available"
+	// or "downloading", which explains the no-op better than a second sentence.
+	return { started, reason: null, state: updateStatePayload() };
+});
+
+ipcMain.handle('update:download', () => {
+	const verdict = canStartDownload({
+		phase: updateState.phase,
+		busy: updateBusy(),
+	});
+	if (!verdict.allowed) {
+		log.info('Auto-update download refused', { reason: verdict.reason });
+		return { ok: false, reason: verdict.reason, state: updateStatePayload() };
+	}
+
+	log.info('Auto-update download requested', { version: updateState.version });
+	// Move to 'downloading' immediately rather than waiting for the first
+	// download-progress event: on a fast link the first chunk can be seconds away,
+	// and until then the button would still read "click to download".
+	pushUpdateEvent({ type: 'download-started' });
+	autoUpdater.downloadUpdate().catch((error) => {
+		log.error('downloadUpdate failed', {
+			error: (error as Error)?.message || String(error),
+		});
+		pushUpdateEvent({
+			type: 'error',
+			message: (error as Error)?.message || String(error),
+		});
+	});
+	return { ok: true, reason: null, state: updateStatePayload() };
+});
+
+ipcMain.handle('update:install', async () => {
+	const verdict = canInstallNow({
+		phase: updateState.phase,
+		busy: updateBusy(),
+	});
+	if (!verdict.allowed) {
+		log.info('Auto-update install refused', { reason: verdict.reason });
+		return { ok: false, reason: verdict.reason, state: updateStatePayload() };
+	}
+
+	// quitAndInstall() kills the app with no warning. Previously one click on an
+	// unlabelled arrow did exactly that, which could throw away a long exposure
+	// mid-accumulation. canInstallNow already refuses while a capture is running;
+	// this covers everything else the user might be part-way through.
+	const { response } = await dialog.showMessageBox(mainWindow ?? undefined, {
+		type: 'question',
+		buttons: ['Restart and install', 'Later'],
+		defaultId: 0,
+		cancelId: 1,
+		title: 'Install update',
+		message: `Install version ${updateState.version ?? 'update'}?`,
+		detail:
+			'The app will close and reopen once the update is installed. If you choose Later, it will install by itself the next time you close the app.',
+	});
+
+	if (response !== 0) {
+		log.info('Auto-update install deferred by user');
+		return {
+			ok: false,
+			reason: null,
+			state: updateStatePayload(),
+		};
+	}
+
+	log.info('Auto-update installing', { version: updateState.version });
+	autoUpdater.quitAndInstall();
+	return { ok: true, reason: null, state: updateStatePayload() };
 });
 
 function clearPendingReshadeWait(reason = 'Screenshot cancelled'): void {

--- a/src/renderer/components/SettingsModal.vue
+++ b/src/renderer/components/SettingsModal.vue
@@ -13,6 +13,15 @@
 					<span class="heading"
 						><a @click="openLogsFolder">Open Logs Folder</a></span
 					>
+					<!-- Somewhere to ASK. The updater is otherwise entirely passive,
+					     so a user who wanted to know whether they were current had no
+					     way to find out short of opening GitHub. -->
+					<span class="heading"
+						><a @click="checkForUpdates">Check for Updates</a></span
+					>
+					<span class="heading settings-meta__update">{{
+						updateStatus
+					}}</span>
 				</aside>
 
 				<div class="settings-form">
@@ -335,6 +344,10 @@ import {
 	FILENAME_FIELDS,
 	DEFAULT_FORMAT,
 } from '../../utilities/filenameFormat';
+import {
+	describeUpdate,
+	initialUpdateState,
+} from '../../utilities/update-decisions';
 const { ipcRenderer, shell } = require('electron');
 const path = require('path');
 
@@ -378,6 +391,18 @@ export default {
 			filenameFields: FILENAME_FIELDS,
 			defaultFormat: DEFAULT_FORMAT,
 			iracingOpen: false,
+			// Mirrors main's update state so the status line stays live while the
+			// modal is open — it shows download percent as it climbs, not a frozen
+			// answer from whenever the modal was first created.
+			update: {
+				...initialUpdateState(),
+				busy: false,
+				currentVersion: version,
+			},
+			// A one-off message from update:check that the state cannot express
+			// (today: "only runs in an installed build"). Cleared by the next state
+			// broadcast so it can't linger past its truth.
+			updateNotice: null,
 		};
 	},
 	computed: {
@@ -418,6 +443,18 @@ export default {
 				acc[field.category].push(field);
 				return acc;
 			}, {});
+		},
+		// The same sentence the title-bar tooltip uses, from the same helper, so the
+		// two places that talk about updates cannot drift apart.
+		updateStatus() {
+			return (
+				this.updateNotice ??
+				describeUpdate(
+					this.update,
+					this.update.currentVersion,
+					this.update.busy
+				)
+			);
 		},
 		// Whether the description is reporting a problem rather than describing the
 		// feature, which is the only thing the warning styling keys off.
@@ -591,8 +628,41 @@ export default {
 		ipcRenderer.on('iracing-disconnected', () => {
 			this.iracingOpen = false;
 		});
+
+		// Not removed on unmount on purpose: under the v-show Oruga modal this
+		// component stays mounted for the app lifetime (see the screenWidth watcher
+		// note above), so created() runs once and this is a single listener, not a
+		// leak per open.
+		ipcRenderer.on('update:state', (event, state) => {
+			this.update = state;
+			this.updateNotice = null;
+		});
+		ipcRenderer
+			.invoke('update:state')
+			.then((state) => {
+				this.update = state;
+			})
+			.catch(() => {
+				// Main not ready; the broadcast will catch us up.
+			});
 	},
 	methods: {
+		async checkForUpdates() {
+			this.updateNotice = null;
+			try {
+				const result = await ipcRenderer.invoke('update:check');
+				if (result?.state) {
+					this.update = result.state;
+				}
+				if (result?.reason) {
+					this.updateNotice = result.reason;
+				}
+			} catch (error) {
+				this.updateNotice = `Update check failed: ${
+					(error as Error)?.message || String(error)
+				}`;
+			}
+		},
 		restoreNow() {
 			const w = parseInt(this.screenWidth, 10);
 			const h = parseInt(this.screenHeight, 10);
@@ -764,6 +834,18 @@ hr {
 	text-transform: uppercase;
 	font-size: 0.75rem;
 	letter-spacing: 0.05em;
+}
+
+/* A sentence, not a label — it must wrap rather than run off the aside, and it
+   keeps its case (the uppercase treatment above is for the links). */
+.settings-meta__update {
+	text-transform: none;
+	letter-spacing: normal;
+	font-size: 0.7rem;
+	line-height: 1.3;
+	opacity: 0.75;
+	white-space: normal;
+	margin-top: -0.25rem;
 }
 
 .settings-form {

--- a/src/renderer/components/TitleBar.test.ts
+++ b/src/renderer/components/TitleBar.test.ts
@@ -1,0 +1,249 @@
+// @vitest-environment happy-dom
+//
+// Component tests for the title-bar update affordance, on the harness
+// renderer-harness.test.ts established. The behaviours locked here are the ones the
+// old implementation got wrong: it listened for a single fire-and-forget
+// 'update-available' send (so a renderer that mounted late never learned about a
+// ready update), rendered an unlabelled green arrow, and quit the app on one click
+// through a channel that asked main nothing.
+//
+// NOTE ON THE ELECTRON STUB: TitleBar.vue resolves ipcRenderer via a NATIVE
+// `require('electron')`, which vi.mock cannot reach (it only intercepts the
+// transformed import graph) — so the stub is planted in Node's require cache, the
+// same approach logger.integration.test.ts documents.
+import { createRequire } from 'module';
+import { mount, flushPromises } from '@vue/test-utils';
+
+const nodeRequire = createRequire(import.meta.url);
+
+const notificationOpen = vi.fn();
+vi.mock('@oruga-ui/oruga-next', () => ({
+	useOruga: () => ({ notification: { open: notificationOpen } }),
+}));
+
+// Set per test before mounting; the stub reads them lazily.
+let invokeResults: Record<string, unknown> = {};
+const invoked: Array<{ channel: string; args: unknown[] }> = [];
+const listeners = new Map<string, (...args: unknown[]) => void>();
+const removed: string[] = [];
+
+const ipcRendererStub = {
+	on(channel: string, handler: (...args: unknown[]) => void) {
+		listeners.set(channel, handler);
+	},
+	removeListener(channel: string) {
+		removed.push(channel);
+		listeners.delete(channel);
+	},
+	send: vi.fn(),
+	sendSync: vi.fn(),
+	invoke(channel: string, ...args: unknown[]) {
+		invoked.push({ channel, args });
+		if (!(channel in invokeResults)) {
+			return Promise.reject(new Error(`no stub for ${channel}`));
+		}
+		return Promise.resolve(invokeResults[channel]);
+	},
+};
+
+const id = nodeRequire.resolve('electron');
+nodeRequire.cache[id] = {
+	id,
+	filename: id,
+	loaded: true,
+	exports: { ipcRenderer: ipcRendererStub },
+} as unknown as NodeModule;
+
+// Imported AFTER the stub is planted — the component captures ipcRenderer at module
+// scope, so a later install would be too late.
+const { default: TitleBar } = await import('./TitleBar.vue');
+
+function state(patch: Record<string, unknown> = {}) {
+	return {
+		phase: 'idle',
+		version: null,
+		percent: null,
+		error: null,
+		checkedAt: null,
+		busy: false,
+		currentVersion: '3.2.2',
+		...patch,
+	};
+}
+
+function mountBar() {
+	return mount(TitleBar, {
+		props: { title: 'iRacing Screenshot Tool', ico: 'icon.png' },
+		global: { stubs: { 'font-awesome-icon': true } },
+	});
+}
+
+beforeEach(() => {
+	invokeResults = {};
+	invoked.length = 0;
+	removed.length = 0;
+	listeners.clear();
+	notificationOpen.mockClear();
+});
+
+describe('TitleBar update affordance', () => {
+	test('asks main for the state on mount instead of only listening', async () => {
+		invokeResults = { 'update:state': state() };
+		mountBar();
+		await flushPromises();
+
+		expect(invoked.map((c) => c.channel)).toContain('update:state');
+		expect(listeners.has('update:state')).toBe(true);
+	});
+
+	// The regression that made the old notification missable: the download finishes
+	// before this component exists, so nothing is ever broadcast to it.
+	test('shows an update that was already downloaded before it mounted', async () => {
+		invokeResults = {
+			'update:state': state({ phase: 'downloaded', version: '3.3.0' }),
+		};
+		const wrapper = mountBar();
+		await flushPromises();
+
+		const button = wrapper.find('.update-button');
+		expect(button.exists()).toBe(true);
+		expect(button.attributes('title')).toContain('v3.3.0');
+		expect(button.attributes('title')).toMatch(/restart and install/i);
+	});
+
+	test('stays hidden when there is nothing to act on', async () => {
+		invokeResults = { 'update:state': state({ checkedAt: 1 }) };
+		const wrapper = mountBar();
+		await flushPromises();
+
+		expect(wrapper.find('.update-button').exists()).toBe(false);
+	});
+
+	test('survives main not answering the query yet', async () => {
+		// No stub for update:state — the invoke rejects.
+		const wrapper = mountBar();
+		await flushPromises();
+
+		expect(wrapper.find('.update-button').exists()).toBe(false);
+		expect(wrapper.find('.titlebar').exists()).toBe(true);
+	});
+
+	test('renders a broadcast that arrives after mount', async () => {
+		invokeResults = { 'update:state': state({ checkedAt: 1 }) };
+		const wrapper = mountBar();
+		await flushPromises();
+
+		listeners.get('update:state')?.(
+			{},
+			state({ phase: 'available', version: '3.3.0' })
+		);
+		await flushPromises();
+
+		const button = wrapper.find('.update-button');
+		expect(button.exists()).toBe(true);
+		expect(button.attributes('title')).toMatch(/click to download/i);
+		// The label is also the accessible name — an icon-only control needs one.
+		expect(button.attributes('aria-label')).toBe(button.attributes('title'));
+	});
+
+	test('shows download percent while the transfer runs', async () => {
+		invokeResults = {
+			'update:state': state({
+				phase: 'downloading',
+				version: '3.3.0',
+				percent: 62,
+			}),
+		};
+		const wrapper = mountBar();
+		await flushPromises();
+
+		expect(wrapper.find('.update-percent').text()).toBe('62%');
+		expect(wrapper.find('.update-button').attributes('title')).toContain(
+			'62%'
+		);
+	});
+
+	test('an available update asks main to download, not to install', async () => {
+		invokeResults = {
+			'update:state': state({ phase: 'available', version: '3.3.0' }),
+			'update:download': { ok: true, reason: null, state: state({}) },
+		};
+		const wrapper = mountBar();
+		await flushPromises();
+
+		await wrapper.find('.update-button').trigger('click');
+		await flushPromises();
+
+		expect(invoked.map((c) => c.channel)).toContain('update:download');
+		expect(invoked.map((c) => c.channel)).not.toContain('update:install');
+	});
+
+	test('a downloaded update asks main to install', async () => {
+		invokeResults = {
+			'update:state': state({ phase: 'downloaded', version: '3.3.0' }),
+			'update:install': { ok: true, reason: null, state: state({}) },
+		};
+		const wrapper = mountBar();
+		await flushPromises();
+
+		await wrapper.find('.update-button').trigger('click');
+		await flushPromises();
+
+		expect(invoked.map((c) => c.channel)).toContain('update:install');
+	});
+
+	test('surfaces a refusal reason and stays put', async () => {
+		const refused = state({
+			phase: 'downloaded',
+			version: '3.3.0',
+			busy: true,
+		});
+		invokeResults = {
+			'update:state': refused,
+			'update:install': {
+				ok: false,
+				reason:
+					'A capture is in progress. The update will install by itself when you close the app.',
+				state: refused,
+			},
+		};
+		const wrapper = mountBar();
+		await flushPromises();
+
+		await wrapper.find('.update-button').trigger('click');
+		await flushPromises();
+
+		expect(notificationOpen).toHaveBeenCalledTimes(1);
+		expect(notificationOpen.mock.calls[0][0].message).toMatch(
+			/close the app/i
+		);
+		// Still offered — a refusal is not a dismissal.
+		expect(wrapper.find('.update-button').exists()).toBe(true);
+	});
+
+	// Declining the confirmation dialog comes back ok:false with no reason, and a
+	// toast repeating a choice the user just made would be noise.
+	test('says nothing when the user declines the install dialog', async () => {
+		const downloaded = state({ phase: 'downloaded', version: '3.3.0' });
+		invokeResults = {
+			'update:state': downloaded,
+			'update:install': { ok: false, reason: null, state: downloaded },
+		};
+		const wrapper = mountBar();
+		await flushPromises();
+
+		await wrapper.find('.update-button').trigger('click');
+		await flushPromises();
+
+		expect(notificationOpen).not.toHaveBeenCalled();
+	});
+
+	test('removes its listener on unmount', async () => {
+		invokeResults = { 'update:state': state() };
+		const wrapper = mountBar();
+		await flushPromises();
+
+		wrapper.unmount();
+		expect(removed).toContain('update:state');
+	});
+});

--- a/src/renderer/components/TitleBar.vue
+++ b/src/renderer/components/TitleBar.vue
@@ -16,11 +16,26 @@
 					title
 				}}</span>
 			</div>
-			<div v-if="updateReady" class="button" @click="onUpdate">
+			<!-- The tooltip is not decoration. This used to be a bare green arrow
+			     that appeared without explanation and, on one click, quit the app
+			     to install — so the title/aria-label naming the version and the
+			     action is the smallest thing that makes it honest. Hidden entirely
+			     unless there is something to act on (shouldShowUpdateBadge). -->
+			<div
+				v-if="showUpdate"
+				class="button update-button"
+				role="button"
+				:title="updateTooltip"
+				:aria-label="updateTooltip"
+				@click="onUpdate"
+			>
 				<font-awesome-icon
-					:style="{ color: 'green' }"
-					:icon="['fas', 'arrow-down']"
+					:style="{ color: updateColor }"
+					:icon="['fas', updateIcon]"
 				/>
+				<span v-if="updatePercent !== null" class="update-percent"
+					>{{ updatePercent }}%</span
+				>
 			</div>
 			<div class="button" @click="onMinimize">
 				<span class="dash">&#x2012;</span>
@@ -32,19 +47,90 @@
 </template>
 
 <script lang="ts">
+import { useOruga } from '@oruga-ui/oruga-next';
+import {
+	describeUpdate,
+	initialUpdateState,
+	shouldShowUpdateBadge,
+	type UpdateState,
+} from '../../utilities/update-decisions';
+import { version } from '../../../package.json';
+
 const { ipcRenderer } = require('electron');
+
+// What main sends on 'update:state' and returns from the query: the reduced state
+// plus the two things only main can answer.
+type UpdateStatePayload = UpdateState & {
+	busy: boolean;
+	currentVersion: string;
+};
 
 export default {
 	props: ['title', 'ico'],
 	data() {
 		return {
-			updateReady: false,
+			update: {
+				...initialUpdateState(),
+				busy: false,
+				currentVersion: version,
+			} as UpdateStatePayload,
+			// Hoisted so beforeUnmount can removeListener it — same pattern as
+			// LongExposurePanel's onProgress. The old code added an ipcRenderer
+			// listener in mounted and never removed it.
+			onUpdateState: null as
+				| ((event: unknown, state: UpdateStatePayload) => void)
+				| null,
 		};
 	},
-	mounted() {
-		ipcRenderer.on('update-available', () => {
-			this.updateReady = true;
-		});
+	computed: {
+		showUpdate(): boolean {
+			return shouldShowUpdateBadge(this.update);
+		},
+		updateTooltip(): string {
+			return describeUpdate(
+				this.update,
+				this.update.currentVersion,
+				this.update.busy
+			);
+		},
+		updateIcon(): string {
+			// Distinct glyphs per phase: "there is something to fetch" and "there is
+			// something ready to install" are different asks, and a single arrow for
+			// both was half of why the old affordance was unreadable.
+			return this.update.phase === 'downloaded'
+				? 'rotate-right'
+				: 'cloud-arrow-down';
+		},
+		updateColor(): string {
+			// Green only when it is ready — while downloading it is merely in flight.
+			return this.update.phase === 'downloaded' ? '#48c78e' : '#ffffff';
+		},
+		updatePercent(): number | null {
+			return this.update.phase === 'downloading'
+				? this.update.percent
+				: null;
+		},
+	},
+	async mounted() {
+		this.onUpdateState = (_event, state: UpdateStatePayload) => {
+			this.update = state;
+		};
+		ipcRenderer.on('update:state', this.onUpdateState);
+
+		// ASK, rather than only listening. The download can finish before this
+		// component mounts (or the renderer can reload), and the previous
+		// fire-and-forget send meant that lost the notification for the session.
+		try {
+			this.update = await ipcRenderer.invoke('update:state');
+		} catch {
+			// Main not ready yet; the broadcast will catch us up.
+		}
+	},
+	beforeUnmount() {
+		if (this.onUpdateState) {
+			ipcRenderer.removeListener('update:state', this.onUpdateState);
+			this.onUpdateState = null;
+		}
 	},
 	methods: {
 		onClose() {
@@ -56,8 +142,28 @@ export default {
 		onMaximize() {
 			ipcRenderer.send('window-control', 'toggle-maximize');
 		},
-		onUpdate() {
-			ipcRenderer.send('install-update', '');
+		async onUpdate() {
+			// One button, two actions, decided by main. The renderer does not get to
+			// guess: main re-checks the capture guard at the moment of the call, so
+			// its verdict is the authoritative one even if this state is a beat old.
+			const channel =
+				this.update.phase === 'downloaded'
+					? 'update:install'
+					: 'update:download';
+			const result = await ipcRenderer.invoke(channel);
+			if (result?.state) {
+				this.update = result.state;
+			}
+			// A refusal the user can do something about (a capture is running) is
+			// worth a toast; declining the install dialog returns no reason and
+			// deliberately says nothing.
+			if (result && !result.ok && result.reason) {
+				useOruga().notification.open({
+					message: result.reason,
+					variant: 'warning',
+					duration: 6000,
+				});
+			}
 		},
 	},
 };
@@ -112,6 +218,21 @@ img {
 }
 .button:hover {
 	background-color: rgba(255, 255, 255, 0.1);
+}
+/* Wider than the window controls because it can carry a percentage next to the
+   glyph; auto width keeps it from crowding the minimise button when it cannot. */
+.update-button {
+	width: auto;
+	min-width: 44px;
+	padding: 0 8px;
+	gap: 4px;
+	justify-content: center;
+}
+.update-percent {
+	font-size: 9pt;
+	color: white;
+	user-select: none;
+	font-variant-numeric: tabular-nums;
 }
 .close:hover {
 	background-color: red;

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -32,6 +32,11 @@ import {
 	faCircleExclamation,
 	faTriangleExclamation,
 	faCircleInfo,
+	// TitleBar's update states. Two glyphs, because "download it" and "restart to
+	// install it" are different actions and one arrow for both told the user
+	// neither.
+	faCloudArrowDown,
+	faRotateRight,
 } from '@fortawesome/free-solid-svg-icons';
 import { faDiscord } from '@fortawesome/free-brands-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/vue-fontawesome';
@@ -51,6 +56,8 @@ library.add(
 	faCircleExclamation,
 	faTriangleExclamation,
 	faCircleInfo,
+	faCloudArrowDown,
+	faRotateRight,
 	faDiscord
 );
 

--- a/src/utilities/update-decisions.test.ts
+++ b/src/utilities/update-decisions.test.ts
@@ -1,0 +1,385 @@
+import {
+	applyUpdateEvent,
+	canInstallNow,
+	canStartDownload,
+	clampPercent,
+	describeUpdate,
+	initialUpdateState,
+	shouldCheckNow,
+	shouldShowUpdateBadge,
+	UPDATE_RECHECK_INTERVAL_MS,
+	type UpdateState,
+} from './update-decisions';
+
+const NOW = 1_754_000_000_000;
+
+function stateWith(patch: Partial<UpdateState>): UpdateState {
+	return { ...initialUpdateState(), ...patch };
+}
+
+describe('initialUpdateState', () => {
+	test('starts idle with nothing claimed', () => {
+		expect(initialUpdateState()).toEqual({
+			phase: 'idle',
+			version: null,
+			percent: null,
+			error: null,
+			checkedAt: null,
+		});
+	});
+});
+
+describe('clampPercent', () => {
+	test('rounds a float into whole percent', () => {
+		expect(clampPercent(42.4)).toBe(42);
+		expect(clampPercent(42.6)).toBe(43);
+	});
+
+	test('clamps outside 0-100 rather than trusting the reporter', () => {
+		expect(clampPercent(-5)).toBe(0);
+		expect(clampPercent(103.2)).toBe(100);
+	});
+
+	test('rejects non-finite and non-numeric input', () => {
+		expect(clampPercent(NaN)).toBeNull();
+		expect(clampPercent(Infinity)).toBeNull();
+		expect(clampPercent(undefined)).toBeNull();
+		expect(clampPercent('50')).toBeNull();
+	});
+});
+
+describe('applyUpdateEvent', () => {
+	test('checking clears a previous error but keeps the staged version', () => {
+		const before = stateWith({
+			phase: 'error',
+			version: '3.3.0',
+			error: 'boom',
+		});
+		const after = applyUpdateEvent(before, { type: 'checking' }, NOW);
+		expect(after.phase).toBe('checking');
+		expect(after.error).toBeNull();
+		expect(after.version).toBe('3.3.0');
+	});
+
+	test('available records the version and stamps the check', () => {
+		const after = applyUpdateEvent(
+			initialUpdateState(),
+			{ type: 'available', version: '3.3.0' },
+			NOW
+		);
+		expect(after).toEqual({
+			phase: 'available',
+			version: '3.3.0',
+			percent: null,
+			error: null,
+			checkedAt: NOW,
+		});
+	});
+
+	test('not-available clears the version and stamps the check', () => {
+		const before = stateWith({ phase: 'available', version: '3.3.0' });
+		const after = applyUpdateEvent(
+			before,
+			{ type: 'not-available', version: '3.2.2' },
+			NOW
+		);
+		expect(after.phase).toBe('idle');
+		expect(after.version).toBeNull();
+		expect(after.checkedAt).toBe(NOW);
+	});
+
+	test('download-started opens at zero percent', () => {
+		const before = stateWith({ phase: 'available', version: '3.3.0' });
+		const after = applyUpdateEvent(before, { type: 'download-started' }, NOW);
+		expect(after.phase).toBe('downloading');
+		expect(after.percent).toBe(0);
+		expect(after.version).toBe('3.3.0');
+	});
+
+	test('progress clamps through the same rule as clampPercent', () => {
+		const before = stateWith({ phase: 'downloading', version: '3.3.0' });
+		expect(
+			applyUpdateEvent(before, { type: 'progress', percent: 61.7 }, NOW)
+				.percent
+		).toBe(62);
+		expect(
+			applyUpdateEvent(before, { type: 'progress', percent: 250 }, NOW)
+				.percent
+		).toBe(100);
+		expect(
+			applyUpdateEvent(before, { type: 'progress', percent: null }, NOW)
+				.percent
+		).toBeNull();
+	});
+
+	test('downloaded falls back to the version already staged', () => {
+		const before = stateWith({ phase: 'downloading', version: '3.3.0' });
+		const after = applyUpdateEvent(
+			before,
+			{ type: 'downloaded', version: null },
+			NOW
+		);
+		expect(after.phase).toBe('downloaded');
+		expect(after.version).toBe('3.3.0');
+		expect(after.percent).toBe(100);
+	});
+
+	test('error from idle surfaces the message', () => {
+		const after = applyUpdateEvent(
+			initialUpdateState(),
+			{ type: 'error', message: 'ERR_UPDATER_CHANNEL_FILE_NOT_FOUND' },
+			NOW
+		);
+		expect(after.phase).toBe('error');
+		expect(after.error).toBe('ERR_UPDATER_CHANNEL_FILE_NOT_FOUND');
+	});
+
+	// The invariant that matters most: the bits are on disk and will install on
+	// quit, so a later failed re-check must not tell the user the update failed.
+	test('a downloaded update outranks a later error', () => {
+		const before = stateWith({
+			phase: 'downloaded',
+			version: '3.3.0',
+			percent: 100,
+		});
+		const after = applyUpdateEvent(
+			before,
+			{ type: 'error', message: 'offline' },
+			NOW + 1000
+		);
+		expect(after).toEqual(before);
+	});
+
+	test('an unknown event leaves the state untouched', () => {
+		const before = stateWith({ phase: 'available', version: '3.3.0' });
+		const after = applyUpdateEvent(
+			before,
+			{ type: 'nonsense' } as unknown as { type: 'checking' },
+			NOW
+		);
+		expect(after).toBe(before);
+	});
+});
+
+describe('shouldCheckNow', () => {
+	test('checks when nothing has ever been checked', () => {
+		expect(
+			shouldCheckNow({ phase: 'idle', checkedAt: null, nowMs: NOW })
+		).toBe(true);
+	});
+
+	test('holds off inside the interval and allows it after', () => {
+		expect(
+			shouldCheckNow({
+				phase: 'idle',
+				checkedAt: NOW - UPDATE_RECHECK_INTERVAL_MS + 1,
+				nowMs: NOW,
+			})
+		).toBe(false);
+		expect(
+			shouldCheckNow({
+				phase: 'idle',
+				checkedAt: NOW - UPDATE_RECHECK_INTERVAL_MS,
+				nowMs: NOW,
+			})
+		).toBe(true);
+	});
+
+	test('force bypasses the interval', () => {
+		expect(
+			shouldCheckNow({
+				phase: 'idle',
+				checkedAt: NOW - 1000,
+				nowMs: NOW,
+				force: true,
+			})
+		).toBe(true);
+	});
+
+	test('never interrupts a check or a download, even forced', () => {
+		for (const phase of ['checking', 'downloading'] as const) {
+			expect(
+				shouldCheckNow({
+					phase,
+					checkedAt: null,
+					nowMs: NOW,
+					force: true,
+				})
+			).toBe(false);
+		}
+	});
+
+	test('does not churn while an update is staged and awaiting the user', () => {
+		for (const phase of ['available', 'downloaded'] as const) {
+			expect(
+				shouldCheckNow({
+					phase,
+					checkedAt: NOW - UPDATE_RECHECK_INTERVAL_MS * 10,
+					nowMs: NOW,
+					force: true,
+				})
+			).toBe(false);
+		}
+	});
+
+	test('re-checks after a previous failure', () => {
+		expect(
+			shouldCheckNow({
+				phase: 'error',
+				checkedAt: NOW - UPDATE_RECHECK_INTERVAL_MS,
+				nowMs: NOW,
+			})
+		).toBe(true);
+	});
+});
+
+describe('canStartDownload', () => {
+	test('allows a download of an available update when idle-handed', () => {
+		expect(canStartDownload({ phase: 'available', busy: false })).toEqual({
+			allowed: true,
+			reason: null,
+		});
+	});
+
+	test('refuses while a capture is running', () => {
+		const verdict = canStartDownload({ phase: 'available', busy: true });
+		expect(verdict.allowed).toBe(false);
+		expect(verdict.reason).toMatch(/capture is in progress/i);
+	});
+
+	test('refuses when there is nothing to download', () => {
+		expect(canStartDownload({ phase: 'idle', busy: false }).allowed).toBe(
+			false
+		);
+		expect(canStartDownload({ phase: 'error', busy: false }).allowed).toBe(
+			false
+		);
+	});
+
+	test('refuses a second download of the same update', () => {
+		expect(
+			canStartDownload({ phase: 'downloading', busy: false }).reason
+		).toMatch(/already downloading/i);
+		expect(
+			canStartDownload({ phase: 'downloaded', busy: false }).reason
+		).toMatch(/already downloaded/i);
+	});
+});
+
+describe('canInstallNow', () => {
+	test('allows installing a downloaded update', () => {
+		expect(canInstallNow({ phase: 'downloaded', busy: false })).toEqual({
+			allowed: true,
+			reason: null,
+		});
+	});
+
+	test('refuses mid-capture and says what happens instead', () => {
+		const verdict = canInstallNow({ phase: 'downloaded', busy: true });
+		expect(verdict.allowed).toBe(false);
+		expect(verdict.reason).toMatch(/close the app/i);
+	});
+
+	test('refuses when nothing has been downloaded', () => {
+		for (const phase of [
+			'idle',
+			'checking',
+			'available',
+			'downloading',
+			'error',
+		] as const) {
+			expect(canInstallNow({ phase, busy: false }).allowed).toBe(false);
+		}
+	});
+});
+
+describe('describeUpdate', () => {
+	test('distinguishes "not checked yet" from "up to date"', () => {
+		expect(describeUpdate(initialUpdateState(), '3.2.2')).toMatch(
+			/have not been checked/i
+		);
+		expect(describeUpdate(stateWith({ checkedAt: NOW }), '3.2.2')).toMatch(
+			/latest version \(v3\.2\.2\)/i
+		);
+	});
+
+	test('names the version and the action for an available update', () => {
+		const text = describeUpdate(
+			stateWith({ phase: 'available', version: '3.3.0' }),
+			'3.2.2'
+		);
+		expect(text).toContain('v3.3.0');
+		expect(text).toMatch(/click to download/i);
+	});
+
+	test('shows download percent when there is one', () => {
+		expect(
+			describeUpdate(
+				stateWith({ phase: 'downloading', version: '3.3.0', percent: 62 }),
+				'3.2.2'
+			)
+		).toContain('62%');
+		expect(
+			describeUpdate(
+				stateWith({
+					phase: 'downloading',
+					version: '3.3.0',
+					percent: null,
+				}),
+				'3.2.2'
+			)
+		).toMatch(/downloading v3\.3\.0…/i);
+	});
+
+	test('explains the install-on-close path while busy', () => {
+		expect(
+			describeUpdate(
+				stateWith({ phase: 'downloaded', version: '3.3.0' }),
+				'3.2.2',
+				true
+			)
+		).toMatch(/install when you close the app/i);
+		expect(
+			describeUpdate(
+				stateWith({ phase: 'downloaded', version: '3.3.0' }),
+				'3.2.2',
+				false
+			)
+		).toMatch(/click to restart and install/i);
+	});
+
+	test('surfaces the error text', () => {
+		expect(
+			describeUpdate(
+				stateWith({ phase: 'error', error: 'offline' }),
+				'3.2.2'
+			)
+		).toContain('offline');
+	});
+
+	test('falls back gracefully when the version is unknown', () => {
+		expect(
+			describeUpdate(stateWith({ phase: 'available' }), '3.2.2')
+		).toMatch(/^A new version is available/);
+	});
+});
+
+describe('shouldShowUpdateBadge', () => {
+	test('shows only once there is something the user can act on', () => {
+		expect(shouldShowUpdateBadge(stateWith({ phase: 'available' }))).toBe(
+			true
+		);
+		expect(shouldShowUpdateBadge(stateWith({ phase: 'downloading' }))).toBe(
+			true
+		);
+		expect(shouldShowUpdateBadge(stateWith({ phase: 'downloaded' }))).toBe(
+			true
+		);
+	});
+
+	test('stays quiet for idle, checking and error', () => {
+		for (const phase of ['idle', 'checking', 'error'] as const) {
+			expect(shouldShowUpdateBadge(stateWith({ phase }))).toBe(false);
+		}
+	});
+});

--- a/src/utilities/update-decisions.ts
+++ b/src/utilities/update-decisions.ts
@@ -1,0 +1,302 @@
+// Pure auto-update decision cores, extracted from index.ts for the same reason as
+// capture-decisions.ts: index.ts pulls electron/sharp/koffi/irsdk at module scope
+// and cannot load under vitest. No I/O, no module state, no electron — index.ts
+// owns the autoUpdater wiring and calls these for every decision it makes.
+//
+// In utilities/ rather than main/ because the RENDERER shares it, the same way it
+// shares shot-recipe.ts: TitleBar phrases its tooltip with describeUpdate and
+// decides whether to render at all with shouldShowUpdateBadge. One copy of the
+// wording means the title bar and the Settings line can never disagree about what
+// the app is doing.
+//
+// Background: until this landed the app checked once at startup, downloaded ~114 MB
+// silently while the user might be on track, and reported the result as an untitled
+// green arrow that clicking quit the app instantly. Each function below is one of
+// those behaviours made explicit and testable.
+
+// Where a pending update has got to. `idle` covers both "not checked yet" and
+// "checked, nothing newer" — `checkedAt` distinguishes them.
+export type UpdatePhase =
+	| 'idle'
+	| 'checking'
+	| 'available'
+	| 'downloading'
+	| 'downloaded'
+	| 'error';
+
+export interface UpdateState {
+	phase: UpdatePhase;
+	// The version being offered, downloaded or ready. Null when there is nothing to
+	// name. electron-updater hands us `info.version` without the leading 'v'.
+	version: string | null;
+	// Download progress, 0-100, null unless a download is running.
+	percent: number | null;
+	// Already phrased for display; null unless `phase === 'error'`.
+	error: string | null;
+	// When the last check RESOLVED (not when it started), epoch ms. Null before the
+	// first one completes. Drives both the re-check debounce and the "you're up to
+	// date" wording, which must not claim freshness we never established.
+	checkedAt: number | null;
+}
+
+// A capture in flight is the one thing that makes an update action unsafe, so the
+// callers pass it in rather than each re-deriving `longExposureActive || takingScreenshot`.
+export interface UpdateBusyInput {
+	busy: boolean;
+}
+
+export function initialUpdateState(): UpdateState {
+	return {
+		phase: 'idle',
+		version: null,
+		percent: null,
+		error: null,
+		checkedAt: null,
+	};
+}
+
+// electron-updater's ProgressInfo.percent is a float and, on a resumed or
+// mis-reported transfer, can land outside 0-100. Clamped here so no consumer has to
+// defend against a 103%-wide progress bar.
+export function clampPercent(raw: unknown): number | null {
+	if (typeof raw !== 'number' || !Number.isFinite(raw)) {
+		return null;
+	}
+	return Math.max(0, Math.min(100, Math.round(raw)));
+}
+
+export type UpdateEvent =
+	| { type: 'checking' }
+	| { type: 'available'; version: string | null }
+	| { type: 'not-available'; version: string | null }
+	| { type: 'download-started' }
+	| { type: 'progress'; percent: unknown }
+	| { type: 'downloaded'; version: string | null }
+	| { type: 'error'; message: string };
+
+// The state machine. Every autoUpdater event in index.ts routes through here, so
+// the transitions are locked by tests instead of being spread across seven
+// listeners that each mutate a shared object.
+export function applyUpdateEvent(
+	state: UpdateState,
+	event: UpdateEvent,
+	nowMs: number
+): UpdateState {
+	switch (event.type) {
+		case 'checking':
+			// Version is deliberately preserved: a re-check while an update is already
+			// staged must not blank the label the title bar is showing.
+			return { ...state, phase: 'checking', error: null };
+
+		case 'available':
+			return {
+				...state,
+				phase: 'available',
+				version: event.version,
+				percent: null,
+				error: null,
+				checkedAt: nowMs,
+			};
+
+		case 'not-available':
+			return {
+				...state,
+				phase: 'idle',
+				version: null,
+				percent: null,
+				error: null,
+				checkedAt: nowMs,
+			};
+
+		case 'download-started':
+			return { ...state, phase: 'downloading', percent: 0, error: null };
+
+		case 'progress':
+			return {
+				...state,
+				phase: 'downloading',
+				percent: clampPercent(event.percent),
+				error: null,
+			};
+
+		case 'downloaded':
+			return {
+				...state,
+				phase: 'downloaded',
+				version: event.version ?? state.version,
+				percent: 100,
+				error: null,
+				checkedAt: nowMs,
+			};
+
+		case 'error':
+			// A DOWNLOADED update outranks a later failure. Without this, one flaky
+			// re-check six hours after a successful download would replace a ready
+			// install with an error badge — and the bits are still on disk, so the
+			// user would be told the update failed while it sits waiting to install
+			// on quit (autoInstallOnAppQuit is electron-updater's default).
+			if (state.phase === 'downloaded') {
+				return state;
+			}
+			return {
+				...state,
+				phase: 'error',
+				percent: null,
+				error: event.message,
+			};
+
+		default:
+			return state;
+	}
+}
+
+// Policy: at most one check per this window, however many times we are asked.
+export const UPDATE_RECHECK_INTERVAL_MS = 6 * 60 * 60 * 1000;
+
+// How often index.ts ASKS the policy above. Deliberately much shorter than the
+// interval so a machine that slept through its slot re-checks soon after waking
+// rather than at the next exact multiple.
+export const UPDATE_POLL_INTERVAL_MS = 30 * 60 * 1000;
+
+export interface ShouldCheckInput {
+	phase: UpdatePhase;
+	checkedAt: number | null;
+	nowMs: number;
+	// Defaults to UPDATE_RECHECK_INTERVAL_MS; injectable for tests.
+	minIntervalMs?: number;
+	// A user pressing "Check for updates" bypasses the interval — but not the phase
+	// guard below, because there is nothing sensible to do mid-check or mid-download.
+	force?: boolean;
+}
+
+// Whether to start a check now. Called by the startup path, the poll timer, the
+// window-focus hook and the Settings button, so the debounce lives in one place and
+// focus cannot spam GitHub every time the user alt-tabs back from iRacing.
+export function shouldCheckNow({
+	phase,
+	checkedAt,
+	nowMs,
+	minIntervalMs = UPDATE_RECHECK_INTERVAL_MS,
+	force = false,
+}: ShouldCheckInput): boolean {
+	// Never interrupt work already in progress.
+	if (phase === 'checking' || phase === 'downloading') {
+		return false;
+	}
+	// Something is already staged and waiting on the user. Re-checking cannot
+	// improve on that and would churn the title bar out from under a pending
+	// decision.
+	if (phase === 'available' || phase === 'downloaded') {
+		return false;
+	}
+	if (force || checkedAt === null) {
+		return true;
+	}
+	return nowMs - checkedAt >= minIntervalMs;
+}
+
+export interface ActionVerdict {
+	allowed: boolean;
+	// Why not, phrased for display. Null when allowed.
+	reason: string | null;
+}
+
+// Downloading is ~114 MB. Starting that while a capture is running competes with
+// iRacing for disk and bandwidth at the exact moment the user cares most, which is
+// why autoDownload is off and this gate exists.
+export function canStartDownload({
+	phase,
+	busy,
+}: UpdateBusyInput & { phase: UpdatePhase }): ActionVerdict {
+	if (phase === 'downloading') {
+		return { allowed: false, reason: 'The update is already downloading.' };
+	}
+	if (phase === 'downloaded') {
+		return { allowed: false, reason: 'The update is already downloaded.' };
+	}
+	if (phase !== 'available') {
+		return { allowed: false, reason: 'There is no update to download.' };
+	}
+	if (busy) {
+		return {
+			allowed: false,
+			reason: 'A capture is in progress. Try again once it finishes.',
+		};
+	}
+	return { allowed: true, reason: null };
+}
+
+// Installing quits the app. Doing that mid-capture loses the shot — and for a long
+// exposure that can be minutes of accumulated work.
+export function canInstallNow({
+	phase,
+	busy,
+}: UpdateBusyInput & { phase: UpdatePhase }): ActionVerdict {
+	if (phase !== 'downloaded') {
+		return { allowed: false, reason: 'No update is ready to install.' };
+	}
+	if (busy) {
+		return {
+			allowed: false,
+			// Accurate, not a consolation: autoInstallOnAppQuit defaults to true, so
+			// the downloaded update really does install on the next normal quit.
+			reason:
+				'A capture is in progress. The update will install by itself when you close the app.',
+		};
+	}
+	return { allowed: true, reason: null };
+}
+
+// One sentence for the title-bar tooltip and the Settings line. The title bar had
+// no tooltip at all: a green arrow appeared and the user was left to guess both what
+// it meant and what clicking it would do.
+export function describeUpdate(
+	state: UpdateState,
+	currentVersion: string,
+	busy = false
+): string {
+	const version = state.version ? `v${state.version}` : 'A new version';
+
+	switch (state.phase) {
+		case 'checking':
+			return 'Checking for updates…';
+
+		case 'available':
+			return busy
+				? `${version} is available. A capture is in progress — you can download it once that finishes.`
+				: `${version} is available. Click to download it.`;
+
+		case 'downloading':
+			return state.percent === null
+				? `Downloading ${version}…`
+				: `Downloading ${version} — ${state.percent}%`;
+
+		case 'downloaded':
+			return busy
+				? `${version} is ready. A capture is in progress, so it will install when you close the app.`
+				: `${version} is ready. Click to restart and install it.`;
+
+		case 'error':
+			return `Update check failed: ${state.error ?? 'unknown error'}`;
+
+		case 'idle':
+		default:
+			// Never claim freshness we have not established — before the first check
+			// resolves we genuinely do not know.
+			return state.checkedAt === null
+				? `Updates have not been checked yet (you're on v${currentVersion}).`
+				: `You're on the latest version (v${currentVersion}).`;
+	}
+}
+
+// Whether the title bar shows its update button at all. Idle and checking are
+// silent: a spinner that appears every six hours to say nothing would be worse than
+// the arrow it replaced. Errors stay in the log and the Settings line — an update
+// check failing is not something the user asked about or can act on from here.
+export function shouldShowUpdateBadge(state: UpdateState): boolean {
+	return (
+		state.phase === 'available' ||
+		state.phase === 'downloading' ||
+		state.phase === 'downloaded'
+	);
+}


### PR DESCRIPTION
Auto-update has never worked in any shipped build. There were three independent breaks, each sufficient on its own; this fixes all three and rebuilds the client behaviour that sat on top of them.

## The breaks

**1. The client never checked.** The gate was `process.env.NODE_ENV === 'production'`. Nothing sets `NODE_ENV` in a packaged Electron app — electron-vite leaves it as a runtime read in `out/main/index.js`, unlike the webpack config it replaced in `13d84e1`, whose `mode: 'production'` inlined it via `optimization.nodeEnv`. So this regressed at the bundler migration rather than being an original bug. Evidence: `app.log` across packaged v3.2.2 runs contains not one `Auto-update checking` line, though that handler logs unconditionally as soon as `checkForUpdates()` is entered. Now gated on `app.isPackaged`, which is the condition `AppUpdater.isUpdaterActive` itself tests.

**2. Releases were flagged pre-release.** `gh release edit --draft=false --latest` clears draft but not prerelease, and GitHub will not point `/releases/latest` at a prerelease however many times you pass `--latest`. v3.1.0, v3.2.1 and v3.2.2 all shipped flagged, so that redirect sat on **v3.1.1**. That is the URL electron-updater resolves the newest version through when `allowPrerelease` is at its default (`GitHubProvider.getLatestTagName`). Fixed with `--prerelease=false` in the publish step.

**3. So the check would have 404'd anyway.** v3.1.1 predates the `latest.yml` upload fix, so the channel file it would have fetched does not exist. Fixing #2 repoints `/releases/latest` at v3.2.2, whose `latest.yml` is present and correct.

## The rebuild

With the plumbing alive, the previous client behaviour would have been worse than nothing — so:

- **`autoDownload` off.** The ~114 MB installer used to start transferring the moment the app was ready, competing with iRacing for bandwidth and disk while the user might be on track, with nothing on screen to say so. The check still runs freely; the bytes move when the user asks. `autoInstallOnAppQuit` is deliberately left at its default of `true` — the "it will install when you close the app" message is a promise that depends on it.
- **State is held, not just announced.** Main owns one `UpdateState`, broadcasts every transition, *and* answers `update:state`. The query is the load-bearing half: the previous fire-and-forget send on download completion was lost whenever the renderer mounted after the event, costing the notification for the whole session.
- **`download-progress` wired**, so the transfer is a percentage rather than an unexplained stall.
- **Re-checks** on a 30-minute poll and on window focus, both rationed to one check per six hours. A startup-only check meant a release landing at 8pm stayed invisible until the next launch, and this app is left open for whole evenings.
- **The title-bar affordance** was an unlabelled green arrow that quit the app on one click. It now names the version and the action in its `title`/`aria-label`, uses distinct glyphs for "download it" and "restart to install it", refuses with a reason while a capture or long exposure is in flight, and confirms through a dialog otherwise.
- **Settings** gained a manual *Check for Updates* with a live status line, and says plainly that checks only run in an installed build.

All the logic lives in `src/utilities/update-decisions.ts` — pure, in `utilities/` rather than `main/` because the renderer shares it the way it shares `shot-recipe.ts`, so the title bar and the Settings line cannot drift apart in what they claim.

## Testing

`npm test` — 797 passing, 45 of them new. `update-decisions.test.ts` covers the reducer, the rationing policy, both capture guards and the wording; `TitleBar.test.ts` covers the renderer on the harness `renderer-harness.test.ts` established, using the require-cache electron stub `logger.integration.test.ts` documents, and locks the specific regressions (an update downloaded before the component mounts still shows; clicks route to download vs install by phase; a refusal toasts without dismissing the badge). Type-check, eslint and prettier clean; `npm run pack` builds, and the emitted bundle was checked to confirm the gate compiles to `app.isPackaged`.

## Two things to know before merging

- **The fix is not retroactive.** Every user on ≤ v3.2.2 carries the dead gate and has to install one release by hand; there is no way to reach them from here.
- **The pre-release flags on the existing releases are still set.** Cosmetic for the updater — the next non-prerelease release takes over `/releases/latest` on its own — but until then the repo shows v3.1.1 as Latest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
