### PR TITLE
feat(i18n): multi-locale support in thirteen European languages

### DIFF
--- a/src/locales/cs.ts
+++ b/src/locales/cs.ts
@@ -1,0 +1,485 @@
+// Czech. Translated from en.ts — see that file's header before editing.
+//
+// NOTE ON PLURALS. Czech has four CLDR categories:
+//   one   n = 1                → 1 průchod
+//   few   n = 2..4             → 2 průchody
+//   many  fractional counts    → 1,5 průchodu
+//   other everything else (0, 5+) → 5 průchodů
+// `other` is therefore the genitive plural, not a copy of `one` — getting this
+// wrong renders "5 průchody", which is not Czech.
+//
+// Product and technology names stay untranslated: iRacing, ReShade, Discord,
+// Windows.Graphics.Capture, WGC, VRAM, GPU, NVIDIA Turing and the file formats.
+
+import type { Catalog } from './index';
+
+const cs: Catalog = {
+	notice: {
+		danger: 'Problémy',
+		warning: 'Dobré vědět',
+		info: 'Poznámky',
+	},
+
+	promo: {
+		greeting: 'Děkujeme, že používáte iRacing Screenshot Tool!',
+		signature: 'Vytvořila a spravuje AR Media Solutions.',
+	},
+
+	changelog: {
+		title: 'Seznam změn',
+		untitledRelease: 'Verze',
+	},
+
+	gallery: {
+		menu: {
+			openExternally: 'Otevřít v jiné aplikaci',
+			openFolder: 'Otevřít složku',
+			copy: 'Kopírovat',
+			delete: 'Odstranit',
+		},
+		copiedToClipboard: '{name} zkopírováno do schránky',
+	},
+
+	sidebar: {
+		resolution: 'Rozlišení',
+		width: 'Šířka',
+		height: 'Výška',
+		output: 'Výstup:',
+		cropWatermark: 'Oříznout vodoznak',
+		keepAspectRatio: 'Zachovat poměr stran',
+		screenshot: 'Snímek obrazovky',
+		custom: 'Vlastní',
+		vramStatus: '{adapter}{free} volných z {total}',
+		savedSuccessfully: '{name} úspěšně uloženo',
+		screenshotFailed: 'Snímek se nezdařil: {message}',
+		errorLogPrefix: 'Protokol: ',
+		notices: {
+			exclusiveFullscreen:
+				'iRacing běží ve výhradním celoobrazovkovém režimu — snímky budou černé. V iRacingu nastavte Display > Full Screen na OFF (Borderless nebo Windowed), aby snímání fungovalo.',
+			vramRisk:
+				'{resolution} potřebuje přibližně {needed} paměti VRAM navíc, ale volných je jen {free} — iRacingu pravděpodobně dojde paměť a spadne.',
+			vramCaution:
+				'{resolution} nechává málo rezervy paměti VRAM ({free} volných) a u náročných kombinací trati a vozu může spadnout.',
+			switchResolution: 'Přepnout na {resolution}',
+			vramStatic:
+				'Vysoká rozlišení mohou způsobit pád iRacingu, pokud dojde paměť VRAM. Některé kombinace trati a vozu vyžadují více VRAM.',
+			reshade:
+				'Po stisknutí tlačítka snímku v iRacing Screenshot Tool budete muset ještě stisknout klávesovou zkratku pro snímek v ReShade.',
+			crop: 'Oříznutí vodoznaku výsledný obraz mírně přiblíží. Oblasti u okrajů obrazovky budou odříznuty.',
+			aspectRatio:
+				'„Zachovat poměr stran“ přizpůsobí výšku snímku poměru vašeho monitoru (například 21:9 ultraširoký) místo výchozích 16:9. Zvolené rozlišení určuje šířku.',
+		},
+	},
+
+	settings: {
+		title: 'Nastavení',
+		version: 'Verze - {version}',
+		changelog: 'Seznam změn',
+		openLogsFolder: 'Otevřít složku protokolů',
+		checkForUpdates: 'Zkontrolovat aktualizace',
+		updateCheckFailed: 'Kontrola aktualizací se nezdařila: {message}',
+
+		language: 'Jazyk',
+		languageDescription:
+			'Jazyk používaný v celé aplikaci. Při prvním spuštění se převezme z Windows.',
+
+		screenshotFolder: 'Složka pro snímky',
+		selectFolder: 'Vybrat složku',
+		screenshotKeybind: 'Klávesová zkratka snímku',
+		editBind: 'Upravit zkratku',
+
+		customFilenameFormat: 'Vlastní formát názvu souboru',
+		customFilenameFormatDescription:
+			'Použít vlastní vzor místo výchozího ({track}-{driver}-{counter})',
+		filenameFieldsHint:
+			'Kliknutím na pole je přidáte do formátu. Oddělovače (-, _ apod.) pište přímo.',
+		reset: 'Obnovit',
+		preview: 'Náhled:',
+
+		outputFormat: 'Výstupní formát',
+		formatJpeg: 'JPEG (nejvyšší kvalita)',
+		formatPng: 'PNG (bezztrátový)',
+		formatWebp: 'WebP (kvalita 95 %)',
+
+		disableTooltips: 'Skrýt tipy',
+		disableTooltipsDescription: 'Nechte mě být, vím, co dělám',
+
+		cropTopLeft: 'Upřednostnit oříznutí vodoznaku vlevo nahoře',
+		cropTopLeftDescription:
+			'Ořízne pouze pravý dolní roh (3 %). Když je volba vypnutá, snímek se ořízne rovnoměrně ze všech stran (celkem 6 %), takže výsledek zůstane vystředěný.',
+
+		manualWindowRestore: 'Ruční obnovení okna',
+		manualWindowRestoreDescription:
+			'Nahradí automatické obnovení okna vlastní pozicí a velikostí. Užitečné pro ultraširoké monitory nebo Nvidia Surround.',
+		left: 'Vlevo',
+		top: 'Nahoře',
+		width: 'Šířka',
+		height: 'Výška',
+		restoreNow: 'Obnovit nyní',
+
+		nativeCapture: 'Snímání ve vysoké věrnosti (WGC)',
+		nativeCaptureDescription:
+			'Snímá skutečné barvy bez podvzorkování přes Windows.Graphics.Capture místo výchozí cesty (která barvy podvzorkuje). Při selhání snímání se automaticky vrátí k záložní metodě.',
+		nativeCaptureUnavailable:
+			'V tomto systému není dostupné — snímání ve vysoké věrnosti zde nemůže běžet.',
+		nativeCaptureUnverified:
+			'Windows hlásí podporu, ale zkušební snímek se nevrátil. Pokud selhávání potrvá, snímání se automaticky přepne na záložní metodu.',
+
+		reshade: 'Režim kompatibility s ReShade',
+		reshadeDescription:
+			'Při použití ReShade musíte nejprve použít zkratku iRacing Screenshot Tool nebo stisknout tlačítko a poté, jakmile okno iRacingu změní velikost, použít svou zkratku snímku v ReShade.',
+		reshadeIni: 'Soubor INI ReShade',
+		selectFile: 'Vybrat soubor',
+	},
+
+	longExposure: {
+		title: 'Dlouhá expozice',
+		shutter: 'Závěrka',
+		playbackSpeed: 'Rychlost přehrávání',
+		playbackAuto: 'Automaticky (podle cílového počtu vzorků)',
+		playbackRealTime: '1x (reálný čas)',
+		targetSamples: 'Cílový počet vzorků',
+		advanced: 'Pokročilé',
+		defaultsSummary: 'výchozích hodnot: {count}',
+
+		weighting: 'Vážení',
+		weightingBox: 'Box (rovnoměrné)',
+		weightingLinear: 'Lineární (ostré na konci)',
+		weightingEase: 'Ease (ostřejší začátek, dlouhý ohon)',
+
+		interpolation: 'Interpolace snímků',
+		interpolationOff: 'Vypnuto',
+		interpolation2: '2× (jeden mezisnímek)',
+		interpolation4: '4× (tři mezisnímky)',
+		interpolation8: '8× (sedm mezisnímků)',
+
+		passes: 'Průchody',
+		passes1: '1 (jediný průchod)',
+		passes2: '2× — dvojnásobné čekání',
+		passes4: '4× — čtyřnásobné čekání',
+		passes8: '8× — osminásobné čekání',
+
+		bracket: 'Braketing závěrek',
+		highlightRecovery: 'Obnova světel (EV)',
+
+		cancel: 'Zrušit',
+		saved: 'Dlouhá expozice uložena — vzorků: {count}',
+		failed: 'Dlouhá expozice se nezdařila',
+
+		modified: {
+			weighting_linear: 'lineární',
+			weighting_ease: 'ease',
+			interpolation: 'interpolace {factor}×',
+			passes: {
+				one: '{count} průchod',
+				few: '{count} průchody',
+				many: '{count} průchodu',
+				other: '{count} průchodů',
+			},
+			bracketed: 'braketing',
+			recovery: 'obnova {stops} EV',
+		},
+
+		progress: {
+			working: 'Pracuji…',
+			seeking: 'Hledám…{pass}',
+			accumulating: 'Exponuji… vzorků: {count}{pass}',
+			resolving: 'Vyvolávám…',
+			restoring: 'Obnovuji záznam…',
+			pass: ' (průchod {current} z {total})',
+		},
+
+		notices: {
+			needsNativeCapture:
+				'Dlouhá expozice vyžaduje snímání ve vysoké věrnosti (WGC), které je nyní vypnuté. Zapněte je v nastavení, aby šla dlouhá expozice použít.',
+			unavailableWithReason:
+				'Dlouhá expozice není na tomto počítači dostupná: {reason}',
+			unavailable: 'Dlouhá expozice není na tomto počítači dostupná.',
+			interpolationCost:
+				'Interpolace vymýšlí snímky mezi skutečnými, aby stopa byla plynulejší. Stojí čas GPU na každý snímek, proto porovnejte počet skutečných vzorků uloženého snímku se stejným snímkem bez interpolace — pokud toto číslo klesne, kupuje vymyšlené vzorky za skutečné.',
+			passesAndInterpolation:
+				'Průchody a interpolace soupeří o stejný rozpočet na snímek. Když jsou zapnuté obě, každý průchod zachytí méně skutečných snímků — vypnutí interpolace obvykle přinese lepší výsledek při stejném čekání.',
+			passes:
+				'Každý průchod znovu přehraje tentýž okamžik a zachytí snímky, které ostatní minuly, takže stopa je plynulejší, nikoli jasnější. Nejlépe se hodí u krátkých závěrek, kde jediný průchod nasbírá jen hrstku vzorků.',
+			interpolationUnsupported:
+				'Interpolace snímků vyžaduje GPU NVIDIA Turing nebo novější{adapter}. Vše ostatní na dlouhé expozici funguje normálně.',
+			interpolationAdapter: ' (toto snímání běží na {adapter})',
+			reshade:
+				'Dlouhá expozice snímá nativně a nepoužívá ReShade, takže efekty ReShade se ve výsledku neobjeví.',
+		},
+	},
+
+	help: {
+		title: 'Nápověda',
+		sections: 'Sekce nápovědy',
+		tabGeneral: 'Obecné',
+		tabLongExposure: 'Dlouhá expozice',
+
+		general: {
+			iracingSettings: 'Nastavení iRacingu',
+			borderless: 'iRacing musí běžet v režimu Windowed Borderless',
+			vram: 'Pro snímky v rozlišení 8K a vyšším se doporučuje alespoň 8 GB paměti VRAM',
+			newerContent: 'Novější tratě a vozy vyžadují více paměti VRAM',
+			shrinkUi:
+				'Pokud používáte volbu oříznutí vodoznaku, zmenšete před pořízením snímku uživatelské rozhraní na minimum — zkratka „Control+PageDown“ ho zmenší. Pokud to nefunguje, možná bude nutné obnovit přiblížení rozhraní v nastavení iRacingu.',
+
+			screenshotFolder: 'Složka pro snímky',
+			screenshotFolderBody:
+				'Snímky se ve výchozím nastavení ukládají do „C:\\Users\\user\\Pictures\\Screenshots“; to lze změnit v nastavení.',
+
+			screenshotHotkey: 'Klávesová zkratka snímku',
+			screenshotHotkeyBody:
+				'Ve výchozím nastavení pořídí „Control + PrintScreen“ snímek s aktuálním nastavením; zkratku lze změnit v nastavení.',
+
+			issues: 'Problémy',
+			issuesBody: 'Pokud narazíte na potíže, nahlaste je prosím na',
+			discord: 'Discordu',
+
+			instructions: 'Postup',
+			step1: 'iRacing <b>musí</b> běžet v režimu Windowed Borderless',
+			step2: 'Spusťte iRacing a nastavte kameru do pozice, ze které chcete snímek pořídit',
+			step3: 'Zvolte požadované rozlišení (než přejdete na 8K, vyzkoušejte nižší rozlišení)',
+			step4: 'Rozhodněte se, zda chcete oříznout vodoznak iRacingu; pokud ano, zmenšete nejprve rozhraní iRacingu zkratkou „Control + PageDown“ na nejmenší velikost',
+			step5: 'Stiskněte tlačítko snímku nebo použijte zkratku „Control + PrintScreen“',
+			step6: 'Podle zvoleného rozlišení to může trvat několik sekund; jakmile se okno iRacingu vrátí do normální velikosti, je hotovo',
+			step7: 'Váš snímek se uloží do „C:\\Users\\{User}\\Pictures\\Screenshots“',
+		},
+
+		longExposure: {
+			whatItDoes: 'Co to dělá',
+			whatItDoesBody:
+				'Dlouhá expozice sloučí mnoho snímků záznamu do jednoho obrazu, stejně jako ponechaná otevřená závěrka fotoaparátu: nehybné věci zůstanou ostré, pohybující se se rozmažou do stop. Nástroj sám řídí záznam, zachytí každý snímek, který simulátor vykreslí, a sečte je na GPU.',
+
+			shutter: 'Závěrka',
+			shutterBody:
+				'Jak dlouho expozice trvá <i>v čase záznamu</i>, od zlomku jednoho snímku záznamu až po deset sekund. Právě toto nastavení určuje délku stop. Delší závěrky zároveň nasbírají více snímků, takže potřebují méně pomoci od všeho ostatního níže; nejrychlejší hodnoty pokrývají jediný snímek záznamu a nasbírají jen hrstku vzorků.',
+
+			playback: 'Rychlost přehrávání',
+			playbackBody:
+				'Během snímání expozice se záznam přehrává zpomaleně, takže simulátor vykreslí více snímků na sekundu času záznamu a sloučení získá více vzorků. 1/16 nasbírá zhruba šestnáctkrát více snímků než reálný čas — a trvá šestnáctkrát déle reálného času. To je hlavní kompromis tohoto panelu: trpělivost za hladkost.',
+			playbackAutoBody:
+				'„Automaticky (podle cílového počtu vzorků)“ zvolí rychlost za vás podle <b>cílového počtu vzorků</b>: nástroj najde nejrychlejší přehrávání, které ještě dosáhne požadovaného počtu. Pokud raději omezíte čekání, zadejte konkrétní rychlost.',
+
+			weighting: 'Vážení',
+			weightingBody:
+				'Jak moc každý zachycený snímek přispívá k výsledku. <b>Box</b> je váží všechny stejně a dává rovnoměrnou stopu. <b>Lineární</b> stoupá ke konci okna, takže objekt je nejostřejší tam, kde skončil, a podél své dráhy slábne. <b>Ease</b> je totéž s ostřejším začátkem a delším ohonem.',
+
+			interpolation: 'Interpolace snímků',
+			interpolationBody:
+				'Pomocí jednotky optického toku na GPU vymýšlí další snímky mezi skutečnými a vyplňuje mezery ve stopě. Vyžaduje kartu NVIDIA Turing nebo novější a na hardwaru, který to neumí, je zcela skrytá.',
+			interpolationCostBody:
+				'Není zadarmo: stojí čas GPU u každého zachyceného snímku a rozpočet je jeden snímek iRacingu. Pokud nestíhá, začne vynechávat <i>skutečné</i> snímky, aby vyrobila syntetické, což je čistá ztráta — stopa vyjde kratší a hrubší. Náklady rostou s megapixely násobenými faktorem, takže co je pohodlné při 2560×1440, není únosné v 8K. Chcete-li to ověřit, pořiďte tentýž okamžik dvakrát, s interpolací i bez ní, a porovnejte počty skutečných vzorků; aplikace vás také dodatečně upozorní, pokud snímek nedosáhl očekávaného počtu.',
+
+			passes: 'Průchody',
+			passesBody:
+				'Navštíví tentýž okamžik několikrát a sčítá vše do jednoho obrazu. Každý průchod zachytí snímky, které ostatní minuly, takže stopa je hladší — nikoli jasnější, protože výsledek se normalizuje podle množství světla, které na každý pixel skutečně dopadlo.',
+			passesTradeBody:
+				'Průchody kupují totéž co interpolace, ale jinou měnou: reálným časem místo času GPU. Osm průchodů trvá zhruba osmkrát déle, ale nikdy vás nemohou připravit o skutečné snímky. Díky tomu jsou správnou pákou při vysokých rozlišeních, kde interpolace nestíhá, a u krátkých závěrek, kde jediný průchod nasbírá jen velmi málo vzorků. Používat obojí najednou je obvykle to nejhorší z obou — soupeří o tentýž rozpočet na snímek.',
+
+			bracket: 'Braketing závěrek',
+			bracketBody:
+				'Z jediného snímání vytvoří jeden obraz pro každou hodnotu závěrky stejnou nebo rychlejší, než jakou jste zvolili. Snímek při 1/60 vám dá i 1/125, 1/250, 1/500 a 1/1000 — tentýž okamžik s postupně kratšími stopami — takže si výsledek vyberete až potom, místo abyste hádali a snímek opakovali.',
+			bracketCostBody:
+				'Nestojí to téměř žádný čas navíc. Každá hodnota končí na tomtéž snímku a liší se jen tím, jak daleko sahá zpět, takže rychlejší závěrka je prostě konec snímků, které stejně procházejí — všechny se plní z jediného průchodu záznamu.',
+			bracketMemoryBody:
+				'Co to naopak stojí, je paměť. Každá hodnota potřebuje vlastní akumulátor v plném rozlišení, takže jedenáct hodnot potřebuje jedenáctkrát více grafické paměti než jedna, což je v 8K více, než má většina karet. Snímání to před spuštěním zkontroluje a raději odmítne, než aby shodilo iRacing; pokud je braketing odmítnut, snižte rozlišení nebo zvolte rychlejší závěrku — což zároveň zkrátí žebřík.',
+			bracketNamingBody:
+				'Hodnota, kterou jste zvolili, se uloží pod obvyklým názvem a je to ta, která se objeví v galerii; ostatní leží vedle ní a mají svou závěrku v názvu souboru.',
+
+			highlights: 'Obnova světel',
+			highlightsBody:
+				'Zesílí světla blízko přepalu ještě před sečtením snímků a na konci zesílení zase odstraní. iRacing předává obraz, na který už bylo použito mapování tónů, takže světlomet a bílá zeď dorazí se stejnou hodnotou; jejich zprůměrováním se z jasného světla procházejícího částí expozice stane šedá šmouha místo jasné stopy. Toto vrací nelinearitu tam, kde ji má skutečný snímač. Měří se v EV; 0 znamená vypnuto a nemění vůbec nic.',
+
+			whatItSaves: 'Co ukládá',
+			whatItSavesBody:
+				'Velikost, oříznutí vodoznaku i formát souboru se řídí stejnými ovládacími prvky jako běžný snímek — nastavením Rozlišení a Oříznout vodoznak výše a výstupním formátem v nastavení. Řádek „Výstup“ v horní části postranního panelu ukazuje přesně to, co dostanete.',
+			whatItSavesPngBody:
+				'Volba PNG zapíše skutečný 16bitový master, což se vyplatí, pokud chcete snímek později barevně upravovat, plus 8bitový náhled pro galerii. Zápis je také mnohem pomalejší při vysokých rozlišeních — 16bitový PNG o 33 megapixelech trvá kolem deseti sekund, zatímco tentýž snímek v JPEG méně než jednu.',
+
+			troubleshooting: 'Pokud výsledek vypadá špatně',
+			troubleGhosts:
+				'<b>Oddělené duchy místo plynulé stopy</b> — příliš málo vzorků. Použijte pomalejší rychlost přehrávání, více průchodů nebo nižší rozlišení.',
+			troubleShutter:
+				'<b>Nevíte, jakou závěrku jste chtěli</b> — zapněte braketing závěrek a rozhodněte se až potom, při stejném čekání.',
+			troubleHighlights:
+				'<b>Přepálená nebo plochá světla</b> — zkuste 3 až 5 EV obnovy světel.',
+			troubleBlack:
+				'<b>Černý obraz</b> — iRacing běží ve výhradním celoobrazovkovém režimu. Nastavte Display &gt; Full Screen na OFF.',
+			troubleSidecar:
+				'Každý snímek zaznamená přesně použité nastavení, počet vzorků a to, jak rovnoměrně byly rozloženy, do souboru .json ve složce protokolů vedle app.log. Uchovává se posledních 20 snímků — braketing se počítá jako jeden — takže snímek, na který se ptáte, tam ještě je, zatímco se na něj ptáte.',
+		},
+	},
+
+	update: {
+		checking: 'Kontroluji aktualizace…',
+		newVersion: 'Nová verze',
+		availableBusy:
+			'{version} je k dispozici. Probíhá snímání — stáhnout ji půjde, jakmile skončí.',
+		available: '{version} je k dispozici. Kliknutím ji stáhnete.',
+		downloading: 'Stahuji {version}…',
+		downloadingPercent: 'Stahuji {version} — {percent} %',
+		downloadedBusy:
+			'{version} je připravena. Probíhá snímání, takže se nainstaluje při zavření aplikace.',
+		downloaded:
+			'{version} je připravena. Kliknutím restartujete a nainstalujete.',
+		failed: 'Kontrola aktualizací se nezdařila: {error}',
+		unknownError: 'neznámá chyba',
+		neverChecked:
+			'Aktualizace zatím nebyly kontrolovány (máte verzi v{version}).',
+		upToDate: 'Máte nejnovější verzi (v{version}).',
+
+		alreadyDownloading: 'Aktualizace se již stahuje.',
+		alreadyDownloaded: 'Aktualizace už byla stažena.',
+		nothingToDownload: 'Není k dispozici žádná aktualizace ke stažení.',
+		captureInProgress: 'Probíhá snímání. Zkuste to znovu, až skončí.',
+		nothingToInstall: 'Žádná aktualizace není připravena k instalaci.',
+		captureInProgressInstall:
+			'Probíhá snímání. Aktualizace se nainstaluje sama, až aplikaci zavřete.',
+		devBuildOnly: 'Kontrola aktualizací funguje jen v nainstalované verzi.',
+
+		installTitle: 'Instalovat aktualizaci',
+		installMessage: 'Nainstalovat verzi {version}?',
+		installFallbackVersion: 'aktualizaci',
+		installDetail:
+			'Aplikace se po instalaci aktualizace zavře a znovu otevře. Pokud zvolíte „Později“, nainstaluje se sama při příštím zavření aplikace.',
+		installConfirm: 'Restartovat a nainstalovat',
+		installLater: 'Později',
+	},
+
+	filenameFields: {
+		categories: {
+			Track: 'Trať',
+			Driver: 'Jezdec',
+			Session: 'Relace',
+			Meta: 'Meta',
+		},
+		track: 'Trať',
+		trackFull: 'Trať (plný název)',
+		trackCity: 'Město',
+		trackCountry: 'Země',
+		trackType: 'Typ trati',
+		driver: 'Jezdec',
+		driverAbbrev: 'Jezdec (zkratka)',
+		driverInitials: 'Iniciály',
+		team: 'Tým',
+		carNumber: 'Č. vozu',
+		car: 'Vůz',
+		carFull: 'Vůz (plný název)',
+		carClass: 'Třída vozu',
+		iRating: 'iRating',
+		sessionType: 'Typ relace',
+		sessionName: 'Název relace',
+		lap: 'Kolo',
+		date: 'Datum',
+		time: 'Čas',
+		datetime: 'Datum+čas',
+		counter: 'Počítadlo',
+	},
+
+	iracingConfig: {
+		projections:
+			'Vypněte „Render Scene Using 3 Projections“ v iRacingu (karta Display > Monitor), abyste na snímcích předešli svislým pruhům',
+	},
+
+	wgc: {
+		cursorCaveat:
+			'V této verzi Windows se může na snímcích objevit kurzor myši. Windows 10 verze 2004 přidaly nastavení, které jej skrývá.',
+		addonUnavailable:
+			'Komponentu pro snímání ve vysoké věrnosti se v tomto systému nepodařilo načíst.',
+		osUnsupported:
+			'Windows.Graphics.Capture není v této verzi Windows dostupné. Vyžaduje Windows 10 verze 1903 nebo novější.',
+		nativeCaptureOff: 'Snímání ve vysoké věrnosti (WGC) je vypnuté',
+	},
+
+	capture: {
+		exclusiveFullscreen:
+			'iRacing běží ve výhradním celoobrazovkovém režimu, takže snímek by byl černý. V iRacingu nastavte Display > Full Screen na OFF (použijte Borderless nebo Windowed) a zkuste to znovu.',
+		exclusiveFullscreenUnattributed:
+			'Nějaká aplikace běží ve výhradním celoobrazovkovém režimu, což vede k černému snímku. Pokud je iRacing v celoobrazovkovém režimu, nastavte Display > Full Screen na OFF (použijte Borderless nebo Windowed) a zkuste to znovu.',
+		unknownError: 'Neznámá chyba snímku obrazovky',
+		outputTooSmall: 'Snímek je příliš malý ({width}x{height})',
+		blackFrame:
+			'Zachycený snímek je černý — zdroj snímání mohl selhat (na některých konfiguracích Windows se obsah akcelerovaný GPU nedaří zachytit)',
+		noSource: 'Pro okno {windowId} nebyl nalezen žádný zdroj snímání plochy',
+		metadataTimeout: 'Vypršel čas při čekání na metadata videa snímání',
+		noVideoFrame: 'Snímací datový tok nevrátil žádný snímek videa',
+		dimensionTimeout:
+			'Vypršel čas při čekání na rozměry okna {width}x{height}; pokračuji s {actualWidth}x{actualHeight}',
+	},
+
+	longExposureCapture: {
+		busy: 'Snímání již probíhá.',
+		needsNativeCapture:
+			'Dlouhá expozice vyžaduje snímání ve vysoké věrnosti (WGC). Zapněte je v nastavení, abyste ji mohli použít.',
+		unavailable: 'Dlouhá expozice není na tomto počítači dostupná.',
+		noTelemetry:
+			'Dlouhá expozice vyžaduje telemetrii záznamu z iRacingu. Zkontrolujte, že simulátor běží a je v relaci.',
+		windowNotFound: 'Okno iRacingu nebylo nalezeno.',
+		cancelled: 'Snímání zrušeno.',
+		seekTimeout:
+			'Záznam nedosáhl snímku {frame} včas. Možná se ještě načítá.',
+		noPasses: 'Snímání musí provést alespoň jeden průchod.',
+		playbackStalled:
+			'Záznam se nerozeběhl. Zkontrolujte, že iRacing nebyl pozastaven jiným nástrojem.',
+		exposureTimeout: 'Expozice nedosáhla snímku {frame} do {seconds} s.',
+		endedEarly: 'Expozice skončila dříve, než dosáhla zvoleného okamžiku.',
+		noFramesPresented: 'iRacing nevykreslil žádné snímky k zachycení.',
+		subFrameNoSamples:
+			'Tato závěrka je kratší než jeden snímek záznamu a iRacing v ní žádný snímek nevykreslil. Zkuste pomalejší rychlost přehrávání nebo nejbližší pomalejší závěrku.',
+		noSamples:
+			'Nebyly nasbírány žádné snímky. iRacing možná během expozice přestal vykreslovat.',
+		withNativeError: '{reason} ({error})',
+		resolveFailed: 'GPU nevrátila žádný obraz.',
+		bracketShortfall:
+			'Braketing si vyžádal {asked} hodnot, ale vrátilo se jich {returned} — zbytek se nepodařilo vyřešit, nebo je tato verze snímací komponenty starší než braketing.',
+	},
+
+	validation: {
+		windowBeforeStart:
+			'Expozice potřebuje {frames} snímků záznamu před zvoleným okamžikem, ten je však jen {anchor} snímků od začátku záznamu. Zvolte pozdější okamžik nebo rychlejší závěrku.',
+		pastEnd: 'Zvolený okamžik leží za koncem záznamu.',
+		sessionChanged:
+			'Záznam od přípravy tohoto snímku přešel do jiné relace. Zvolte okamžik znovu.',
+		singleSampleMultiPass:
+			'Tato závěrka je tak krátká, že do ní na jeden průchod padne asi jediný snímek, takže {passes} průchodů nasbírá zhruba {passes} vzorků. Pomalejší rychlost přehrávání nebo pomalejší závěrka přinesou mnohem víc.',
+		singleSample:
+			'Tato závěrka je tak krátká, že do ní padne jen jediný snímek, takže výsledek nebude mít žádné rozmazání pohybem. Pomalejší rychlost přehrávání nebo pomalejší závěrka přinesou vzorky.',
+		bracketVsInterpolation:
+			'Braketing závěrek a {factor}x interpolace snímků nemohou běžet současně, takže tento snímek bude pořízen bez interpolace. Pokud jsou pro vás mezisnímky důležitější než hodnoty navíc, braketing vypněte.',
+		passesVsInterpolation:
+			'Zapnuto je jak více průchodů, tak {factor}x interpolace. Soupeří spolu: interpolace zpomalí každý průchod natolik, že jej připraví o skutečné snímky, takže stejné čekání koupí méně skutečných vzorků než samotné průchody. Vypnutí interpolace obvykle přinese lepší snímek.',
+		shortOfTarget:
+			'I při rychlosti 1/{divisor} dosáhne tato expozice zhruba {samples} vzorků, méně než požadovaných {target}. Pro více použijte pomalejší závěrku.',
+		longCaptureEscalate:
+			'Toto snímání přehrává záznam rychlostí 1/{divisor} po dobu přibližně {duration} reálného času{passSuffix} a po spuštění je nelze urychlit. {advice}',
+		longCaptureWarn:
+			'Toto snímání potrvá přibližně {duration} reálného času při rychlosti přehrávání 1/{divisor}{passSuffix}.',
+		passSuffix: ', rozložených do {passes} průchodů přes tentýž okamžik',
+		adviceFewerPasses: 'Méně průchodů skončí dříve, s méně vzorky.',
+		adviceFasterPlayback:
+			'Vyšší rychlost přehrávání skončí dříve, s méně vzorky.',
+		pastLogCap:
+			'Očekává se, že toto snímání nasbírá asi {samples} vzorků během {passes} průchodů, což je více než {cap}, které pojme diagnostický protokol. Obrazu se to nedotkne — jen údaje o rovnoměrnosti a mezerách popíšou první část snímání.',
+		interpolationLossy:
+			'Při této velikosti již {factor}x interpolace tento počítač jednou připravila o skutečné vzorky. Zvažte nižší faktor, nižší rozlišení nebo místo toho více průchodů.',
+	},
+
+	duration: {
+		zero: '0 sekund',
+		seconds: {
+			one: '{count} sekunda',
+			few: '{count} sekundy',
+			many: '{count} sekundy',
+			other: '{count} sekund',
+		},
+		minutes: {
+			one: '{count} minuta',
+			few: '{count} minuty',
+			many: '{count} minuty',
+			other: '{count} minut',
+		},
+		minutesSeconds: '{minutes} min {seconds} s',
+	},
+};
+
+export default cs;

--- a/src/locales/da.ts
+++ b/src/locales/da.ts
@@ -1,0 +1,476 @@
+// Danish. Translated from en.ts — see that file's header before editing.
+//
+// Product and technology names stay untranslated: iRacing, ReShade, Discord,
+// Windows.Graphics.Capture, WGC, VRAM, GPU, NVIDIA Turing and the file formats.
+
+import type { Catalog } from './index';
+
+const da: Catalog = {
+	notice: {
+		danger: 'Problemer',
+		warning: 'Værd at vide',
+		info: 'Bemærkninger',
+	},
+
+	promo: {
+		greeting: 'Tak fordi du bruger iRacing Screenshot Tool!',
+		signature: 'Bygget og vedligeholdt af AR Media Solutions.',
+	},
+
+	changelog: {
+		title: 'Ændringslog',
+		untitledRelease: 'Version',
+	},
+
+	gallery: {
+		menu: {
+			openExternally: 'Åbn i et andet program',
+			openFolder: 'Åbn mappe',
+			copy: 'Kopiér',
+			delete: 'Slet',
+		},
+		copiedToClipboard: '{name} kopieret til udklipsholderen',
+	},
+
+	sidebar: {
+		resolution: 'Opløsning',
+		width: 'Bredde',
+		height: 'Højde',
+		output: 'Output:',
+		cropWatermark: 'Beskær vandmærke',
+		keepAspectRatio: 'Bevar billedformat',
+		screenshot: 'Skærmbillede',
+		custom: 'Brugerdefineret',
+		vramStatus: '{adapter}{free} ledig af {total}',
+		savedSuccessfully: '{name} blev gemt',
+		screenshotFailed: 'Skærmbilledet mislykkedes: {message}',
+		errorLogPrefix: 'Log: ',
+		notices: {
+			exclusiveFullscreen:
+				'iRacing kører i eksklusiv fuldskærm — skærmbillederne bliver sorte. Sæt Display > Full Screen til OFF i iRacing (Borderless eller Windowed) for at gøre optagelse mulig.',
+			vramRisk:
+				'{resolution} kræver cirka {needed} mere VRAM, men kun {free} er ledig — iRacing løber sandsynligvis tør for hukommelse og går ned.',
+			vramCaution:
+				'{resolution} efterlader kun lidt VRAM-margen ({free} ledig) og kan gå ned ved krævende bane-/bilkombinationer.',
+			switchResolution: 'Skift til {resolution}',
+			vramStatic:
+				'Høje opløsninger kan få iRacing til at gå ned, hvis VRAM slipper op. Visse bane-/bilkombinationer kræver mere VRAM.',
+			reshade:
+				'Når du har trykket på skærmbilledeknappen i iRacing Screenshot Tool, skal du også trykke på ReShades tastaturgenvej til skærmbilleder.',
+			crop: 'Beskæring af vandmærket zoomer det færdige billede en anelse ind. Områder tæt på skærmkanterne bliver skåret væk.',
+			aspectRatio:
+				'„Bevar billedformat“ tilpasser skærmbilledets højde til din skærms billedformat (for eksempel 21:9 ultrabred) i stedet for standardformatet 16:9. Den valgte opløsning bestemmer bredden.',
+		},
+	},
+
+	settings: {
+		title: 'Indstillinger',
+		version: 'Version - {version}',
+		changelog: 'Ændringslog',
+		openLogsFolder: 'Åbn logmappen',
+		checkForUpdates: 'Søg efter opdateringer',
+		updateCheckFailed: 'Søgningen efter opdateringer mislykkedes: {message}',
+
+		language: 'Sprog',
+		languageDescription:
+			'Det sprog, der bruges i hele appen. Hentes fra Windows, første gang appen køres.',
+
+		screenshotFolder: 'Mappe til skærmbilleder',
+		selectFolder: 'Vælg mappe',
+		screenshotKeybind: 'Tastaturgenvej til skærmbillede',
+		editBind: 'Redigér genvej',
+
+		customFilenameFormat: 'Brugerdefineret filnavnsformat',
+		customFilenameFormatDescription:
+			'Brug et selvvalgt mønster i stedet for standarden ({track}-{driver}-{counter})',
+		filenameFieldsHint:
+			'Klik på felterne for at føje dem til formatet. Skriv skilletegn (-, _ osv.) direkte.',
+		reset: 'Nulstil',
+		preview: 'Forhåndsvisning:',
+
+		outputFormat: 'Outputformat',
+		formatJpeg: 'JPEG (højeste kvalitet)',
+		formatPng: 'PNG (tabsfri)',
+		formatWebp: 'WebP (kvalitet 95 %)',
+
+		disableTooltips: 'Skjul tips',
+		disableTooltipsDescription: 'Lad mig være, jeg ved, hvad jeg gør',
+
+		cropTopLeft: 'Foretræk beskæring af vandmærket øverst til venstre',
+		cropTopLeftDescription:
+			'Beskærer kun det nederste højre hjørne (3 %). Når den er slået fra, beskæres skærmbilledet lige meget fra alle sider (6 % i alt), hvilket giver et centreret resultat.',
+
+		manualWindowRestore: 'Manuel gendannelse af vindue',
+		manualWindowRestoreDescription:
+			'Erstatter den automatiske gendannelse af vinduet med en selvvalgt position og størrelse. Nyttigt ved ultrabrede skærme eller Nvidia Surround.',
+		left: 'Venstre',
+		top: 'Øverst',
+		width: 'Bredde',
+		height: 'Højde',
+		restoreNow: 'Gendan nu',
+
+		nativeCapture: 'Optagelse i høj kvalitet (WGC)',
+		nativeCaptureDescription:
+			'Optager ægte farve uden undersampling via Windows.Graphics.Capture i stedet for standardvejen (som undersampler farven). Falder automatisk tilbage, hvis en optagelse mislykkes.',
+		nativeCaptureUnavailable:
+			'Ikke tilgængelig på dette system — optagelse i høj kvalitet kan ikke køre her.',
+		nativeCaptureUnverified:
+			'Windows melder, at det understøttes, men en testoptagelse kom ikke tilbage. Optagelser falder automatisk tilbage, hvis det bliver ved med at mislykkes.',
+
+		reshade: 'ReShade-kompatibilitetstilstand',
+		reshadeDescription:
+			'Med ReShade skal du først bruge genvejen til iRacing Screenshot Tool eller trykke på knappen og derefter, når iRacing-vinduet har ændret størrelse, bruge din ReShade-genvej til skærmbilleder.',
+		reshadeIni: 'ReShade-INI',
+		selectFile: 'Vælg fil',
+	},
+
+	longExposure: {
+		title: 'Lang eksponering',
+		shutter: 'Lukkertid',
+		playbackSpeed: 'Afspilningshastighed',
+		playbackAuto: 'Automatisk (ud fra måltal for prøver)',
+		playbackRealTime: '1x (realtid)',
+		targetSamples: 'Måltal for prøver',
+		advanced: 'Avanceret',
+		defaultsSummary: '{count} standardværdier',
+
+		weighting: 'Vægtning',
+		weightingBox: 'Box (jævn)',
+		weightingLinear: 'Lineær (skarp til sidst)',
+		weightingEase: 'Ease (skarpere start, lang hale)',
+
+		interpolation: 'Billedinterpolation',
+		interpolationOff: 'Fra',
+		interpolation2: '2× (ét mellembillede)',
+		interpolation4: '4× (tre mellembilleder)',
+		interpolation8: '8× (syv mellembilleder)',
+
+		passes: 'Gennemløb',
+		passes1: '1 (ét gennemløb)',
+		passes2: '2× — dobbelt så lang ventetid',
+		passes4: '4× — fire gange så lang ventetid',
+		passes8: '8× — otte gange så lang ventetid',
+
+		bracket: 'Lukkertidsbracketing',
+		highlightRecovery: 'Genskabelse af højlys (trin)',
+
+		cancel: 'Annullér',
+		saved: 'Lang eksponering gemt — {count} prøver',
+		failed: 'Den lange eksponering mislykkedes',
+
+		modified: {
+			weighting_linear: 'lineær',
+			weighting_ease: 'ease',
+			interpolation: '{factor}× interpolation',
+			passes: {
+				one: '{count} gennemløb',
+				other: '{count} gennemløb',
+			},
+			bracketed: 'bracketing',
+			recovery: '{stops} trins genskabelse',
+		},
+
+		progress: {
+			working: 'Arbejder…',
+			seeking: 'Søger…{pass}',
+			accumulating: 'Eksponerer… {count} prøver{pass}',
+			resolving: 'Fremkalder…',
+			restoring: 'Gendanner replayet…',
+			pass: ' (gennemløb {current} af {total})',
+		},
+
+		notices: {
+			needsNativeCapture:
+				'Lang eksponering kræver optagelse i høj kvalitet (WGC), som lige nu er slået fra. Slå den til i indstillingerne for at kunne bruge lang eksponering.',
+			unavailableWithReason:
+				'Lang eksponering er ikke tilgængelig på denne maskine: {reason}',
+			unavailable: 'Lang eksponering er ikke tilgængelig på denne maskine.',
+			interpolationCost:
+				'Interpolation opfinder billeder mellem de virkelige for at gøre stribeneglattere. Det koster GPU-tid pr. billede, så sammenlign antallet af virkelige prøver i det gemte billede med det samme billede uden interpolation — falder det tal, køber den opfundne prøver med virkelige.',
+			passesAndInterpolation:
+				'Gennemløb og interpolation konkurrerer om det samme budget pr. billede. Med begge slået til fanger hvert gennemløb færre virkelige billeder — at slå interpolationen fra giver som regel et bedre resultat for den samme ventetid.',
+			passes:
+				'Hvert gennemløb afspiller det samme øjeblik igen og fanger billeder, som de andre missede, så striben bliver jævnere frem for lysere. Bedst ved korte lukkertider, hvor et enkelt gennemløb kun samler en håndfuld prøver.',
+			interpolationUnsupported:
+				'Billedinterpolation kræver en NVIDIA Turing-GPU eller nyere{adapter}. Alt andet ved lang eksponering fungerer som normalt.',
+			interpolationAdapter: ' (denne optagelse kører på {adapter})',
+			reshade:
+				'Lang eksponering optager nativt og bruger ikke ReShade, så ReShade-effekter vil ikke fremgå af resultatet.',
+		},
+	},
+
+	help: {
+		title: 'Hjælp',
+		sections: 'Hjælpeafsnit',
+		tabGeneral: 'Generelt',
+		tabLongExposure: 'Lang eksponering',
+
+		general: {
+			iracingSettings: 'iRacing-indstillinger',
+			borderless: 'iRacing skal køre i Windowed Borderless',
+			vram: 'Mindst 8 GB VRAM anbefales til skærmbilleder i 8K eller derover',
+			newerContent: 'Nyere baner og biler kræver mere VRAM',
+			shrinkUi:
+				'Formindsk brugerfladen så meget som muligt, før du tager et skærmbillede, hvis du bruger beskæring af vandmærket; „Control+PageDown“ formindsker den. Virker det ikke, kan du være nødt til at nulstille brugerfladens zoom i iRacings indstillinger.',
+
+			screenshotFolder: 'Mappe til skærmbilleder',
+			screenshotFolderBody:
+				'Skærmbilleder gemmes som standard i „C:\\Users\\user\\Pictures\\Screenshots“; dette kan ændres i indstillingerne.',
+
+			screenshotHotkey: 'Tastaturgenvej til skærmbillede',
+			screenshotHotkeyBody:
+				'Som standard tager „Control + PrintScreen“ et skærmbillede med de aktuelle indstillinger; dette kan ændres i indstillingerne.',
+
+			issues: 'Problemer',
+			issuesBody: 'Har du problemer, så rapportér dem gerne på',
+			discord: 'Discord',
+
+			instructions: 'Vejledning',
+			step1: 'iRacing <b>skal</b> køre i tilstanden Windowed Borderless',
+			step2: 'Start iRacing, og placér kameraet, hvor du vil tage skærmbilledet',
+			step3: 'Vælg den ønskede opløsning (prøv lavere opløsninger, før du går op til 8K)',
+			step4: 'Beslut, om du vil beskære iRacings vandmærke; i så fald skal du først formindske iRacings brugerflade til mindste størrelse med „Control + PageDown“',
+			step5: 'Tryk på skærmbilledeknappen, eller brug genvejen „Control + PrintScreen“ for at tage billederne',
+			step6: 'Afhængigt af den valgte opløsning kan det tage nogle sekunder; når iRacing-vinduet igen har normal størrelse, er det færdigt',
+			step7: 'Dit skærmbillede gemmes i „C:\\Users\\{User}\\Pictures\\Screenshots“',
+		},
+
+		longExposure: {
+			whatItDoes: 'Hvad den gør',
+			whatItDoesBody:
+				'En lang eksponering blander mange billeder fra et replay til ét billede, ligesom når man lader en kameralukker stå åben: det, der står stille, forbliver skarpt, og det, der bevæger sig, trækker striber. Værktøjet styrer selv replayet, optager hvert billede, som simulatoren viser, og lægger dem sammen på GPU’en.',
+
+			shutter: 'Lukkertid',
+			shutterBody:
+				'Hvor længe eksponeringen varer <i>i replaytid</i>, fra en brøkdel af ét replaybillede op til ti sekunder. Det er denne indstilling, der afgør, hvor lange striberne bliver. Længere lukkertider samler også flere billeder og har derfor mindre brug for alt nedenfor; de hurtigste trin dækker ét enkelt replaybillede og samler kun en håndfuld prøver.',
+
+			playback: 'Afspilningshastighed',
+			playbackBody:
+				'Replayet afspilles i slowmotion, mens eksponeringen optages, så simulatoren viser flere billeder pr. sekund replaytid, og blandingen får flere prøver. 1/16 samler cirka seksten gange så mange billeder som realtid — og tager seksten gange så lang faktisk tid. Det er den vigtigste afvejning i panelet: tålmodighed mod blødhed.',
+			playbackAutoBody:
+				'„Automatisk (ud fra måltal for prøver)“ vælger hastigheden for dig ud fra <b>måltal for prøver</b>: værktøjet finder den hurtigste afspilning, der stadig når det ønskede antal. Angiv i stedet en fast hastighed, hvis du hellere vil begrænse ventetiden.',
+
+			weighting: 'Vægtning',
+			weightingBody:
+				'Hvor meget hvert optaget billede bidrager til resultatet. <b>Box</b> vægter dem alle lige og giver en jævn stribe. <b>Lineær</b> stiger mod slutningen af vinduet, så motivet er skarpest der, hvor det sluttede, og toner ud langs sin bane. <b>Ease</b> er den samme idé med en skarpere start og en længere hale.',
+
+			interpolation: 'Billedinterpolation',
+			interpolationBody:
+				'Opfinder ekstra billeder mellem de virkelige ved hjælp af GPU’ens optical flow-motor og udfylder hullerne langs striben. Kræver et NVIDIA Turing-kort eller nyere og skjules helt på hardware, der ikke kan klare det.',
+			interpolationCostBody:
+				'Det er ikke gratis: det koster GPU-tid på hvert optaget billede, og budgettet er ét iRacing-billede. Kan den ikke følge med, begynder den at misse <i>virkelige</i> billeder for at fremstille syntetiske, hvilket er et nettotab — striben bliver kortere og grovere. Omkostningen skalerer med megapixel gange faktoren, så det, der er behageligt ved 2560×1440, er ikke realistisk i 8K. For at tjekke det: tag det samme øjeblik to gange, med og uden, og sammenlign antallet af virkelige prøver; appen advarer dig også bagefter, hvis et billede kom til kort.',
+
+			passes: 'Gennemløb',
+			passesBody:
+				'Besøger det samme øjeblik flere gange og akkumulerer til ét billede. Hvert gennemløb fanger billeder, som de andre tilfældigvis missede, så striben bliver jævnere — ikke lysere, for resultatet normaliseres efter, hvor meget lys der faktisk landede på hver pixel.',
+			passesTradeBody:
+				'Gennemløb køber det samme som interpolation, men i en anden valuta: faktisk tid i stedet for GPU-tid. Otte gennemløb tager cirka otte gange så lang tid, men de kan aldrig koste dig virkelige billeder. Det gør dem til det rigtige greb ved høje opløsninger, hvor interpolationen ikke kan følge med, og ved korte lukkertider, hvor et enkelt gennemløb samler meget få prøver. At bruge begge dele på én gang er som regel det værste af to verdener — de konkurrerer om det samme budget pr. billede.',
+
+			bracket: 'Lukkertidsbracketing',
+			bracketBody:
+				'Leverer ét billede pr. lukkertidstrin, der er lig med eller hurtigere end det, du valgte, ud fra én enkelt optagelse. Et billede ved 1/60 giver dig også 1/125, 1/250, 1/500 og 1/1000 — det samme øjeblik med gradvis kortere striber — så du kan vælge udtrykket bagefter i stedet for at gætte og tage om.',
+			bracketCostBody:
+				'Det koster stort set ingen ekstra tid. Hvert trin slutter på det samme billede og adskiller sig kun ved, hvor langt tilbage det rækker, så en hurtigere lukkertid er ganske enkelt halen af de billeder, der alligevel passerer — de fyldes alle fra ét gennemløb af replayet.',
+			bracketMemoryBody:
+				'Det, det koster, er hukommelse. Hvert trin har brug for sin egen akkumulator i fuld opløsning, så elleve trin kræver elleve gange så meget grafikhukommelse som ét, hvilket i 8K er mere, end de fleste kort har. Optagelsen kontrollerer dette, før den går i gang, og afviser hellere end at få iRacing til at gå ned; bliver en bracketing afvist, så sænk opløsningen eller vælg en hurtigere lukkertid — hvilket også giver en kortere stige.',
+			bracketNamingBody:
+				'Det trin, du valgte, gemmes under det sædvanlige navn og er det, der vises i galleriet; de øvrige ligger ved siden af med deres lukkertid i filnavnet.',
+
+			highlights: 'Genskabelse af højlys',
+			highlightsBody:
+				'Løfter højlys tæt på udbrænding, før billederne lægges sammen, og fjerner løftet igen til sidst. iRacing afleverer et billede, der allerede er tonemappet, så en forlygte og en hvid væg ankommer med samme værdi; at midle det gør et kraftigt lys, der bevæger sig gennem en del af eksponeringen, til en grå udtværing i stedet for et lyst spor. Dette lægger ulineariteten tilbage der, hvor en rigtig sensor har den. Måles i trin; 0 er slået fra og ændrer overhovedet ingenting.',
+
+			whatItSaves: 'Hvad den gemmer',
+			whatItSavesBody:
+				'Størrelse, beskæring af vandmærket og filformat følger de samme indstillinger som et almindeligt skærmbillede — indstillingerne Opløsning og Beskær vandmærke ovenfor samt outputformatet i indstillingerne. Linjen „Output“ øverst i sidepanelet viser præcis, hvad du får.',
+			whatItSavesPngBody:
+				'Vælger du PNG, skrives en ægte 16-bit master, hvilket er det værd, hvis du vil farvekorrigere billedet bagefter, plus en 8-bit forhåndsvisning til galleriet. Den er også meget langsommere at skrive ved høje opløsninger — en 16-bit PNG på 33 megapixel tager omkring ti sekunder, mens det samme billede som JPEG tager under ét.',
+
+			troubleshooting: 'Hvis resultatet ser forkert ud',
+			troubleGhosts:
+				'<b>Adskilte spøgelsesbilleder i stedet for en jævn stribe</b> — for få prøver. Brug en langsommere afspilningshastighed, flere gennemløb eller en lavere opløsning.',
+			troubleShutter:
+				'<b>Usikker på, hvilken lukkertid du ville have</b> — slå lukkertidsbracketing til, og bestem dig bagefter, for den samme ventetid.',
+			troubleHighlights:
+				'<b>Udbrændte eller flade højlys</b> — prøv 3 til 5 trins genskabelse af højlys.',
+			troubleBlack:
+				'<b>Et sort billede</b> — iRacing kører i eksklusiv fuldskærm. Sæt Display &gt; Full Screen til OFF.',
+			troubleSidecar:
+				'Hvert billede registrerer de præcise indstillinger, det brugte, antallet af prøver og hvor jævnt de landede, som en .json-fil i logmappen ved siden af app.log. De seneste 20 billeder gemmes — en bracketing tæller som ét — så det billede, du spørger om, stadig er der, mens du spørger.',
+		},
+	},
+
+	update: {
+		checking: 'Søger efter opdateringer…',
+		newVersion: 'En ny version',
+		availableBusy:
+			'{version} er tilgængelig. Der er en optagelse i gang — du kan hente den, når den er færdig.',
+		available: '{version} er tilgængelig. Klik for at hente den.',
+		downloading: 'Henter {version}…',
+		downloadingPercent: 'Henter {version} — {percent} %',
+		downloadedBusy:
+			'{version} er klar. Der er en optagelse i gang, så den installeres, når du lukker appen.',
+		downloaded: '{version} er klar. Klik for at genstarte og installere.',
+		failed: 'Søgningen efter opdateringer mislykkedes: {error}',
+		unknownError: 'ukendt fejl',
+		neverChecked:
+			'Der er endnu ikke søgt efter opdateringer (du kører v{version}).',
+		upToDate: 'Du kører den nyeste version (v{version}).',
+
+		alreadyDownloading: 'Opdateringen hentes allerede.',
+		alreadyDownloaded: 'Opdateringen er allerede hentet.',
+		nothingToDownload: 'Der er ingen opdatering at hente.',
+		captureInProgress:
+			'Der er en optagelse i gang. Prøv igen, når den er færdig.',
+		nothingToInstall: 'Der er ingen opdatering klar til installation.',
+		captureInProgressInstall:
+			'Der er en optagelse i gang. Opdateringen installerer sig selv, når du lukker appen.',
+		devBuildOnly:
+			'Søgning efter opdateringer kører kun i en installeret version.',
+
+		installTitle: 'Installér opdatering',
+		installMessage: 'Installér version {version}?',
+		installFallbackVersion: 'opdatering',
+		installDetail:
+			'Appen lukker og åbner igen, når opdateringen er installeret. Vælger du „Senere“, installeres den af sig selv, næste gang du lukker appen.',
+		installConfirm: 'Genstart og installér',
+		installLater: 'Senere',
+	},
+
+	filenameFields: {
+		categories: {
+			Track: 'Bane',
+			Driver: 'Kører',
+			Session: 'Session',
+			Meta: 'Meta',
+		},
+		track: 'Bane',
+		trackFull: 'Bane fuldt navn',
+		trackCity: 'By',
+		trackCountry: 'Land',
+		trackType: 'Banetype',
+		driver: 'Kører',
+		driverAbbrev: 'Kører forkortet',
+		driverInitials: 'Initialer',
+		team: 'Hold',
+		carNumber: 'Bilnr.',
+		car: 'Bil',
+		carFull: 'Bil fuldt navn',
+		carClass: 'Bilklasse',
+		iRating: 'iRating',
+		sessionType: 'Sessionstype',
+		sessionName: 'Sessionsnavn',
+		lap: 'Omgang',
+		date: 'Dato',
+		time: 'Klokkeslæt',
+		datetime: 'Dato+klokkeslæt',
+		counter: 'Tæller',
+	},
+
+	iracingConfig: {
+		projections:
+			'Slå „Render Scene Using 3 Projections“ fra i iRacing (fanen Display > Monitor) for at undgå lodrette bånd i skærmbillederne',
+	},
+
+	wgc: {
+		cursorCaveat:
+			'Musemarkøren kan optræde i optagelser på denne version af Windows. Windows 10 version 2004 tilføjede indstillingen, der skjuler den.',
+		addonUnavailable:
+			'Komponenten til optagelse i høj kvalitet kunne ikke indlæses på dette system.',
+		osUnsupported:
+			'Windows.Graphics.Capture er ikke tilgængelig på denne version af Windows. Den kræver Windows 10 version 1903 eller nyere.',
+		nativeCaptureOff: 'Optagelse i høj kvalitet (WGC) er slået fra',
+	},
+
+	capture: {
+		exclusiveFullscreen:
+			'iRacing kører i eksklusiv fuldskærm, så skærmbilledet ville blive sort. Sæt Display > Full Screen til OFF i iRacing (brug Borderless eller Windowed), og prøv igen.',
+		exclusiveFullscreenUnattributed:
+			'Et program kører i eksklusiv fuldskærm, hvilket giver en sort optagelse. Kører iRacing i fuldskærm, så sæt Display > Full Screen til OFF (brug Borderless eller Windowed), og prøv igen.',
+		unknownError: 'Ukendt skærmbilledefejl',
+		outputTooSmall: 'Optagelsen er for lille ({width}x{height})',
+		blackFrame:
+			'Det optagne billede er sort — optagelseskilden kan være mislykket (GPU-accelereret indhold kan ikke altid optages på visse Windows-opsætninger)',
+		noSource:
+			'Ingen skrivebordsoptagelseskilde fundet til vinduet {windowId}',
+		metadataTimeout:
+			'Tidsfristen udløb, mens der blev ventet på optagelsens videometadata',
+		noVideoFrame: 'Optagelsesstrømmen leverede ingen videobilleder',
+		dimensionTimeout:
+			'Tidsfristen udløb, mens der blev ventet på vinduesstørrelsen {width}x{height}; fortsætter med {actualWidth}x{actualHeight}',
+	},
+
+	longExposureCapture: {
+		busy: 'Der er allerede en optagelse i gang.',
+		needsNativeCapture:
+			'Lang eksponering kræver optagelse i høj kvalitet (WGC). Slå den til i indstillingerne for at bruge den.',
+		unavailable: 'Lang eksponering er ikke tilgængelig på denne maskine.',
+		noTelemetry:
+			'Lang eksponering kræver replaytelemetri fra iRacing. Kontrollér, at simulatoren kører og er i en session.',
+		windowNotFound: 'iRacing-vinduet blev ikke fundet.',
+		cancelled: 'Optagelsen blev annulleret.',
+		seekTimeout:
+			'Replayet nåede ikke billede {frame} i tide. Det er måske stadig ved at indlæse.',
+		noPasses: 'En optagelse skal køre mindst ét gennemløb.',
+		playbackStalled:
+			'Replayet gik ikke i gang. Kontrollér, at iRacing ikke er sat på pause af et andet værktøj.',
+		exposureTimeout:
+			'Eksponeringen nåede ikke billede {frame} inden for {seconds} s.',
+		endedEarly: 'Eksponeringen sluttede, før det valgte øjeblik blev nået.',
+		noFramesPresented: 'iRacing viste ingen billeder at optage.',
+		subFrameNoSamples:
+			'Denne lukkertid er kortere end ét replaybillede, og iRacing renderede ikke noget billede inden for den. Prøv en langsommere afspilningshastighed eller den næste længere lukkertid.',
+		noSamples:
+			'Der blev ikke akkumuleret nogen billeder. iRacing er måske holdt op med at rendere under eksponeringen.',
+		withNativeError: '{reason} ({error})',
+		resolveFailed: 'GPU’en returnerede intet billede.',
+		bracketShortfall:
+			'Bracketingen bad om {asked} trin, men {returned} kom tilbage — resten kunne ikke opløses, eller denne version af optagelseskomponenten er ældre end bracketing.',
+	},
+
+	validation: {
+		windowBeforeStart:
+			'Eksponeringen kræver {frames} replaybilleder før det valgte øjeblik, men det ligger kun {anchor} billeder inde i replayet. Vælg et senere øjeblik eller en hurtigere lukkertid.',
+		pastEnd: 'Det valgte øjeblik ligger efter replayets slutning.',
+		sessionChanged:
+			'Replayet er skiftet til en anden session, siden dette billede blev sat op. Vælg øjeblikket igen.',
+		singleSampleMultiPass:
+			'Denne lukkertid er så kort, at der kun lander cirka ét billede inden for den pr. gennemløb, så {passes} gennemløb samler omtrent {passes} prøver. En langsommere afspilningshastighed eller en længere lukkertid giver langt flere.',
+		singleSample:
+			'Denne lukkertid er så kort, at der kun lander ét billede inden for den, så resultatet får ingen bevægelsesuskarphed. En langsommere afspilningshastighed eller en længere lukkertid giver prøver.',
+		bracketVsInterpolation:
+			'Lukkertidsbracketing og {factor}x billedinterpolation kan ikke køre samtidig, så dette billede tages uden interpolation. Slå bracketingen fra, hvis mellembillederne betyder mere for dig end de ekstra trin.',
+		passesVsInterpolation:
+			'Både flere gennemløb og {factor}x interpolation er slået til. De konkurrerer: interpolationen bremser hvert gennemløb så meget, at det koster virkelige billeder, så den samme ventetid køber færre virkelige prøver, end gennemløb alene ville. At slå interpolationen fra giver som regel det bedre billede.',
+		shortOfTarget:
+			'Selv ved hastigheden 1/{divisor} når denne eksponering omkring {samples} prøver, færre end de {target}, der blev bedt om. Brug en længere lukkertid for at få flere.',
+		longCaptureEscalate:
+			'Denne optagelse afspiller replayet ved hastigheden 1/{divisor} i cirka {duration} faktisk tid{passSuffix} og kan ikke fremskyndes, når den først er startet. {advice}',
+		longCaptureWarn:
+			'Denne optagelse tager cirka {duration} faktisk tid ved afspilningshastigheden 1/{divisor}{passSuffix}.',
+		passSuffix: ', fordelt over {passes} gennemløb af det samme øjeblik',
+		adviceFewerPasses:
+			'Færre gennemløb bliver færdige før, med færre prøver.',
+		adviceFasterPlayback:
+			'En hurtigere afspilningshastighed bliver færdig før, med færre prøver.',
+		pastLogCap:
+			'Denne optagelse forventes at samle cirka {samples} prøver over {passes} gennemløb, mere end de {cap}, diagnostikloggen kan rumme. Billedet påvirkes ikke — kun tallene for jævnhed og huller vil beskrive den første del af optagelsen.',
+		interpolationLossy:
+			'I denne størrelse har {factor}x interpolation tidligere kostet denne maskine virkelige prøver. Overvej en lavere faktor, en lavere opløsning eller flere gennemløb i stedet.',
+	},
+
+	duration: {
+		zero: '0 sekunder',
+		seconds: {
+			one: '{count} sekund',
+			other: '{count} sekunder',
+		},
+		minutes: {
+			one: '{count} minut',
+			other: '{count} minutter',
+		},
+		minutesSeconds: '{minutes} min. {seconds} s',
+	},
+};
+
+export default da;

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -1,0 +1,480 @@
+// German. Translated from en.ts — see that file's header before editing.
+//
+// Product and technology names are left untranslated on purpose: iRacing,
+// ReShade, Discord, Windows.Graphics.Capture, WGC, VRAM, GPU, NVIDIA Turing and
+// the file formats are what the user sees in iRacing's own settings and on their
+// hardware, so translating them would break the link to the thing being named.
+
+import type { Catalog } from './index';
+
+const de: Catalog = {
+	notice: {
+		danger: 'Probleme',
+		warning: 'Wissenswertes',
+		info: 'Hinweise',
+	},
+
+	promo: {
+		greeting: 'Danke, dass du das iRacing Screenshot Tool nutzt!',
+		signature: 'Entwickelt und gepflegt von AR Media Solutions.',
+	},
+
+	changelog: {
+		title: 'Änderungsprotokoll',
+		untitledRelease: 'Version',
+	},
+
+	gallery: {
+		menu: {
+			openExternally: 'Extern öffnen',
+			openFolder: 'Ordner öffnen',
+			copy: 'Kopieren',
+			delete: 'Löschen',
+		},
+		copiedToClipboard: '{name} in die Zwischenablage kopiert',
+	},
+
+	sidebar: {
+		resolution: 'Auflösung',
+		width: 'Breite',
+		height: 'Höhe',
+		output: 'Ausgabe:',
+		cropWatermark: 'Wasserzeichen beschneiden',
+		keepAspectRatio: 'Seitenverhältnis beibehalten',
+		screenshot: 'Screenshot',
+		custom: 'Benutzerdefiniert',
+		vramStatus: '{adapter}{free} frei von {total}',
+		savedSuccessfully: '{name} erfolgreich gespeichert',
+		screenshotFailed: 'Screenshot fehlgeschlagen: {message}',
+		errorLogPrefix: 'Protokoll: ',
+		notices: {
+			exclusiveFullscreen:
+				'iRacing läuft im exklusiven Vollbild — Screenshots werden schwarz. Stelle in iRacing unter Display > Full Screen auf OFF (Borderless oder Windowed), um die Aufnahme zu ermöglichen.',
+			vramRisk:
+				'{resolution} benötigt etwa {needed} mehr VRAM, aber nur {free} sind frei — iRacing wird wahrscheinlich der Speicher ausgehen und abstürzen.',
+			vramCaution:
+				'{resolution} lässt wenig VRAM-Reserve ({free} frei) und kann bei aufwendigen Strecken-/Fahrzeugkombinationen abstürzen.',
+			switchResolution: 'Auf {resolution} wechseln',
+			vramStatic:
+				'Hohe Auflösungen können iRacing zum Absturz bringen, wenn der VRAM ausgeht. Bestimmte Strecken-/Fahrzeugkombinationen benötigen mehr VRAM.',
+			reshade:
+				'Nachdem du im iRacing Screenshot Tool auf den Screenshot-Knopf gedrückt hast, musst du zusätzlich deine ReShade-Tastenkombination für Screenshots betätigen.',
+			crop: 'Das Beschneiden des Wasserzeichens zoomt das fertige Bild leicht heran. Bereiche nahe den Bildrändern werden abgeschnitten.',
+			aspectRatio:
+				'„Seitenverhältnis beibehalten“ passt die Höhe des Screenshots an das Seitenverhältnis deines Monitors an (z. B. 21:9 Ultrawide) statt an die Vorgabe 16:9. Die gewählte Auflösung bestimmt die Breite.',
+		},
+	},
+
+	settings: {
+		title: 'Einstellungen',
+		version: 'Version - {version}',
+		changelog: 'Änderungsprotokoll',
+		openLogsFolder: 'Protokollordner öffnen',
+		checkForUpdates: 'Nach Updates suchen',
+		updateCheckFailed: 'Update-Prüfung fehlgeschlagen: {message}',
+
+		language: 'Sprache',
+		languageDescription:
+			'Die in der gesamten App verwendete Sprache. Beim ersten Start aus Windows übernommen.',
+
+		screenshotFolder: 'Screenshot-Ordner',
+		selectFolder: 'Ordner wählen',
+		screenshotKeybind: 'Screenshot-Tastenkombination',
+		editBind: 'Belegung ändern',
+
+		customFilenameFormat: 'Eigenes Dateinamensformat',
+		customFilenameFormatDescription:
+			'Ein eigenes Muster statt der Vorgabe verwenden ({track}-{driver}-{counter})',
+		filenameFieldsHint:
+			'Klicke auf Felder, um sie dem Format hinzuzufügen. Trennzeichen (-, _ usw.) direkt eintippen.',
+		reset: 'Zurücksetzen',
+		preview: 'Vorschau:',
+
+		outputFormat: 'Ausgabeformat',
+		formatJpeg: 'JPEG (höchste Qualität)',
+		formatPng: 'PNG (verlustfrei)',
+		formatWebp: 'WebP (Qualität 95 %)',
+
+		disableTooltips: 'Hinweise ausblenden',
+		disableTooltipsDescription: 'Lass mich in Ruhe, ich weiß, was ich tue',
+
+		cropTopLeft: 'Wasserzeichen bevorzugt oben links beschneiden',
+		cropTopLeftDescription:
+			'Beschneidet nur die untere rechte Ecke (3 %). Ist die Option aus, wird der Screenshot gleichmäßig von allen Seiten beschnitten (insgesamt 6 %), was ein zentriertes Ergebnis ergibt.',
+
+		manualWindowRestore: 'Fenster manuell wiederherstellen',
+		manualWindowRestoreDescription:
+			'Überschreibt die automatische Fensterwiederherstellung mit eigener Position und Größe. Nützlich für Ultrawide oder Nvidia Surround.',
+		left: 'Links',
+		top: 'Oben',
+		width: 'Breite',
+		height: 'Höhe',
+		restoreNow: 'Jetzt wiederherstellen',
+
+		nativeCapture: 'High-Fidelity-Aufnahme (WGC)',
+		nativeCaptureDescription:
+			'Nimmt echte, nicht unterabgetastete Farben über Windows.Graphics.Capture auf statt über die Standard-Pipeline (die Farben unterabtastet). Fällt automatisch zurück, wenn eine Aufnahme fehlschlägt.',
+		nativeCaptureUnavailable:
+			'Auf diesem System nicht verfügbar — High-Fidelity-Aufnahme kann hier nicht laufen.',
+		nativeCaptureUnverified:
+			'Windows meldet Unterstützung, doch eine Testaufnahme kam nicht zurück. Aufnahmen fallen automatisch zurück, falls es weiterhin fehlschlägt.',
+
+		reshade: 'ReShade-Kompatibilitätsmodus',
+		reshadeDescription:
+			'Bei Verwendung von ReShade musst du zuerst die Tastenkombination des iRacing Screenshot Tools nutzen oder den Knopf drücken und dann, sobald sich das iRacing-Fenster in der Größe geändert hat, deine ReShade-Screenshot-Tastenkombination betätigen.',
+		reshadeIni: 'ReShade-INI',
+		selectFile: 'Datei wählen',
+	},
+
+	longExposure: {
+		title: 'Langzeitbelichtung',
+		shutter: 'Verschlusszeit',
+		playbackSpeed: 'Wiedergabegeschwindigkeit',
+		playbackAuto: 'Automatisch (aus Zielanzahl)',
+		playbackRealTime: '1x (Echtzeit)',
+		targetSamples: 'Ziel-Abtastungen',
+		advanced: 'Erweitert',
+		defaultsSummary: '{count} Standardwerte',
+
+		weighting: 'Gewichtung',
+		weightingBox: 'Box (gleichmäßig)',
+		weightingLinear: 'Linear (scharf am Ende)',
+		weightingEase: 'Ease (schärferer Kopf, langer Schweif)',
+
+		interpolation: 'Bildinterpolation',
+		interpolationOff: 'Aus',
+		interpolation2: '2× (ein Zwischenbild)',
+		interpolation4: '4× (drei Zwischenbilder)',
+		interpolation8: '8× (sieben Zwischenbilder)',
+
+		passes: 'Durchgänge',
+		passes1: '1 (ein Durchgang)',
+		passes2: '2× — doppelte Wartezeit',
+		passes4: '4× — vierfache Wartezeit',
+		passes8: '8× — achtfache Wartezeit',
+
+		bracket: 'Verschlusszeiten-Reihe',
+		highlightRecovery: 'Lichterrettung (Blendenstufen)',
+
+		cancel: 'Abbrechen',
+		saved: 'Langzeitbelichtung gespeichert — {count} Abtastungen',
+		failed: 'Langzeitbelichtung fehlgeschlagen',
+
+		modified: {
+			weighting_linear: 'linear',
+			weighting_ease: 'ease',
+			interpolation: '{factor}× Interpolation',
+			passes: {
+				one: '{count} Durchgang',
+				other: '{count} Durchgänge',
+			},
+			bracketed: 'Reihe',
+			recovery: '{stops} Stufen Lichterrettung',
+		},
+
+		progress: {
+			working: 'Arbeitet…',
+			seeking: 'Suche…{pass}',
+			accumulating: 'Belichtet… {count} Abtastungen{pass}',
+			resolving: 'Entwickelt…',
+			restoring: 'Stellt Replay wieder her…',
+			pass: ' (Durchgang {current} von {total})',
+		},
+
+		notices: {
+			needsNativeCapture:
+				'Langzeitbelichtung benötigt die High-Fidelity-Aufnahme (WGC), die derzeit aus ist. Schalte sie in den Einstellungen ein, um Langzeitbelichtung zu ermöglichen.',
+			unavailableWithReason:
+				'Langzeitbelichtung ist auf diesem Rechner nicht verfügbar: {reason}',
+			unavailable:
+				'Langzeitbelichtung ist auf diesem Rechner nicht verfügbar.',
+			interpolationCost:
+				'Interpolation erfindet Bilder zwischen den echten, um den Schweif zu glätten. Sie kostet GPU-Zeit pro Bild — vergleiche also die Zahl echter Abtastungen der gespeicherten Aufnahme mit derselben Aufnahme ohne Interpolation. Sinkt diese Zahl, erkauft sie erfundene Abtastungen mit echten.',
+			passesAndInterpolation:
+				'Durchgänge und Interpolation konkurrieren um dasselbe Budget pro Bild. Sind beide aktiv, nimmt jeder Durchgang weniger echte Bilder auf — die Interpolation auszuschalten ergibt bei gleicher Wartezeit meist die bessere Aufnahme.',
+			passes:
+				'Jeder Durchgang wiederholt denselben Moment und fängt Bilder ein, die die anderen verpasst haben; der Schweif wird dadurch gleichmäßiger, nicht heller. Am besten bei kurzen Verschlusszeiten, wo ein einzelner Durchgang nur wenige Abtastungen sammelt.',
+			interpolationUnsupported:
+				'Bildinterpolation benötigt eine NVIDIA-GPU ab Turing{adapter}. Alles andere an der Langzeitbelichtung funktioniert wie gewohnt.',
+			interpolationAdapter: ' (diese Aufnahme läuft auf {adapter})',
+			reshade:
+				'Die Langzeitbelichtung nimmt nativ auf und nutzt ReShade nicht, daher erscheinen ReShade-Effekte nicht im Ergebnis.',
+		},
+	},
+
+	help: {
+		title: 'Hilfe',
+		sections: 'Hilfeabschnitte',
+		tabGeneral: 'Allgemein',
+		tabLongExposure: 'Langzeitbelichtung',
+
+		general: {
+			iracingSettings: 'iRacing-Einstellungen',
+			borderless: 'iRacing muss im Modus Windowed Borderless laufen',
+			vram: 'Für Screenshots ab 8K-Auflösung werden mindestens 8 GB VRAM empfohlen',
+			newerContent: 'Neuere Strecken und Fahrzeuge benötigen mehr VRAM',
+			shrinkUi:
+				'Verkleinere die Benutzeroberfläche vor dem Screenshot so weit wie möglich, wenn du die Option zum Beschneiden des Wasserzeichens nutzt. „Control+PageDown“ verkleinert sie; falls das nicht funktioniert, musst du eventuell den UI-Zoom in den iRacing-Einstellungen zurücksetzen.',
+
+			screenshotFolder: 'Screenshot-Ordner',
+			screenshotFolderBody:
+				'Screenshots werden standardmäßig unter „C:\\Users\\user\\Pictures\\Screenshots“ gespeichert; das lässt sich in den Einstellungen ändern.',
+
+			screenshotHotkey: 'Screenshot-Tastenkombination',
+			screenshotHotkeyBody:
+				'Standardmäßig erstellt „Control + PrintScreen“ einen Screenshot mit den aktuellen Einstellungen; das lässt sich in den Einstellungen ändern.',
+
+			issues: 'Probleme',
+			issuesBody: 'Falls du Probleme hast, melde sie bitte auf dem',
+			discord: 'Discord',
+
+			instructions: 'Anleitung',
+			step1: 'iRacing <b>muss</b> im Modus Windowed Borderless laufen',
+			step2: 'Starte iRacing und richte die Kamera so aus, wie du den Screenshot haben möchtest',
+			step3: 'Wähle die gewünschte Auflösung (probiere niedrigere Auflösungen, bevor du auf 8K gehst)',
+			step4: 'Entscheide, ob du das iRacing-Wasserzeichen beschneiden willst; falls ja, musst du zuvor die iRacing-Oberfläche mit „Control + PageDown“ auf die kleinste Größe bringen',
+			step5: 'Drücke den Screenshot-Knopf oder nutze die Tastenkombination „Control + PrintScreen“, um die Screenshots aufzunehmen',
+			step6: 'Je nach gewählter Auflösung kann das einige Sekunden dauern; sobald dein iRacing-Fenster wieder seine normale Größe hat, ist der Vorgang beendet',
+			step7: 'Dein Screenshot wird unter „C:\\Users\\{User}\\Pictures\\Screenshots“ gespeichert',
+		},
+
+		longExposure: {
+			whatItDoes: 'Was sie macht',
+			whatItDoesBody:
+				'Eine Langzeitbelichtung verschmilzt viele Bilder eines Replays zu einem einzigen Bild, so wie ein offen gelassener Kameraverschluss: Unbewegtes bleibt scharf, Bewegtes zieht Schlieren. Das Tool steuert das Replay selbst, nimmt jedes vom Simulator dargestellte Bild auf und addiert sie auf der GPU.',
+
+			shutter: 'Verschlusszeit',
+			shutterBody:
+				'Wie lange die Belichtung <i>in Replay-Zeit</i> dauert, von einem Bruchteil eines Replay-Bildes bis zu zehn Sekunden. Diese Einstellung bestimmt die Länge der Schlieren. Längere Verschlusszeiten sammeln außerdem mehr Bilder und brauchen daher weniger Hilfe von allem Folgenden; die kürzesten Stufen umfassen ein einziges Replay-Bild und sammeln nur eine Handvoll Abtastungen.',
+
+			playback: 'Wiedergabegeschwindigkeit',
+			playbackBody:
+				'Das Replay wird während der Belichtung in Zeitlupe abgespielt, sodass der Simulator mehr Bilder pro Sekunde Replay-Zeit darstellt und die Überlagerung mehr Abtastungen erhält. 1/16 sammelt etwa sechzehnmal so viele Bilder wie Echtzeit — und dauert sechzehnmal so lange in tatsächlicher Zeit. Das ist der zentrale Kompromiss dieses Bereichs: Geduld gegen Gleichmäßigkeit.',
+			playbackAutoBody:
+				'„Automatisch (aus Zielanzahl)“ wählt die Geschwindigkeit anhand der <b>Ziel-Abtastungen</b>: Das Tool ermittelt die schnellste Wiedergabe, die die gewünschte Anzahl noch erreicht. Gib stattdessen eine feste Geschwindigkeit an, wenn du die Wartezeit begrenzen willst.',
+
+			weighting: 'Gewichtung',
+			weightingBody:
+				'Wie stark jedes aufgenommene Bild zum Ergebnis beiträgt. <b>Box</b> gewichtet alle gleich und ergibt eine gleichmäßige Schliere. <b>Linear</b> steigt zum Ende des Fensters an, sodass das Motiv dort am schärfsten ist, wo es endete, und entlang seines Weges verblasst. <b>Ease</b> ist dieselbe Idee mit schärferem Kopf und längerem Schweif.',
+
+			interpolation: 'Bildinterpolation',
+			interpolationBody:
+				'Erfindet mithilfe der Optical-Flow-Einheit der GPU zusätzliche Bilder zwischen den echten und füllt so die Lücken entlang der Schliere. Erfordert eine NVIDIA-Karte ab Turing und wird auf Hardware, die das nicht kann, vollständig ausgeblendet.',
+			interpolationCostBody:
+				'Sie ist nicht umsonst: Sie kostet GPU-Zeit bei jedem aufgenommenen Bild, und das Budget ist ein iRacing-Bild. Kommt sie nicht mit, verpasst sie <i>echte</i> Bilder, um synthetische zu erzeugen — unterm Strich ein Verlust: Die Schliere wird kürzer und gröber. Die Kosten skalieren mit Megapixeln mal Faktor, was bei 2560×1440 bequem ist, ist bei 8K nicht tragfähig. Zum Prüfen nimmst du denselben Moment zweimal auf, einmal mit und einmal ohne, und vergleichst die echten Abtastzahlen; die App warnt dich hinterher auch, wenn eine Aufnahme zu kurz kam.',
+
+			passes: 'Durchgänge',
+			passesBody:
+				'Besucht denselben Moment mehrfach und sammelt alles in einem Bild. Jeder Durchgang fängt Bilder ein, die die anderen zufällig verpasst haben, sodass die Schliere gleichmäßiger wird — nicht heller, denn das Ergebnis wird darauf normiert, wie viel Licht tatsächlich auf jedem Pixel gelandet ist.',
+			passesTradeBody:
+				'Durchgänge kaufen dasselbe wie Interpolation, nur in anderer Währung: tatsächliche Zeit statt GPU-Zeit. Acht Durchgänge dauern etwa achtmal so lange, können dich aber nie echte Bilder kosten. Damit sind sie der richtige Hebel bei hohen Auflösungen, wo die Interpolation nicht mitkommt, und bei kurzen Verschlusszeiten, wo ein einzelner Durchgang sehr wenige Abtastungen sammelt. Beides zugleich zu nutzen ist meist das Schlechteste aus beiden Welten — sie konkurrieren um dasselbe Budget pro Bild.',
+
+			bracket: 'Verschlusszeiten-Reihe',
+			bracketBody:
+				'Liefert aus einer einzigen Aufnahme ein Bild je Verschlusszeitstufe, die gleich der gewählten oder kürzer ist. Eine Aufnahme bei 1/60 liefert dir auch 1/125, 1/250, 1/500 und 1/1000 — denselben Moment mit zunehmend kürzeren Schlieren — sodass du die Wirkung hinterher wählen kannst, statt zu raten und neu aufzunehmen.',
+			bracketCostBody:
+				'Es kostet fast keine zusätzliche Zeit. Jede Stufe endet auf demselben Bild und unterscheidet sich nur darin, wie weit sie zurückreicht; eine kürzere Verschlusszeit ist also schlicht das Ende der ohnehin vorbeiziehenden Bilder — sie werden alle aus einem Durchgang des Replays gefüllt.',
+			bracketMemoryBody:
+				'Was es sehr wohl kostet, ist Speicher. Jede Stufe braucht ihren eigenen Sammler in voller Auflösung, elf Stufen brauchen also den elffachen Videospeicher einer einzigen, was bei 8K mehr ist, als die meisten Karten haben. Die Aufnahme prüft das vorab und verweigert sich, statt iRacing zum Absturz zu bringen. Wird eine Reihe abgelehnt, senke die Auflösung oder wähle eine kürzere Verschlusszeit — was zugleich eine kürzere Leiter bedeutet.',
+			bracketNamingBody:
+				'Die von dir gewählte Stufe wird unter dem üblichen Namen gespeichert und erscheint in der Galerie; die übrigen liegen daneben und tragen ihre Verschlusszeit im Dateinamen.',
+
+			highlights: 'Lichterrettung',
+			highlightsBody:
+				'Hebt beinahe ausgebrannte Lichter an, bevor die Bilder addiert werden, und nimmt die Anhebung am Ende wieder zurück. iRacing liefert ein bereits tonemapptes Bild, sodass ein Scheinwerfer und eine weiße Wand mit demselben Wert ankommen; mittelt man das, wird aus einem hellen Licht, das durch einen Teil der Belichtung wandert, ein grauer Schmierer statt einer hellen Spur. Dies bringt die Nichtlinearität dorthin zurück, wo ein echter Sensor sie hat. Gemessen in Blendenstufen; 0 ist aus und ändert überhaupt nichts.',
+
+			whatItSaves: 'Was gespeichert wird',
+			whatItSavesBody:
+				'Größe, Beschneiden des Wasserzeichens und Dateiformat folgen denselben Bedienelementen wie ein normaler Screenshot — den Einstellungen Auflösung und Wasserzeichen beschneiden oben sowie dem Ausgabeformat in den Einstellungen. Die Zeile „Ausgabe“ am oberen Rand der Seitenleiste zeigt genau, was du bekommst.',
+			whatItSavesPngBody:
+				'Mit PNG wird ein echtes 16-Bit-Master geschrieben, was sich lohnt, wenn du die Aufnahme später gradieren willst, dazu eine 8-Bit-Vorschau für die Galerie. Bei hohen Auflösungen ist es auch deutlich langsamer zu schreiben — ein 16-Bit-PNG mit 33 Megapixeln braucht rund zehn Sekunden, dasselbe Bild als JPEG unter einer.',
+
+			troubleshooting: 'Wenn das Ergebnis falsch aussieht',
+			troubleGhosts:
+				'<b>Einzelne Geisterbilder statt einer gleichmäßigen Schliere</b> — zu wenige Abtastungen. Nutze eine langsamere Wiedergabegeschwindigkeit, mehr Durchgänge oder eine niedrigere Auflösung.',
+			troubleShutter:
+				'<b>Unsicher, welche Verschlusszeit du wolltest</b> — schalte die Verschlusszeiten-Reihe ein und entscheide hinterher, bei gleicher Wartezeit.',
+			troubleHighlights:
+				'<b>Ausgebrannte oder flaue Lichter</b> — probiere 3 bis 5 Stufen Lichterrettung.',
+			troubleBlack:
+				'<b>Ein schwarzes Bild</b> — iRacing läuft im exklusiven Vollbild. Stelle Display &gt; Full Screen auf OFF.',
+			troubleSidecar:
+				'Jede Aufnahme protokolliert die genau verwendeten Einstellungen, die Zahl der Abtastungen und wie gleichmäßig sie verteilt waren, als .json-Datei im Protokollordner neben app.log. Die letzten 20 Aufnahmen werden aufbewahrt — eine Reihe zählt als eine — sodass die Aufnahme, nach der du fragst, noch da ist, während du fragst.',
+		},
+	},
+
+	update: {
+		checking: 'Suche nach Updates…',
+		newVersion: 'Eine neue Version',
+		availableBusy:
+			'{version} ist verfügbar. Eine Aufnahme läuft — du kannst sie herunterladen, sobald diese fertig ist.',
+		available: '{version} ist verfügbar. Zum Herunterladen klicken.',
+		downloading: '{version} wird heruntergeladen…',
+		downloadingPercent: '{version} wird heruntergeladen — {percent} %',
+		downloadedBusy:
+			'{version} ist bereit. Eine Aufnahme läuft, daher wird sie installiert, wenn du die App schließt.',
+		downloaded:
+			'{version} ist bereit. Zum Neustarten und Installieren klicken.',
+		failed: 'Update-Prüfung fehlgeschlagen: {error}',
+		unknownError: 'unbekannter Fehler',
+		neverChecked:
+			'Es wurde noch nicht nach Updates gesucht (du nutzt v{version}).',
+		upToDate: 'Du nutzt die neueste Version (v{version}).',
+
+		alreadyDownloading: 'Das Update wird bereits heruntergeladen.',
+		alreadyDownloaded: 'Das Update wurde bereits heruntergeladen.',
+		nothingToDownload: 'Es gibt kein Update zum Herunterladen.',
+		captureInProgress:
+			'Eine Aufnahme läuft. Versuche es erneut, sobald sie fertig ist.',
+		nothingToInstall: 'Es ist kein Update zur Installation bereit.',
+		captureInProgressInstall:
+			'Eine Aufnahme läuft. Das Update installiert sich von selbst, wenn du die App schließt.',
+		devBuildOnly:
+			'Update-Prüfungen laufen nur in einer installierten Version.',
+
+		installTitle: 'Update installieren',
+		installMessage: 'Version {version} installieren?',
+		installFallbackVersion: 'Update',
+		installDetail:
+			'Die App wird geschlossen und nach der Installation des Updates wieder geöffnet. Wählst du „Später“, installiert es sich von selbst, wenn du die App das nächste Mal schließt.',
+		installConfirm: 'Neu starten und installieren',
+		installLater: 'Später',
+	},
+
+	filenameFields: {
+		categories: {
+			Track: 'Strecke',
+			Driver: 'Fahrer',
+			Session: 'Session',
+			Meta: 'Meta',
+		},
+		track: 'Strecke',
+		trackFull: 'Strecke vollständig',
+		trackCity: 'Stadt',
+		trackCountry: 'Land',
+		trackType: 'Streckentyp',
+		driver: 'Fahrer',
+		driverAbbrev: 'Fahrer Kürzel',
+		driverInitials: 'Initialen',
+		team: 'Team',
+		carNumber: 'Startnr.',
+		car: 'Fahrzeug',
+		carFull: 'Fahrzeug vollständig',
+		carClass: 'Fahrzeugklasse',
+		iRating: 'iRating',
+		sessionType: 'Session-Typ',
+		sessionName: 'Session-Name',
+		lap: 'Runde',
+		date: 'Datum',
+		time: 'Uhrzeit',
+		datetime: 'Datum+Uhrzeit',
+		counter: 'Zähler',
+	},
+
+	iracingConfig: {
+		projections:
+			'Deaktiviere „Render Scene Using 3 Projections“ in iRacing (Display > Monitor), um vertikale Streifen in Screenshots zu vermeiden',
+	},
+
+	wgc: {
+		cursorCaveat:
+			'Der Mauszeiger kann bei dieser Windows-Version in Aufnahmen erscheinen. Windows 10 Version 2004 hat die Einstellung eingeführt, die ihn ausblendet.',
+		addonUnavailable:
+			'Die Komponente für die High-Fidelity-Aufnahme konnte auf diesem System nicht geladen werden.',
+		osUnsupported:
+			'Windows.Graphics.Capture ist auf dieser Windows-Version nicht verfügbar. Es benötigt Windows 10 Version 1903 oder neuer.',
+		nativeCaptureOff: 'High-Fidelity-Aufnahme (WGC) ist ausgeschaltet',
+	},
+
+	capture: {
+		exclusiveFullscreen:
+			'iRacing läuft im exklusiven Vollbild, daher wäre der Screenshot schwarz. Stelle in iRacing Display > Full Screen auf OFF (nutze Borderless oder Windowed) und versuche es erneut.',
+		exclusiveFullscreenUnattributed:
+			'Eine Anwendung läuft im exklusiven Vollbild, was zu einer schwarzen Aufnahme führt. Falls iRacing im Vollbild läuft, stelle Display > Full Screen auf OFF (nutze Borderless oder Windowed) und versuche es erneut.',
+		unknownError: 'Unbekannter Screenshot-Fehler',
+		outputTooSmall: 'Aufnahme ist zu klein ({width}x{height})',
+		blackFrame:
+			'Das aufgenommene Bild ist schwarz — die Aufnahmequelle könnte fehlgeschlagen sein (GPU-beschleunigte Inhalte lassen sich auf manchen Windows-Systemen nicht aufnehmen)',
+		noSource: 'Keine Desktop-Aufnahmequelle für Fenster {windowId} gefunden',
+		metadataTimeout:
+			'Zeitüberschreitung beim Warten auf die Video-Metadaten der Aufnahme',
+		noVideoFrame: 'Der Aufnahme-Stream lieferte kein Videobild',
+		dimensionTimeout:
+			'Zeitüberschreitung beim Warten auf die Fenstergröße {width}x{height}; es wird mit {actualWidth}x{actualHeight} fortgefahren',
+	},
+
+	longExposureCapture: {
+		busy: 'Es läuft bereits eine Aufnahme.',
+		needsNativeCapture:
+			'Langzeitbelichtung benötigt die High-Fidelity-Aufnahme (WGC). Schalte sie in den Einstellungen ein, um sie zu nutzen.',
+		unavailable: 'Langzeitbelichtung ist auf diesem Rechner nicht verfügbar.',
+		noTelemetry:
+			'Langzeitbelichtung benötigt Replay-Telemetrie von iRacing. Prüfe, ob der Simulator läuft und sich in einer Session befindet.',
+		windowNotFound: 'iRacing-Fenster nicht gefunden.',
+		cancelled: 'Aufnahme abgebrochen.',
+		seekTimeout:
+			'Das Replay hat Bild {frame} nicht rechtzeitig erreicht. Es lädt möglicherweise noch.',
+		noPasses: 'Eine Aufnahme muss mindestens einen Durchgang ausführen.',
+		playbackStalled:
+			'Das Replay hat nicht mit der Wiedergabe begonnen. Prüfe, ob iRacing nicht von einem anderen Werkzeug pausiert wurde.',
+		exposureTimeout:
+			'Die Belichtung hat Bild {frame} nicht innerhalb von {seconds} s erreicht.',
+		endedEarly:
+			'Die Belichtung endete, bevor der gewählte Moment erreicht war.',
+		noFramesPresented: 'iRacing hat keine Bilder zur Aufnahme geliefert.',
+		subFrameNoSamples:
+			'Diese Verschlusszeit ist kürzer als ein Replay-Bild, und iRacing hat darin kein Bild gerendert. Versuche eine langsamere Wiedergabegeschwindigkeit oder die nächstlängere Verschlusszeit.',
+		noSamples:
+			'Es wurden keine Bilder gesammelt. iRacing hat während der Belichtung möglicherweise aufgehört zu rendern.',
+		withNativeError: '{reason} ({error})',
+		resolveFailed: 'Die GPU hat kein Bild zurückgegeben.',
+		bracketShortfall:
+			'Die Reihe hat {asked} Stufen angefordert, aber {returned} kamen zurück — die übrigen ließen sich nicht auflösen, oder diese Version der Aufnahmekomponente ist älter als die Reihenfunktion.',
+	},
+
+	validation: {
+		windowBeforeStart:
+			'Die Belichtung benötigt {frames} Replay-Bilder vor dem gewählten Moment, liegt aber nur {anchor} Bilder im Replay. Wähle einen späteren Moment oder eine kürzere Verschlusszeit.',
+		pastEnd: 'Der gewählte Moment liegt hinter dem Ende des Replays.',
+		sessionChanged:
+			'Das Replay hat seit der Einrichtung dieser Aufnahme zu einer anderen Session gewechselt. Wähle den Moment erneut.',
+		singleSampleMultiPass:
+			'Diese Verschlusszeit ist so kurz, dass pro Durchgang nur etwa ein Bild hineinfällt; {passes} Durchgänge sammeln also rund {passes} Abtastungen. Eine langsamere Wiedergabegeschwindigkeit oder eine längere Verschlusszeit bringt weit mehr.',
+		singleSample:
+			'Diese Verschlusszeit ist so kurz, dass nur ein Bild hineinfällt; das Ergebnis hat daher keine Bewegungsunschärfe. Eine langsamere Wiedergabegeschwindigkeit oder eine längere Verschlusszeit bringt Abtastungen.',
+		bracketVsInterpolation:
+			'Verschlusszeiten-Reihe und {factor}x Bildinterpolation können nicht beide laufen, daher wird diese Aufnahme ohne Interpolation gemacht. Schalte die Reihe aus, wenn dir die Zwischenbilder wichtiger sind als die zusätzlichen Stufen.',
+		passesVsInterpolation:
+			'Mehrere Durchgänge und {factor}x Interpolation sind beide aktiv. Sie konkurrieren: Die Interpolation bremst jeden Durchgang so weit, dass er echte Bilder verliert, sodass dieselbe Wartezeit weniger echte Abtastungen bringt als Durchgänge allein. Die Interpolation auszuschalten ergibt meist die bessere Aufnahme.',
+		shortOfTarget:
+			'Selbst bei 1/{divisor} Geschwindigkeit erreicht diese Belichtung nur etwa {samples} Abtastungen, weniger als die geforderten {target}. Nutze eine längere Verschlusszeit für mehr.',
+		longCaptureEscalate:
+			'Diese Aufnahme spielt das Replay mit 1/{divisor} Geschwindigkeit für etwa {duration} tatsächlicher Zeit ab{passSuffix} und lässt sich nach dem Start nicht beschleunigen. {advice}',
+		longCaptureWarn:
+			'Diese Aufnahme dauert etwa {duration} tatsächlicher Zeit bei 1/{divisor} Wiedergabegeschwindigkeit{passSuffix}.',
+		passSuffix: ', verteilt auf {passes} Durchgänge über denselben Moment',
+		adviceFewerPasses:
+			'Weniger Durchgänge sind schneller fertig, mit weniger Abtastungen.',
+		adviceFasterPlayback:
+			'Eine höhere Wiedergabegeschwindigkeit ist schneller fertig, mit weniger Abtastungen.',
+		pastLogCap:
+			'Diese Aufnahme wird voraussichtlich etwa {samples} Abtastungen über {passes} Durchgänge sammeln, mehr als die {cap}, die das Diagnoseprotokoll fasst. Das Bild ist davon unberührt — nur die Gleichmäßigkeits- und Lückenwerte beschreiben dann den ersten Teil der Aufnahme.',
+		interpolationLossy:
+			'In dieser Größe hat {factor}x Interpolation diesen Rechner schon einmal echte Abtastungen gekostet. Erwäge einen niedrigeren Faktor, eine niedrigere Auflösung oder stattdessen mehr Durchgänge.',
+	},
+
+	duration: {
+		zero: '0 Sekunden',
+		seconds: {
+			one: '{count} Sekunde',
+			other: '{count} Sekunden',
+		},
+		minutes: {
+			one: '{count} Minute',
+			other: '{count} Minuten',
+		},
+		minutesSeconds: '{minutes} Min. {seconds} s',
+	},
+};
+
+export default de;

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -1,0 +1,498 @@
+// The SOURCE catalogue. Every other locale is a translation of this file, and
+// i18n.test.ts fails the build if one of them drifts out of key-parity with it.
+//
+// Two rules for anyone editing this file:
+//
+//   1. Changing English text here is a translation-invalidating edit. The other
+//      twelve catalogues still hold the OLD wording and will keep showing it —
+//      key-parity tests cannot see that a sentence changed meaning. Update them
+//      too, or the change ships to English speakers only.
+//
+//   2. The English strings are byte-identical to the literals they replaced.
+//      That is what let this land without rewriting the main-process tests, which
+//      assert on the exact sentences validatePlan and decideWgcSupport produce.
+//
+// Placeholders are {braces}. An unknown one is left alone by the interpolator, so
+// copy that talks ABOUT tokens — the filename-format help below — can contain
+// {track} and {counter} literally without escaping.
+
+export default {
+	// Product name. Deliberately not translated anywhere it appears: it is the
+	// name of the thing, and iRacing does not translate its own.
+	notice: {
+		// NoticeCard's heading for the multi-notice form, taken from the highest
+		// severity present.
+		danger: 'Problems',
+		warning: 'Worth knowing',
+		info: 'Notes',
+	},
+
+	promo: {
+		greeting: 'Thanks for using iRacing Screenshot Tool!',
+		signature: 'Built and maintained by AR Media Solutions.',
+	},
+
+	changelog: {
+		title: 'Changelog',
+		// Fallback when a GitHub release has neither a name nor a tag.
+		untitledRelease: 'Release',
+	},
+
+	gallery: {
+		menu: {
+			openExternally: 'Open Externally',
+			openFolder: 'Open Folder',
+			copy: 'Copy',
+			delete: 'Delete',
+		},
+		copiedToClipboard: '{name} copied to clipboard',
+	},
+
+	sidebar: {
+		resolution: 'Resolution',
+		width: 'Width',
+		height: 'Height',
+		// Carries its own colon so languages that space punctuation differently
+		// (French writes "Sortie :") can place it.
+		output: 'Output:',
+		cropWatermark: 'Crop Watermark',
+		keepAspectRatio: 'Keep Aspect Ratio',
+		screenshot: 'Screenshot',
+		custom: 'Custom',
+		// "NVIDIA GeForce RTX 4090: 18.6 GB free of 22.5 GB"
+		vramStatus: '{adapter}{free} free of {total}',
+		savedSuccessfully: '{name} saved successfully',
+		screenshotFailed: 'Screenshot failed: {message}',
+		errorLogPrefix: 'Log: ',
+		notices: {
+			exclusiveFullscreen:
+				'iRacing is in exclusive fullscreen — screenshots will capture black. In iRacing set Display > Full Screen to OFF (Borderless or Windowed) to enable capture.',
+			vramRisk:
+				'{resolution} needs about {needed} more VRAM but only {free} is free — iRacing will likely run out of memory and crash.',
+			vramCaution:
+				'{resolution} leaves little VRAM headroom ({free} free) and may crash on heavy track/car combinations.',
+			switchResolution: 'Switch to {resolution}',
+			vramStatic:
+				'High resolutions may crash iRacing if you run out of VRAM. Certain track/car combinations will require more VRAM.',
+			reshade:
+				'After pressing the screenshot button in the iRacing Screenshot Tool, you will need to press the keybind for taking a screenshot for ReShade.',
+			crop: 'Crop Watermark zooms the final picture in slightly. Regions near the borders of the screen will be cut off.',
+			aspectRatio:
+				"Keep Aspect Ratio adjusts the screenshot height to match your monitor's aspect ratio (e.g. 21:9 ultrawide) instead of the default 16:9. The selected resolution sets the width.",
+		},
+	},
+
+	settings: {
+		title: 'Settings',
+		version: 'Version - {version}',
+		changelog: 'Changelog',
+		openLogsFolder: 'Open Logs Folder',
+		checkForUpdates: 'Check for Updates',
+		updateCheckFailed: 'Update check failed: {message}',
+
+		language: 'Language',
+		languageDescription:
+			'The language used throughout the app. Detected from Windows the first time the app runs.',
+
+		screenshotFolder: 'Screenshot Folder',
+		selectFolder: 'Select Folder',
+		screenshotKeybind: 'Screenshot Keybind',
+		editBind: 'Edit Bind',
+
+		customFilenameFormat: 'Custom Filename Format',
+		customFilenameFormatDescription:
+			'Use a custom pattern instead of the default ({track}-{driver}-{counter})',
+		filenameFieldsHint:
+			'Click fields to add them to the format. Type separators (-, _, etc.) directly.',
+		reset: 'Reset',
+		preview: 'Preview:',
+
+		outputFormat: 'Output Format',
+		formatJpeg: 'JPEG (max quality)',
+		formatPng: 'PNG (lossless)',
+		formatWebp: 'WebP (quality 95%)',
+
+		disableTooltips: 'Disable Tooltips',
+		disableTooltipsDescription: "Leave me alone, I know what I'm doing",
+
+		cropTopLeft: 'Prefer top-left watermark crop',
+		cropTopLeftDescription:
+			'Crops only the bottom-right corner (3%). When off, the screenshot is cropped (6% total) equally from all sides for a centered result.',
+
+		manualWindowRestore: 'Manual Window Restore',
+		manualWindowRestoreDescription:
+			'Override the automatic window restore with custom position and size. Useful for people using an Ultrawide or Nvidia Surround',
+		left: 'Left',
+		top: 'Top',
+		width: 'Width',
+		height: 'Height',
+		restoreNow: 'Restore Now',
+
+		nativeCapture: 'High-Fidelity Capture (WGC)',
+		nativeCaptureDescription:
+			'Capture true un-subsampled color via Windows.Graphics.Capture instead of the default pipeline (which subsamples color). Falls back automatically if a capture fails.',
+		nativeCaptureUnavailable:
+			'Unavailable on this system — high-fidelity capture cannot run here.',
+		nativeCaptureUnverified:
+			'Windows reports this is supported, but a test capture did not come back. Captures will fall back automatically if it keeps failing.',
+
+		reshade: 'Reshade Compatibility Mode',
+		reshadeDescription:
+			'When using reshade you will have to first use your hotkey for the iRacing Screenshot Tool or press the button, then use your reshade screenshot hotkey once the iRacing window has resized',
+		reshadeIni: 'Reshade INI',
+		selectFile: 'Select File',
+	},
+
+	longExposure: {
+		title: 'Long Exposure',
+		shutter: 'Shutter',
+		playbackSpeed: 'Playback speed',
+		playbackAuto: 'Auto (from sample target)',
+		playbackRealTime: '1x (real time)',
+		targetSamples: 'Target samples',
+		advanced: 'Advanced',
+		// The folded Advanced row when nothing is away from its default.
+		defaultsSummary: '{count} defaults',
+
+		weighting: 'Weighting',
+		weightingBox: 'Box (even)',
+		weightingLinear: 'Linear (sharp at the end)',
+		weightingEase: 'Ease (sharper head, long tail)',
+
+		interpolation: 'Frame interpolation',
+		interpolationOff: 'Off',
+		interpolation2: '2× (one in-between)',
+		interpolation4: '4× (three in-betweens)',
+		interpolation8: '8× (seven in-betweens)',
+
+		passes: 'Passes',
+		passes1: '1 (single pass)',
+		passes2: '2× — twice the wait',
+		passes4: '4× — four times the wait',
+		passes8: '8× — eight times the wait',
+
+		bracket: 'Bracket shutters',
+		highlightRecovery: 'Highlight recovery (stops)',
+
+		cancel: 'Cancel',
+		saved: 'Long exposure saved — {count} samples',
+		failed: 'Long exposure failed',
+
+		// Names for the settings the folded Advanced row calls out. These read as
+		// fragments in a comma-separated list, not as sentences.
+		modified: {
+			// Short forms of the weighting names — the summary row is one line with
+			// an ellipsis, so the full option labels do not fit.
+			weighting_linear: 'linear',
+			weighting_ease: 'ease',
+			interpolation: '{factor}× interpolation',
+			passes: {
+				one: '{count} pass',
+				other: '{count} passes',
+			},
+			bracketed: 'bracketed',
+			recovery: '{stops} stop recovery',
+		},
+
+		progress: {
+			working: 'Working…',
+			seeking: 'Seeking…{pass}',
+			accumulating: 'Exposing… {count} samples{pass}',
+			resolving: 'Developing…',
+			restoring: 'Restoring replay…',
+			pass: ' (pass {current} of {total})',
+		},
+
+		notices: {
+			needsNativeCapture:
+				'Long exposure needs High-Fidelity Capture (WGC), which is currently off. Turn it on in Settings to enable long exposure.',
+			unavailableWithReason:
+				'Long exposure is unavailable on this machine: {reason}',
+			unavailable: 'Long exposure is unavailable on this machine.',
+			interpolationCost:
+				"Interpolation invents frames between the real ones to smooth the streak. It costs GPU time per frame, so check the saved shot's real sample count against the same shot with it off — if that number drops, it is buying invented samples with real ones.",
+			passesAndInterpolation:
+				'Passes and interpolation compete for the same per-frame budget. With both on, each pass captures fewer real frames — turning interpolation off usually makes the better shot for the same wait.',
+			passes:
+				'Each pass replays the same moment and catches frames the others missed, so the streak gets smoother rather than brighter. Best on fast shutters, where a single pass collects only a handful of samples.',
+			interpolationUnsupported:
+				'Frame interpolation needs an NVIDIA Turing or newer GPU{adapter}. Everything else about long exposure works as normal.',
+			interpolationAdapter: ' (this capture runs on {adapter})',
+			reshade:
+				'Long exposure captures natively and does not use ReShade, so ReShade effects will not appear in the result.',
+		},
+	},
+
+	help: {
+		title: 'Help',
+		sections: 'Help sections',
+		tabGeneral: 'General',
+		tabLongExposure: 'Long Exposure',
+
+		general: {
+			iracingSettings: 'iRacing Settings',
+			borderless: 'iRacing must be running in Windowed Borderless',
+			vram: 'At least 8GB of VRAM is recommended for screenshots of 8k resolution or higher',
+			newerContent: 'Newer tracks and cars will require more VRAM',
+			shrinkUi:
+				'Shrink the UI to the smallest it can go before taking a screenshot if using the Crop Watermark option, "Control+PageDown" will shrink it, if this doesnt work you may need to reset your UI Zoom in the iRacing settings',
+
+			screenshotFolder: 'Screenshot Folder',
+			screenshotFolderBody:
+				'Screenshots will be saved by default to "C:\\Users\\user\\Pictures\\Screenshots" this can be changed in the settings',
+
+			screenshotHotkey: 'Screenshot Hotkey',
+			screenshotHotkeyBody:
+				'By default "Control + PrintScreen" will take a screenshot with the current settings, this can be changed in the settings.',
+
+			issues: 'Issues',
+			issuesBody: 'If you have any issues please report them on the',
+			discord: 'Discord',
+
+			instructions: 'Instructions',
+			step1: 'iRacing <b>must</b> be running in Windowed Borderless Mode',
+			step2: 'Run iRacing and setup the camera in the position you want to take the screenshot',
+			step3: 'Select your desired resolution (Try lower resolutions before going to 8K)',
+			step4: "Select if you want to crop the iRacing watermark or not, if you want to crop it you will need to resize the iRacing UI with 'Control + PageDown' to the smallest size first",
+			step5: "Press the screenshot button or use the Hotkey 'Control + PrintScreen' to take the screenshots",
+			step6: 'Depending on the resolution selected this may take a few seconds, once your iRacing screen resizes to its normal size it is finished',
+			step7: "Your screenshot will be saved to 'C:\\Users\\{User}\\Pictures\\Screenshots'",
+		},
+
+		longExposure: {
+			whatItDoes: 'What it does',
+			whatItDoesBody:
+				'A long exposure blends many frames of a replay into one image, the way leaving a camera shutter open does: stationary things stay sharp, moving things streak. The tool drives the replay itself, captures every frame the sim presents, and adds them up on the GPU.',
+
+			shutter: 'Shutter',
+			shutterBody:
+				'How long the exposure lasts <i>in replay time</i>, from a fraction of one replay frame up to ten seconds. This is the setting that decides how long the streaks are. Longer shutters also collect more frames, so they need less help from everything below; the fastest stops span a single replay frame and collect only a handful of samples.',
+
+			playback: 'Playback speed',
+			playbackBody:
+				'The replay is played in slow motion while the exposure is captured, so the sim presents more frames per second of replay time and the blend gets more samples. 1/16 collects roughly sixteen times as many frames as real time — and takes sixteen times as long in wall clock. This is the main trade in the panel: patience for smoothness.',
+			playbackAutoBody:
+				'"Auto (from sample target)" picks the speed for you from <b>Target samples</b>: the tool solves for the fastest playback that still reaches the number you asked for. Set an explicit speed instead if you would rather cap the wait.',
+
+			weighting: 'Weighting',
+			weightingBody:
+				'How much each captured frame contributes to the result. <b>Box</b> weights them all equally, giving an even streak. <b>Linear</b> ramps toward the end of the window, so the subject is sharpest where it finished and fades back along its path. <b>Ease</b> is the same idea with a sharper head and a longer tail.',
+
+			interpolation: 'Frame interpolation',
+			interpolationBody:
+				"Invents extra frames between the real ones using the GPU's optical-flow engine, filling in the gaps along the streak. Requires an NVIDIA Turing or newer card and is hidden entirely on hardware that cannot do it.",
+			interpolationCostBody:
+				'It is not free: it costs GPU time on every captured frame, and the budget is one iRacing frame. If it cannot keep up it starts missing <i>real</i> frames in order to manufacture synthetic ones, which is a net loss — the streak comes out shorter and coarser. The cost scales with megapixels times the factor, so what is comfortable at 2560×1440 is not viable at 8K. To check it, shoot the same moment twice with it on and off and compare the real sample counts; the app also warns you afterwards if a shot fell short.',
+
+			passes: 'Passes',
+			passesBody:
+				'Visits the same moment several times, accumulating into one image. Each pass catches frames the others happened to miss, so the streak gets smoother — not brighter, because the result is normalised by how much light actually landed on each pixel.',
+			passesTradeBody:
+				'Passes buy the same thing interpolation does, with a different currency: wall clock instead of GPU time. Eight passes take roughly eight times as long, but they can never cost you real frames. That makes them the right lever at high resolutions, where interpolation cannot keep up, and on fast shutters, where a single pass collects very few samples. Using both at once is usually the worst of the trade — they compete for the same per-frame budget.',
+
+			bracket: 'Bracket shutters',
+			bracketBody:
+				'Emits one image per shutter stop at or faster than the one you chose, from a single capture. A shot at 1/60 also gives you 1/125, 1/250, 1/500 and 1/1000 — the same moment with progressively shorter streaks — so you can pick the look afterwards instead of guessing and re-shooting.',
+			bracketCostBody:
+				'It costs almost no extra time. Every stop ends on the same frame and differs only in how far back it reaches, so a faster shutter is simply the tail of the frames already going past — they are all filled from one pass of the replay.',
+			bracketMemoryBody:
+				'What it does cost is memory. Each stop needs its own full-resolution accumulator, so eleven stops need eleven times the video memory of one, which at 8K is more than most cards have. The capture checks this before it starts and refuses rather than crashing iRacing, so if a bracket is declined, lower the resolution or pick a faster shutter — which is also a shorter ladder.',
+			bracketNamingBody:
+				'The stop you chose is saved under the usual name and is the one that appears in the gallery; the others sit beside it with their shutter in the filename.',
+
+			highlights: 'Highlight recovery',
+			highlightsBody:
+				'Boosts near-clipped highlights before the frames are added up, then undoes the boost at the end. iRacing hands over an image that has already been tonemapped, so a headlight and a white wall arrive at the same value; averaging that makes a bright light sweeping through part of the exposure read as a grey smudge rather than a bright trail. This puts the non-linearity back where a real sensor has it. Measured in stops; 0 is off and changes nothing at all.',
+
+			whatItSaves: 'What it saves',
+			whatItSavesBody:
+				'Size, watermark cropping and file format all follow the same controls a normal screenshot uses — the Resolution and Crop Watermark settings above, and the output format in Settings. The Output line at the top of the sidebar shows exactly what you will get.',
+			whatItSavesPngBody:
+				'Choosing PNG writes a true 16-bit master, which is worth it if you intend to grade the shot afterwards, plus an 8-bit preview for the gallery. It is also much slower to write at high resolutions — a 33-megapixel 16-bit PNG takes around ten seconds where the same frame as JPEG takes under one.',
+
+			troubleshooting: 'If the result looks wrong',
+			troubleGhosts:
+				'<b>Discrete ghosts instead of a smooth streak</b> — too few samples. Use a slower playback speed, more passes, or a lower resolution.',
+			troubleShutter:
+				'<b>Not sure which shutter you wanted</b> — turn on Bracket shutters and decide afterwards, for the same wait.',
+			troubleHighlights:
+				'<b>Blown-out or flat highlights</b> — try 3 to 5 stops of highlight recovery.',
+			troubleBlack:
+				'<b>A black image</b> — iRacing is in exclusive fullscreen. Set Display &gt; Full Screen to OFF.',
+			troubleSidecar:
+				'Every shot records the exact settings it used, the sample count and how evenly the samples landed, as a .json file in the log folder alongside app.log. The last 20 shots are kept — a bracket counts as one — so the shot you are asking about is still there while you are asking about it.',
+		},
+	},
+
+	update: {
+		checking: 'Checking for updates…',
+		// "A new version" when the updater has not told us which one yet.
+		newVersion: 'A new version',
+		availableBusy:
+			'{version} is available. A capture is in progress — you can download it once that finishes.',
+		available: '{version} is available. Click to download it.',
+		downloading: 'Downloading {version}…',
+		downloadingPercent: 'Downloading {version} — {percent}%',
+		downloadedBusy:
+			'{version} is ready. A capture is in progress, so it will install when you close the app.',
+		downloaded: '{version} is ready. Click to restart and install it.',
+		failed: 'Update check failed: {error}',
+		unknownError: 'unknown error',
+		neverChecked: "Updates have not been checked yet (you're on v{version}).",
+		upToDate: "You're on the latest version (v{version}).",
+
+		alreadyDownloading: 'The update is already downloading.',
+		alreadyDownloaded: 'The update is already downloaded.',
+		nothingToDownload: 'There is no update to download.',
+		captureInProgress:
+			'A capture is in progress. Try again once it finishes.',
+		nothingToInstall: 'No update is ready to install.',
+		captureInProgressInstall:
+			'A capture is in progress. The update will install by itself when you close the app.',
+		devBuildOnly: 'Update checks only run in an installed build.',
+
+		installTitle: 'Install update',
+		installMessage: 'Install version {version}?',
+		installFallbackVersion: 'update',
+		installDetail:
+			'The app will close and reopen once the update is installed. If you choose Later, it will install by itself the next time you close the app.',
+		installConfirm: 'Restart and install',
+		installLater: 'Later',
+	},
+
+	filenameFields: {
+		categories: {
+			Track: 'Track',
+			Driver: 'Driver',
+			Session: 'Session',
+			Meta: 'Meta',
+		},
+		track: 'Track',
+		trackFull: 'Track Full',
+		trackCity: 'City',
+		trackCountry: 'Country',
+		trackType: 'Track Type',
+		driver: 'Driver',
+		driverAbbrev: 'Driver Abbrev',
+		driverInitials: 'Initials',
+		team: 'Team',
+		carNumber: 'Car #',
+		car: 'Car',
+		carFull: 'Car Full',
+		carClass: 'Car Class',
+		iRating: 'iRating',
+		sessionType: 'Session Type',
+		sessionName: 'Session Name',
+		lap: 'Lap',
+		date: 'Date',
+		time: 'Time',
+		datetime: 'Date+Time',
+		counter: 'Counter',
+	},
+
+	iracingConfig: {
+		projections:
+			'Disable "Render Scene Using 3 Projections" in iRacing (Display > Monitor tab) to avoid vertical bands in screenshots',
+	},
+
+	wgc: {
+		cursorCaveat:
+			'The mouse cursor may appear in captures on this version of Windows. Windows 10 version 2004 added the control that hides it.',
+		addonUnavailable:
+			'The high-fidelity capture component could not be loaded on this system.',
+		osUnsupported:
+			'Windows.Graphics.Capture is not available on this version of Windows. It needs Windows 10 version 1903 or newer.',
+		// A `reason`, not a sentence — it is shown as the tail of "Long exposure is
+		// unavailable on this machine: …".
+		nativeCaptureOff: 'High-Fidelity Capture (WGC) is turned off',
+	},
+
+	capture: {
+		exclusiveFullscreen:
+			'iRacing is in exclusive fullscreen, so the screenshot would be black. In iRacing, set Display > Full Screen to OFF (use Borderless or Windowed) and try again.',
+		exclusiveFullscreenUnattributed:
+			'An application is running in exclusive fullscreen, which produces a black capture. If iRacing is in Full Screen, set Display > Full Screen to OFF (use Borderless or Windowed) and try again.',
+		unknownError: 'Unknown screenshot error',
+		outputTooSmall: 'Capture output is too small ({width}x{height})',
+		blackFrame:
+			'Captured frame is black — the capture source may have failed (GPU-accelerated content can fail to capture on some Windows setups)',
+		noSource: 'No desktop capture source found for window {windowId}',
+		metadataTimeout: 'Timed out waiting for capture video metadata',
+		noVideoFrame: 'Capture stream did not produce a video frame',
+		dimensionTimeout:
+			'Timed out waiting for window dimensions {width}x{height}; proceeding with {actualWidth}x{actualHeight}',
+	},
+
+	longExposureCapture: {
+		busy: 'A capture is already in progress.',
+		needsNativeCapture:
+			'Long exposure needs High-Fidelity Capture (WGC). Turn it on in Settings to use it.',
+		unavailable: 'Long exposure is not available on this machine.',
+		noTelemetry:
+			'Long exposure needs replay telemetry from iRacing. Check that the sim is running and in a session.',
+		windowNotFound: 'iRacing window not found.',
+		cancelled: 'Capture cancelled.',
+		seekTimeout:
+			'The replay did not reach frame {frame} in time. It may still be loading.',
+		noPasses: 'A capture must run at least one pass.',
+		playbackStalled:
+			'The replay did not start playing. Check that iRacing is not paused by another tool.',
+		exposureTimeout:
+			'The exposure did not reach frame {frame} within {seconds}s.',
+		endedEarly: 'The exposure ended before reaching the selected moment.',
+		// The v3.2.1 field report: zero WGC frames for the whole session.
+		noFramesPresented: 'iRacing did not present any frames to capture.',
+		subFrameNoSamples:
+			'This shutter is shorter than one replay frame, and iRacing did not render a frame inside it. Try a slower playback speed, or the next slower shutter.',
+		noSamples:
+			'No frames were accumulated. iRacing may have stopped rendering during the exposure.',
+		// The native cause, appended when there is one.
+		withNativeError: '{reason} ({error})',
+		resolveFailed: 'The GPU did not return an image.',
+		bracketShortfall:
+			'Bracketing asked for {asked} stops but {returned} came back — the rest failed to resolve, or this build of the capture addon predates bracketing.',
+	},
+
+	validation: {
+		windowBeforeStart:
+			'The exposure needs {frames} replay frames before the selected moment, but it is only {anchor} frames into the replay. Pick a later moment or a faster shutter.',
+		pastEnd: 'The selected moment is past the end of the replay.',
+		sessionChanged:
+			'The replay has moved to a different session since this shot was set up. Re-select the moment.',
+		singleSampleMultiPass:
+			'This shutter is short enough that only about one frame lands inside it per pass, so {passes} passes collect roughly {passes} samples. A slower playback speed or a slower shutter buys far more.',
+		singleSample:
+			'This shutter is short enough that only one frame will land inside it, so the result has no motion blur. A slower playback speed or a slower shutter buys samples.',
+		bracketVsInterpolation:
+			'Bracket shutters and {factor}x frame interpolation cannot both run, so this shot will be taken without interpolation. Turn bracketing off if the in-betweens matter more to you than the extra stops.',
+		passesVsInterpolation:
+			'Multi-pass and {factor}x interpolation are both on. They compete: interpolation slows each pass enough to cost it real frames, so the same wait buys fewer real samples than passes alone would. Turning interpolation off is usually the better shot.',
+		shortOfTarget:
+			'Even at 1/{divisor} speed this exposure reaches about {samples} samples, short of the {target} requested. Use a longer shutter for more.',
+		longCaptureEscalate:
+			'This capture runs the replay at 1/{divisor} speed for about {duration} of real time{passSuffix}, and cannot be hurried once started. {advice}',
+		longCaptureWarn:
+			'This capture will take about {duration} of real time at 1/{divisor} playback speed{passSuffix}.',
+		passSuffix: ' across {passes} passes over the same moment',
+		adviceFewerPasses: 'Fewer passes finish sooner with fewer samples.',
+		adviceFasterPlayback:
+			'A faster playback speed finishes sooner with fewer samples.',
+		pastLogCap:
+			'This capture is predicted to collect about {samples} samples across {passes} passes, past the {cap} the diagnostic log holds. The image is unaffected — only the evenness and gap figures will describe the first part of the capture.',
+		interpolationLossy:
+			'At this size, {factor}x interpolation has previously cost this machine real samples. Consider a lower factor, a lower Resolution, or more passes instead.',
+	},
+
+	duration: {
+		zero: '0 seconds',
+		seconds: {
+			one: '{count} seconds',
+			other: '{count} seconds',
+		},
+		minutes: {
+			one: '{count} minutes',
+			other: '{count} minutes',
+		},
+		minutesSeconds: '{minutes} min {seconds} s',
+	},
+};

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -1,0 +1,478 @@
+// Spanish. Translated from en.ts — see that file's header before editing.
+//
+// Product and technology names stay untranslated: iRacing, ReShade, Discord,
+// Windows.Graphics.Capture, WGC, VRAM, GPU, NVIDIA Turing and the file formats.
+
+import type { Catalog } from './index';
+
+const es: Catalog = {
+	notice: {
+		danger: 'Problemas',
+		warning: 'Conviene saber',
+		info: 'Notas',
+	},
+
+	promo: {
+		greeting: '¡Gracias por usar iRacing Screenshot Tool!',
+		signature: 'Creado y mantenido por AR Media Solutions.',
+	},
+
+	changelog: {
+		title: 'Registro de cambios',
+		untitledRelease: 'Versión',
+	},
+
+	gallery: {
+		menu: {
+			openExternally: 'Abrir con otra aplicación',
+			openFolder: 'Abrir carpeta',
+			copy: 'Copiar',
+			delete: 'Eliminar',
+		},
+		copiedToClipboard: '{name} copiado al portapapeles',
+	},
+
+	sidebar: {
+		resolution: 'Resolución',
+		width: 'Ancho',
+		height: 'Alto',
+		output: 'Salida:',
+		cropWatermark: 'Recortar marca de agua',
+		keepAspectRatio: 'Mantener relación de aspecto',
+		screenshot: 'Captura',
+		custom: 'Personalizada',
+		vramStatus: '{adapter}{free} libres de {total}',
+		savedSuccessfully: '{name} guardado correctamente',
+		screenshotFailed: 'Error en la captura: {message}',
+		errorLogPrefix: 'Registro: ',
+		notices: {
+			exclusiveFullscreen:
+				'iRacing está en pantalla completa exclusiva — las capturas saldrán en negro. En iRacing, pon Display > Full Screen en OFF (Borderless o Windowed) para permitir la captura.',
+			vramRisk:
+				'{resolution} necesita unos {needed} más de VRAM, pero solo hay {free} libres — es probable que iRacing se quede sin memoria y se cierre.',
+			vramCaution:
+				'{resolution} deja poco margen de VRAM ({free} libres) y puede fallar en combinaciones exigentes de circuito y coche.',
+			switchResolution: 'Cambiar a {resolution}',
+			vramStatic:
+				'Las resoluciones altas pueden hacer que iRacing falle si te quedas sin VRAM. Ciertas combinaciones de circuito y coche requieren más VRAM.',
+			reshade:
+				'Después de pulsar el botón de captura en iRacing Screenshot Tool, tendrás que pulsar tu atajo de captura de ReShade.',
+			crop: 'Recortar la marca de agua acerca ligeramente la imagen final. Las zonas cercanas a los bordes de la pantalla quedarán cortadas.',
+			aspectRatio:
+				'«Mantener relación de aspecto» ajusta el alto de la captura a la relación de tu monitor (por ejemplo 21:9 ultrapanorámico) en lugar del 16:9 predeterminado. La resolución elegida define el ancho.',
+		},
+	},
+
+	settings: {
+		title: 'Ajustes',
+		version: 'Versión - {version}',
+		changelog: 'Registro de cambios',
+		openLogsFolder: 'Abrir carpeta de registros',
+		checkForUpdates: 'Buscar actualizaciones',
+		updateCheckFailed: 'Error al buscar actualizaciones: {message}',
+
+		language: 'Idioma',
+		languageDescription:
+			'El idioma usado en toda la aplicación. Se detecta desde Windows la primera vez que se ejecuta.',
+
+		screenshotFolder: 'Carpeta de capturas',
+		selectFolder: 'Elegir carpeta',
+		screenshotKeybind: 'Atajo de captura',
+		editBind: 'Editar atajo',
+
+		customFilenameFormat: 'Formato de nombre personalizado',
+		customFilenameFormatDescription:
+			'Usar un patrón propio en lugar del predeterminado ({track}-{driver}-{counter})',
+		filenameFieldsHint:
+			'Haz clic en los campos para añadirlos al formato. Escribe los separadores (-, _, etc.) directamente.',
+		reset: 'Restablecer',
+		preview: 'Vista previa:',
+
+		outputFormat: 'Formato de salida',
+		formatJpeg: 'JPEG (máxima calidad)',
+		formatPng: 'PNG (sin pérdidas)',
+		formatWebp: 'WebP (calidad 95 %)',
+
+		disableTooltips: 'Ocultar consejos',
+		disableTooltipsDescription: 'Déjame en paz, sé lo que hago',
+
+		cropTopLeft: 'Preferir recorte de marca de agua arriba a la izquierda',
+		cropTopLeftDescription:
+			'Recorta solo la esquina inferior derecha (3 %). Si está desactivado, la captura se recorta por igual en todos los lados (6 % en total) para un resultado centrado.',
+
+		manualWindowRestore: 'Restauración manual de ventana',
+		manualWindowRestoreDescription:
+			'Sustituye la restauración automática de la ventana por una posición y un tamaño propios. Útil para quien usa ultrapanorámica o Nvidia Surround.',
+		left: 'Izquierda',
+		top: 'Arriba',
+		width: 'Ancho',
+		height: 'Alto',
+		restoreNow: 'Restaurar ahora',
+
+		nativeCapture: 'Captura de alta fidelidad (WGC)',
+		nativeCaptureDescription:
+			'Captura color real sin submuestreo mediante Windows.Graphics.Capture en lugar del método predeterminado (que submuestrea el color). Recurre automáticamente al método alternativo si una captura falla.',
+		nativeCaptureUnavailable:
+			'No disponible en este sistema — la captura de alta fidelidad no puede funcionar aquí.',
+		nativeCaptureUnverified:
+			'Windows indica que es compatible, pero una captura de prueba no llegó a completarse. Las capturas recurrirán al método alternativo si sigue fallando.',
+
+		reshade: 'Modo de compatibilidad con ReShade',
+		reshadeDescription:
+			'Con ReShade tendrás que usar primero el atajo de iRacing Screenshot Tool o pulsar el botón, y después usar tu atajo de captura de ReShade una vez que la ventana de iRacing haya cambiado de tamaño.',
+		reshadeIni: 'INI de ReShade',
+		selectFile: 'Elegir archivo',
+	},
+
+	longExposure: {
+		title: 'Exposición larga',
+		shutter: 'Obturación',
+		playbackSpeed: 'Velocidad de reproducción',
+		playbackAuto: 'Automática (según el objetivo de muestras)',
+		playbackRealTime: '1x (tiempo real)',
+		targetSamples: 'Objetivo de muestras',
+		advanced: 'Avanzado',
+		defaultsSummary: '{count} valores predeterminados',
+
+		weighting: 'Ponderación',
+		weightingBox: 'Box (uniforme)',
+		weightingLinear: 'Lineal (nítida al final)',
+		weightingEase: 'Ease (cabeza más nítida, cola larga)',
+
+		interpolation: 'Interpolación de fotogramas',
+		interpolationOff: 'Desactivada',
+		interpolation2: '2× (un fotograma intermedio)',
+		interpolation4: '4× (tres fotogramas intermedios)',
+		interpolation8: '8× (siete fotogramas intermedios)',
+
+		passes: 'Pasadas',
+		passes1: '1 (una sola pasada)',
+		passes2: '2× — el doble de espera',
+		passes4: '4× — cuatro veces la espera',
+		passes8: '8× — ocho veces la espera',
+
+		bracket: 'Horquillado de obturación',
+		highlightRecovery: 'Recuperación de altas luces (pasos)',
+
+		cancel: 'Cancelar',
+		saved: 'Exposición larga guardada — {count} muestras',
+		failed: 'Error en la exposición larga',
+
+		modified: {
+			weighting_linear: 'lineal',
+			weighting_ease: 'ease',
+			interpolation: 'interpolación {factor}×',
+			passes: {
+				one: '{count} pasada',
+				other: '{count} pasadas',
+			},
+			bracketed: 'horquillado',
+			recovery: 'recuperación de {stops} pasos',
+		},
+
+		progress: {
+			working: 'Trabajando…',
+			seeking: 'Buscando…{pass}',
+			accumulating: 'Exponiendo… {count} muestras{pass}',
+			resolving: 'Revelando…',
+			restoring: 'Restaurando la repetición…',
+			pass: ' (pasada {current} de {total})',
+		},
+
+		notices: {
+			needsNativeCapture:
+				'La exposición larga necesita la captura de alta fidelidad (WGC), que está desactivada. Actívala en los ajustes para poder usarla.',
+			unavailableWithReason:
+				'La exposición larga no está disponible en este equipo: {reason}',
+			unavailable: 'La exposición larga no está disponible en este equipo.',
+			interpolationCost:
+				'La interpolación inventa fotogramas entre los reales para suavizar la estela. Cuesta tiempo de GPU por fotograma, así que compara el número de muestras reales de la toma guardada con la misma toma sin interpolación: si esa cifra baja, está comprando muestras inventadas con muestras reales.',
+			passesAndInterpolation:
+				'Las pasadas y la interpolación compiten por el mismo presupuesto por fotograma. Con ambas activadas, cada pasada captura menos fotogramas reales — desactivar la interpolación suele dar una toma mejor con la misma espera.',
+			passes:
+				'Cada pasada repite el mismo instante y recoge fotogramas que las demás perdieron, de modo que la estela queda más uniforme, no más brillante. Va especialmente bien en obturaciones rápidas, donde una sola pasada recoge pocas muestras.',
+			interpolationUnsupported:
+				'La interpolación de fotogramas requiere una GPU NVIDIA Turing o más reciente{adapter}. Todo lo demás de la exposición larga funciona con normalidad.',
+			interpolationAdapter: ' (esta captura se ejecuta en {adapter})',
+			reshade:
+				'La exposición larga captura de forma nativa y no usa ReShade, por lo que los efectos de ReShade no aparecerán en el resultado.',
+		},
+	},
+
+	help: {
+		title: 'Ayuda',
+		sections: 'Secciones de ayuda',
+		tabGeneral: 'General',
+		tabLongExposure: 'Exposición larga',
+
+		general: {
+			iracingSettings: 'Ajustes de iRacing',
+			borderless: 'iRacing debe ejecutarse en Windowed Borderless',
+			vram: 'Se recomiendan al menos 8 GB de VRAM para capturas de 8K o superiores',
+			newerContent:
+				'Los circuitos y coches más recientes requieren más VRAM',
+			shrinkUi:
+				'Reduce la interfaz al mínimo antes de hacer la captura si usas la opción de recortar la marca de agua; «Control+PageDown» la reduce. Si no funciona, quizá tengas que restablecer el zoom de la interfaz en los ajustes de iRacing.',
+
+			screenshotFolder: 'Carpeta de capturas',
+			screenshotFolderBody:
+				'Las capturas se guardan de forma predeterminada en «C:\\Users\\user\\Pictures\\Screenshots»; esto se puede cambiar en los ajustes.',
+
+			screenshotHotkey: 'Atajo de captura',
+			screenshotHotkeyBody:
+				'De forma predeterminada, «Control + PrintScreen» hace una captura con los ajustes actuales; esto se puede cambiar en los ajustes.',
+
+			issues: 'Problemas',
+			issuesBody: 'Si tienes algún problema, comunícalo en el',
+			discord: 'Discord',
+
+			instructions: 'Instrucciones',
+			step1: 'iRacing <b>debe</b> ejecutarse en modo Windowed Borderless',
+			step2: 'Ejecuta iRacing y coloca la cámara en la posición desde la que quieras hacer la captura',
+			step3: 'Elige la resolución deseada (prueba resoluciones más bajas antes de pasar a 8K)',
+			step4: 'Decide si quieres recortar la marca de agua de iRacing; si es así, primero tendrás que reducir la interfaz de iRacing al tamaño mínimo con «Control + PageDown»',
+			step5: 'Pulsa el botón de captura o usa el atajo «Control + PrintScreen» para tomar las capturas',
+			step6: 'Según la resolución elegida, esto puede tardar unos segundos; cuando la ventana de iRacing recupere su tamaño normal, habrá terminado',
+			step7: 'Tu captura se guardará en «C:\\Users\\{User}\\Pictures\\Screenshots»',
+		},
+
+		longExposure: {
+			whatItDoes: 'Qué hace',
+			whatItDoesBody:
+				'Una exposición larga funde muchos fotogramas de una repetición en una sola imagen, igual que dejar abierto el obturador de una cámara: lo que está quieto queda nítido y lo que se mueve deja estela. La herramienta controla la propia repetición, captura cada fotograma que presenta el simulador y los suma en la GPU.',
+
+			shutter: 'Obturación',
+			shutterBody:
+				'Cuánto dura la exposición <i>en tiempo de repetición</i>, desde una fracción de un fotograma de repetición hasta diez segundos. Este ajuste es el que decide la longitud de las estelas. Las obturaciones más largas también recogen más fotogramas, así que necesitan menos ayuda de todo lo demás; los pasos más rápidos abarcan un único fotograma de repetición y recogen apenas unas pocas muestras.',
+
+			playback: 'Velocidad de reproducción',
+			playbackBody:
+				'La repetición se reproduce a cámara lenta mientras se captura la exposición, de modo que el simulador presenta más fotogramas por segundo de tiempo de repetición y la mezcla obtiene más muestras. 1/16 recoge unas dieciséis veces más fotogramas que el tiempo real, y tarda dieciséis veces más en tiempo real. Este es el compromiso principal del panel: paciencia a cambio de suavidad.',
+			playbackAutoBody:
+				'«Automática (según el objetivo de muestras)» elige la velocidad por ti a partir del <b>objetivo de muestras</b>: la herramienta calcula la reproducción más rápida que aún alcanza la cifra que has pedido. Fija una velocidad concreta si prefieres limitar la espera.',
+
+			weighting: 'Ponderación',
+			weightingBody:
+				'Cuánto aporta cada fotograma capturado al resultado. <b>Box</b> los pondera todos por igual y da una estela uniforme. <b>Lineal</b> aumenta hacia el final de la ventana, de modo que el sujeto queda más nítido donde terminó y se desvanece a lo largo de su trayectoria. <b>Ease</b> es la misma idea con una cabeza más nítida y una cola más larga.',
+
+			interpolation: 'Interpolación de fotogramas',
+			interpolationBody:
+				'Inventa fotogramas adicionales entre los reales usando el motor de flujo óptico de la GPU, rellenando los huecos de la estela. Requiere una tarjeta NVIDIA Turing o más reciente y se oculta por completo en hardware que no puede hacerlo.',
+			interpolationCostBody:
+				'No sale gratis: cuesta tiempo de GPU en cada fotograma capturado, y el presupuesto es un fotograma de iRacing. Si no da abasto, empieza a perder fotogramas <i>reales</i> para fabricar otros sintéticos, lo que supone una pérdida neta: la estela sale más corta y más basta. El coste escala con los megapíxeles multiplicados por el factor, así que lo que resulta cómodo a 2560×1440 no es viable en 8K. Para comprobarlo, fotografía el mismo instante dos veces, con y sin, y compara el número de muestras reales; la aplicación también te avisa después si una toma se ha quedado corta.',
+
+			passes: 'Pasadas',
+			passesBody:
+				'Visita el mismo instante varias veces, acumulando en una sola imagen. Cada pasada recoge fotogramas que las demás no llegaron a captar, así que la estela queda más uniforme, no más brillante, porque el resultado se normaliza según la luz que realmente llegó a cada píxel.',
+			passesTradeBody:
+				'Las pasadas compran lo mismo que la interpolación, pero con otra moneda: tiempo real en lugar de tiempo de GPU. Ocho pasadas tardan unas ocho veces más, pero nunca pueden costarte fotogramas reales. Eso las convierte en la palanca adecuada en resoluciones altas, donde la interpolación no da abasto, y en obturaciones rápidas, donde una sola pasada recoge muy pocas muestras. Usar ambas a la vez suele ser lo peor de las dos: compiten por el mismo presupuesto por fotograma.',
+
+			bracket: 'Horquillado de obturación',
+			bracketBody:
+				'Genera una imagen por cada paso de obturación igual o más rápido que el elegido, a partir de una sola captura. Una toma a 1/60 te da también 1/125, 1/250, 1/500 y 1/1000 — el mismo instante con estelas cada vez más cortas — para que elijas el resultado después en lugar de adivinar y repetir la toma.',
+			bracketCostBody:
+				'Apenas cuesta tiempo adicional. Todos los pasos terminan en el mismo fotograma y solo se diferencian en hasta dónde retroceden, así que una obturación más rápida es simplemente el final de los fotogramas que ya están pasando: todos se rellenan con una sola pasada de la repetición.',
+			bracketMemoryBody:
+				'Lo que sí cuesta es memoria. Cada paso necesita su propio acumulador a resolución completa, así que once pasos necesitan once veces la memoria de vídeo de uno, que en 8K es más de la que tienen la mayoría de las tarjetas. La captura lo comprueba antes de empezar y se niega en lugar de hacer que iRacing falle; si se rechaza un horquillado, baja la resolución o elige una obturación más rápida, lo que además acorta la escalera.',
+			bracketNamingBody:
+				'El paso que elegiste se guarda con el nombre habitual y es el que aparece en la galería; los demás quedan junto a él con su obturación en el nombre del archivo.',
+
+			highlights: 'Recuperación de altas luces',
+			highlightsBody:
+				'Realza las altas luces cercanas al recorte antes de sumar los fotogramas y deshace ese realce al final. iRacing entrega una imagen a la que ya se ha aplicado el mapeo tonal, así que un faro y una pared blanca llegan con el mismo valor; promediar eso convierte una luz intensa que atraviesa parte de la exposición en un borrón gris en lugar de una estela luminosa. Esto devuelve la no linealidad al lugar donde la tiene un sensor real. Se mide en pasos; 0 la desactiva y no cambia absolutamente nada.',
+
+			whatItSaves: 'Qué guarda',
+			whatItSavesBody:
+				'El tamaño, el recorte de la marca de agua y el formato de archivo siguen los mismos controles que una captura normal: los ajustes de Resolución y Recortar marca de agua de arriba, y el formato de salida en los ajustes. La línea «Salida» en la parte superior de la barra lateral muestra exactamente lo que vas a obtener.',
+			whatItSavesPngBody:
+				'Elegir PNG escribe un máster real de 16 bits, algo que merece la pena si vas a etalonar la toma después, además de una vista previa de 8 bits para la galería. También es mucho más lento de escribir en resoluciones altas: un PNG de 16 bits y 33 megapíxeles tarda unos diez segundos, mientras que el mismo fotograma en JPEG tarda menos de uno.',
+
+			troubleshooting: 'Si el resultado no se ve bien',
+			troubleGhosts:
+				'<b>Fantasmas separados en lugar de una estela suave</b> — muy pocas muestras. Usa una velocidad de reproducción más lenta, más pasadas o una resolución más baja.',
+			troubleShutter:
+				'<b>No sabes qué obturación querías</b> — activa el horquillado de obturación y decide después, con la misma espera.',
+			troubleHighlights:
+				'<b>Altas luces quemadas o planas</b> — prueba entre 3 y 5 pasos de recuperación de altas luces.',
+			troubleBlack:
+				'<b>Una imagen negra</b> — iRacing está en pantalla completa exclusiva. Pon Display &gt; Full Screen en OFF.',
+			troubleSidecar:
+				'Cada toma registra los ajustes exactos que usó, el número de muestras y lo uniformemente que se repartieron, en un archivo .json dentro de la carpeta de registros, junto a app.log. Se conservan las últimas 20 tomas — un horquillado cuenta como una — de modo que la toma por la que preguntas sigue ahí mientras preguntas.',
+		},
+	},
+
+	update: {
+		checking: 'Buscando actualizaciones…',
+		newVersion: 'Una versión nueva',
+		availableBusy:
+			'{version} está disponible. Hay una captura en curso — podrás descargarla cuando termine.',
+		available: '{version} está disponible. Haz clic para descargarla.',
+		downloading: 'Descargando {version}…',
+		downloadingPercent: 'Descargando {version} — {percent} %',
+		downloadedBusy:
+			'{version} está lista. Hay una captura en curso, así que se instalará cuando cierres la aplicación.',
+		downloaded: '{version} está lista. Haz clic para reiniciar e instalarla.',
+		failed: 'Error al buscar actualizaciones: {error}',
+		unknownError: 'error desconocido',
+		neverChecked:
+			'Todavía no se han buscado actualizaciones (tienes la v{version}).',
+		upToDate: 'Tienes la última versión (v{version}).',
+
+		alreadyDownloading: 'La actualización ya se está descargando.',
+		alreadyDownloaded: 'La actualización ya se ha descargado.',
+		nothingToDownload: 'No hay ninguna actualización que descargar.',
+		captureInProgress:
+			'Hay una captura en curso. Vuelve a intentarlo cuando termine.',
+		nothingToInstall: 'No hay ninguna actualización lista para instalar.',
+		captureInProgressInstall:
+			'Hay una captura en curso. La actualización se instalará sola cuando cierres la aplicación.',
+		devBuildOnly:
+			'La búsqueda de actualizaciones solo funciona en una versión instalada.',
+
+		installTitle: 'Instalar actualización',
+		installMessage: '¿Instalar la versión {version}?',
+		installFallbackVersion: 'actualización',
+		installDetail:
+			'La aplicación se cerrará y volverá a abrirse una vez instalada la actualización. Si eliges «Más tarde», se instalará sola la próxima vez que cierres la aplicación.',
+		installConfirm: 'Reiniciar e instalar',
+		installLater: 'Más tarde',
+	},
+
+	filenameFields: {
+		categories: {
+			Track: 'Circuito',
+			Driver: 'Piloto',
+			Session: 'Sesión',
+			Meta: 'Meta',
+		},
+		track: 'Circuito',
+		trackFull: 'Circuito completo',
+		trackCity: 'Ciudad',
+		trackCountry: 'País',
+		trackType: 'Tipo de circuito',
+		driver: 'Piloto',
+		driverAbbrev: 'Piloto abreviado',
+		driverInitials: 'Iniciales',
+		team: 'Equipo',
+		carNumber: 'N.º coche',
+		car: 'Coche',
+		carFull: 'Coche completo',
+		carClass: 'Clase de coche',
+		iRating: 'iRating',
+		sessionType: 'Tipo de sesión',
+		sessionName: 'Nombre de sesión',
+		lap: 'Vuelta',
+		date: 'Fecha',
+		time: 'Hora',
+		datetime: 'Fecha+hora',
+		counter: 'Contador',
+	},
+
+	iracingConfig: {
+		projections:
+			'Desactiva «Render Scene Using 3 Projections» en iRacing (pestaña Display > Monitor) para evitar bandas verticales en las capturas',
+	},
+
+	wgc: {
+		cursorCaveat:
+			'El cursor del ratón puede aparecer en las capturas en esta versión de Windows. Windows 10 versión 2004 añadió el control que lo oculta.',
+		addonUnavailable:
+			'No se pudo cargar el componente de captura de alta fidelidad en este sistema.',
+		osUnsupported:
+			'Windows.Graphics.Capture no está disponible en esta versión de Windows. Necesita Windows 10 versión 1903 o posterior.',
+		nativeCaptureOff: 'La captura de alta fidelidad (WGC) está desactivada',
+	},
+
+	capture: {
+		exclusiveFullscreen:
+			'iRacing está en pantalla completa exclusiva, así que la captura saldría en negro. En iRacing, pon Display > Full Screen en OFF (usa Borderless o Windowed) y vuelve a intentarlo.',
+		exclusiveFullscreenUnattributed:
+			'Hay una aplicación en pantalla completa exclusiva, lo que produce una captura en negro. Si iRacing está en pantalla completa, pon Display > Full Screen en OFF (usa Borderless o Windowed) y vuelve a intentarlo.',
+		unknownError: 'Error de captura desconocido',
+		outputTooSmall: 'La captura es demasiado pequeña ({width}x{height})',
+		blackFrame:
+			'El fotograma capturado está en negro — puede que la fuente de captura haya fallado (el contenido acelerado por GPU no siempre se puede capturar en algunas configuraciones de Windows)',
+		noSource:
+			'No se encontró ninguna fuente de captura de escritorio para la ventana {windowId}',
+		metadataTimeout:
+			'Se agotó el tiempo de espera de los metadatos de vídeo de la captura',
+		noVideoFrame: 'El flujo de captura no produjo ningún fotograma de vídeo',
+		dimensionTimeout:
+			'Se agotó el tiempo de espera de las dimensiones de ventana {width}x{height}; se continúa con {actualWidth}x{actualHeight}',
+	},
+
+	longExposureCapture: {
+		busy: 'Ya hay una captura en curso.',
+		needsNativeCapture:
+			'La exposición larga necesita la captura de alta fidelidad (WGC). Actívala en los ajustes para usarla.',
+		unavailable: 'La exposición larga no está disponible en este equipo.',
+		noTelemetry:
+			'La exposición larga necesita la telemetría de repetición de iRacing. Comprueba que el simulador está en marcha y dentro de una sesión.',
+		windowNotFound: 'No se encontró la ventana de iRacing.',
+		cancelled: 'Captura cancelada.',
+		seekTimeout:
+			'La repetición no llegó al fotograma {frame} a tiempo. Puede que aún se esté cargando.',
+		noPasses: 'Una captura debe ejecutar al menos una pasada.',
+		playbackStalled:
+			'La repetición no se puso en marcha. Comprueba que iRacing no esté pausado por otra herramienta.',
+		exposureTimeout:
+			'La exposición no llegó al fotograma {frame} en {seconds} s.',
+		endedEarly:
+			'La exposición terminó antes de llegar al instante seleccionado.',
+		noFramesPresented: 'iRacing no presentó ningún fotograma que capturar.',
+		subFrameNoSamples:
+			'Esta obturación es más corta que un fotograma de repetición, e iRacing no renderizó ninguno dentro de ella. Prueba una velocidad de reproducción más lenta o el siguiente paso de obturación más lento.',
+		noSamples:
+			'No se acumuló ningún fotograma. Puede que iRacing dejara de renderizar durante la exposición.',
+		withNativeError: '{reason} ({error})',
+		resolveFailed: 'La GPU no devolvió ninguna imagen.',
+		bracketShortfall:
+			'El horquillado pidió {asked} pasos pero volvieron {returned} — el resto no se pudo resolver, o esta versión del componente de captura es anterior al horquillado.',
+	},
+
+	validation: {
+		windowBeforeStart:
+			'La exposición necesita {frames} fotogramas de repetición antes del instante seleccionado, pero este solo está a {anchor} fotogramas del inicio. Elige un instante posterior o una obturación más rápida.',
+		pastEnd:
+			'El instante seleccionado está más allá del final de la repetición.',
+		sessionChanged:
+			'La repetición ha cambiado a otra sesión desde que se preparó esta toma. Vuelve a seleccionar el instante.',
+		singleSampleMultiPass:
+			'Esta obturación es tan corta que solo cae en ella alrededor de un fotograma por pasada, así que {passes} pasadas recogen aproximadamente {passes} muestras. Una velocidad de reproducción o una obturación más lentas dan muchas más.',
+		singleSample:
+			'Esta obturación es tan corta que solo caerá un fotograma dentro de ella, así que el resultado no tendrá desenfoque de movimiento. Una velocidad de reproducción o una obturación más lentas aportan muestras.',
+		bracketVsInterpolation:
+			'El horquillado de obturación y la interpolación de fotogramas {factor}x no pueden funcionar a la vez, así que esta toma se hará sin interpolación. Desactiva el horquillado si los fotogramas intermedios te importan más que los pasos adicionales.',
+		passesVsInterpolation:
+			'Están activadas tanto las pasadas múltiples como la interpolación {factor}x. Compiten entre sí: la interpolación ralentiza cada pasada lo suficiente como para costarle fotogramas reales, de modo que la misma espera compra menos muestras reales que las pasadas por sí solas. Desactivar la interpolación suele dar una toma mejor.',
+		shortOfTarget:
+			'Incluso a velocidad 1/{divisor}, esta exposición alcanza unas {samples} muestras, por debajo de las {target} solicitadas. Usa una obturación más lenta para obtener más.',
+		longCaptureEscalate:
+			'Esta captura reproduce la repetición a velocidad 1/{divisor} durante unos {duration} de tiempo real{passSuffix}, y no se puede acelerar una vez iniciada. {advice}',
+		longCaptureWarn:
+			'Esta captura tardará unos {duration} de tiempo real a velocidad de reproducción 1/{divisor}{passSuffix}.',
+		passSuffix: ', repartidas en {passes} pasadas sobre el mismo instante',
+		adviceFewerPasses: 'Menos pasadas terminan antes, con menos muestras.',
+		adviceFasterPlayback:
+			'Una velocidad de reproducción más rápida termina antes, con menos muestras.',
+		pastLogCap:
+			'Se prevé que esta captura recoja unas {samples} muestras en {passes} pasadas, más de las {cap} que admite el registro de diagnóstico. La imagen no se ve afectada — solo las cifras de uniformidad y de huecos describirán la primera parte de la captura.',
+		interpolationLossy:
+			'A este tamaño, la interpolación {factor}x ya le ha costado muestras reales a este equipo. Considera un factor menor, una resolución más baja o más pasadas en su lugar.',
+	},
+
+	duration: {
+		zero: '0 segundos',
+		seconds: {
+			one: '{count} segundo',
+			other: '{count} segundos',
+		},
+		minutes: {
+			one: '{count} minuto',
+			other: '{count} minutos',
+		},
+		minutesSeconds: '{minutes} min {seconds} s',
+	},
+};
+
+export default es;

--- a/src/locales/fi.ts
+++ b/src/locales/fi.ts
@@ -1,0 +1,478 @@
+// Finnish. Translated from en.ts — see that file's header before editing.
+//
+// Product and technology names stay untranslated: iRacing, ReShade, Discord,
+// Windows.Graphics.Capture, WGC, VRAM, GPU, NVIDIA Turing and the file formats.
+//
+// Finnish takes the partitive singular after a number greater than one
+// ("2 näytettä", not "2 näytteet"), so the `other` forms below are partitive
+// singulars rather than nominative plurals.
+
+import type { Catalog } from './index';
+
+const fi: Catalog = {
+	notice: {
+		danger: 'Ongelmat',
+		warning: 'Hyvä tietää',
+		info: 'Huomautukset',
+	},
+
+	promo: {
+		greeting: 'Kiitos, että käytät iRacing Screenshot Toolia!',
+		signature: 'Rakentanut ja ylläpitää AR Media Solutions.',
+	},
+
+	changelog: {
+		title: 'Muutosloki',
+		untitledRelease: 'Versio',
+	},
+
+	gallery: {
+		menu: {
+			openExternally: 'Avaa toisessa sovelluksessa',
+			openFolder: 'Avaa kansio',
+			copy: 'Kopioi',
+			delete: 'Poista',
+		},
+		copiedToClipboard: '{name} kopioitu leikepöydälle',
+	},
+
+	sidebar: {
+		resolution: 'Tarkkuus',
+		width: 'Leveys',
+		height: 'Korkeus',
+		output: 'Tuloste:',
+		cropWatermark: 'Rajaa vesileima',
+		keepAspectRatio: 'Säilytä kuvasuhde',
+		screenshot: 'Kuvakaappaus',
+		custom: 'Mukautettu',
+		vramStatus: '{adapter}{free} vapaana / {total}',
+		savedSuccessfully: '{name} tallennettiin',
+		screenshotFailed: 'Kuvakaappaus epäonnistui: {message}',
+		errorLogPrefix: 'Loki: ',
+		notices: {
+			exclusiveFullscreen:
+				'iRacing on yksinomaisessa koko näytön tilassa — kuvakaappauksista tulee mustia. Aseta iRacingissa Display > Full Screen tilaan OFF (Borderless tai Windowed), jotta kaappaus onnistuu.',
+			vramRisk:
+				'{resolution} vaatii noin {needed} lisää VRAM-muistia, mutta vapaana on vain {free} — iRacingilta loppuu todennäköisesti muisti ja se kaatuu.',
+			vramCaution:
+				'{resolution} jättää vain vähän VRAM-varaa ({free} vapaana) ja voi kaatua raskailla rata- ja autoyhdistelmillä.',
+			switchResolution: 'Vaihda tarkkuuteen {resolution}',
+			vramStatic:
+				'Suuret tarkkuudet voivat kaataa iRacingin, jos VRAM loppuu. Tietyt rata- ja autoyhdistelmät vaativat enemmän VRAM-muistia.',
+			reshade:
+				'Kun olet painanut kuvakaappauspainiketta iRacing Screenshot Toolissa, sinun on vielä painettava ReShaden kuvakaappauspikanäppäintä.',
+			crop: 'Vesileiman rajaus zoomaa lopullista kuvaa hieman sisäänpäin. Näytön reunojen lähellä olevat alueet leikkautuvat pois.',
+			aspectRatio:
+				'”Säilytä kuvasuhde” sovittaa kuvakaappauksen korkeuden näyttösi kuvasuhteeseen (esimerkiksi 21:9 ultralaaja) oletusarvoisen 16:9:n sijaan. Valittu tarkkuus määrää leveyden.',
+		},
+	},
+
+	settings: {
+		title: 'Asetukset',
+		version: 'Versio - {version}',
+		changelog: 'Muutosloki',
+		openLogsFolder: 'Avaa lokikansio',
+		checkForUpdates: 'Tarkista päivitykset',
+		updateCheckFailed: 'Päivitysten tarkistus epäonnistui: {message}',
+
+		language: 'Kieli',
+		languageDescription:
+			'Koko sovelluksessa käytettävä kieli. Tunnistetaan Windowsista sovelluksen ensimmäisellä käynnistyskerralla.',
+
+		screenshotFolder: 'Kuvakaappauskansio',
+		selectFolder: 'Valitse kansio',
+		screenshotKeybind: 'Kuvakaappauksen pikanäppäin',
+		editBind: 'Muokkaa pikanäppäintä',
+
+		customFilenameFormat: 'Mukautettu tiedostonimimuoto',
+		customFilenameFormatDescription:
+			'Käytä omaa mallia oletusmuodon sijaan ({track}-{driver}-{counter})',
+		filenameFieldsHint:
+			'Lisää kenttiä muotoon napsauttamalla niitä. Kirjoita erottimet (-, _ jne.) suoraan.',
+		reset: 'Palauta',
+		preview: 'Esikatselu:',
+
+		outputFormat: 'Tulostemuoto',
+		formatJpeg: 'JPEG (paras laatu)',
+		formatPng: 'PNG (häviötön)',
+		formatWebp: 'WebP (laatu 95 %)',
+
+		disableTooltips: 'Piilota vinkit',
+		disableTooltipsDescription: 'Anna minun olla, tiedän mitä teen',
+
+		cropTopLeft: 'Suosi vesileiman rajausta vasemmasta yläkulmasta',
+		cropTopLeftDescription:
+			'Rajaa vain oikean alakulman (3 %). Kun asetus on pois päältä, kuvakaappaus rajataan tasaisesti kaikilta sivuilta (yhteensä 6 %), jolloin tulos on keskitetty.',
+
+		manualWindowRestore: 'Ikkunan manuaalinen palautus',
+		manualWindowRestoreDescription:
+			'Korvaa automaattisen ikkunan palautuksen omalla sijainnilla ja koolla. Hyödyllinen ultralaajoilla näytöillä tai Nvidia Surroundissa.',
+		left: 'Vasen',
+		top: 'Ylä',
+		width: 'Leveys',
+		height: 'Korkeus',
+		restoreNow: 'Palauta nyt',
+
+		nativeCapture: 'Korkealaatuinen kaappaus (WGC)',
+		nativeCaptureDescription:
+			'Kaappaa aidon, alinäytteistämättömän värin Windows.Graphics.Capturen kautta oletusreitin sijaan (joka alinäytteistää värin). Palaa automaattisesti varareitille, jos kaappaus epäonnistuu.',
+		nativeCaptureUnavailable:
+			'Ei käytettävissä tässä järjestelmässä — korkealaatuinen kaappaus ei voi toimia täällä.',
+		nativeCaptureUnverified:
+			'Windows ilmoittaa tuen olevan olemassa, mutta testikaappaus ei palannut. Kaappaukset siirtyvät automaattisesti varareitille, jos vika toistuu.',
+
+		reshade: 'ReShade-yhteensopivuustila',
+		reshadeDescription:
+			'ReShadea käytettäessä sinun on ensin käytettävä iRacing Screenshot Toolin pikanäppäintä tai painettava painiketta, ja sen jälkeen — kun iRacing-ikkunan koko on muuttunut — käytettävä ReShaden kuvakaappauspikanäppäintä.',
+		reshadeIni: 'ReShaden INI-tiedosto',
+		selectFile: 'Valitse tiedosto',
+	},
+
+	longExposure: {
+		title: 'Pitkä valotus',
+		shutter: 'Suljinaika',
+		playbackSpeed: 'Toistonopeus',
+		playbackAuto: 'Automaattinen (näytetavoitteen mukaan)',
+		playbackRealTime: '1x (reaaliaika)',
+		targetSamples: 'Näytetavoite',
+		advanced: 'Lisäasetukset',
+		defaultsSummary: '{count} oletusarvoa',
+
+		weighting: 'Painotus',
+		weightingBox: 'Box (tasainen)',
+		weightingLinear: 'Lineaarinen (terävä lopussa)',
+		weightingEase: 'Ease (terävämpi alku, pitkä häntä)',
+
+		interpolation: 'Ruutuinterpolointi',
+		interpolationOff: 'Pois',
+		interpolation2: '2× (yksi väliruutu)',
+		interpolation4: '4× (kolme väliruutua)',
+		interpolation8: '8× (seitsemän väliruutua)',
+
+		passes: 'Ajokerrat',
+		passes1: '1 (yksi ajokerta)',
+		passes2: '2× — kaksinkertainen odotus',
+		passes4: '4× — nelinkertainen odotus',
+		passes8: '8× — kahdeksankertainen odotus',
+
+		bracket: 'Suljinaikahaarukointi',
+		highlightRecovery: 'Huippuvalojen palautus (aukkoa)',
+
+		cancel: 'Peruuta',
+		saved: 'Pitkä valotus tallennettu — {count} näytettä',
+		failed: 'Pitkä valotus epäonnistui',
+
+		modified: {
+			weighting_linear: 'lineaarinen',
+			weighting_ease: 'ease',
+			interpolation: '{factor}× interpolointi',
+			passes: {
+				one: '{count} ajokerta',
+				other: '{count} ajokertaa',
+			},
+			bracketed: 'haarukointi',
+			recovery: '{stops} aukon palautus',
+		},
+
+		progress: {
+			working: 'Työstetään…',
+			seeking: 'Haetaan…{pass}',
+			accumulating: 'Valotetaan… {count} näytettä{pass}',
+			resolving: 'Kehitetään…',
+			restoring: 'Palautetaan uusintaa…',
+			pass: ' (ajokerta {current}/{total})',
+		},
+
+		notices: {
+			needsNativeCapture:
+				'Pitkä valotus vaatii korkealaatuisen kaappauksen (WGC), joka on nyt pois päältä. Ota se käyttöön asetuksista, jotta voit käyttää pitkää valotusta.',
+			unavailableWithReason:
+				'Pitkä valotus ei ole käytettävissä tällä koneella: {reason}',
+			unavailable: 'Pitkä valotus ei ole käytettävissä tällä koneella.',
+			interpolationCost:
+				'Interpolointi keksii ruutuja oikeiden väliin tasoittaakseen juovaa. Se kuluttaa GPU-aikaa jokaista ruutua kohden, joten vertaa tallennetun otoksen oikeiden näytteiden määrää samaan otokseen ilman interpolointia — jos luku laskee, se ostaa keksittyjä näytteitä oikeilla.',
+			passesAndInterpolation:
+				'Ajokerrat ja interpolointi kilpailevat samasta ruutukohtaisesta budjetista. Kun molemmat ovat päällä, jokainen ajokerta kaappaa vähemmän oikeita ruutuja — interpoloinnin poistaminen tuottaa yleensä paremman otoksen samalla odotusajalla.',
+			passes:
+				'Jokainen ajokerta toistaa saman hetken uudelleen ja nappaa ruutuja, jotka muut jäivät vaille, joten juova tasoittuu eikä kirkastu. Toimii parhaiten lyhyillä suljinajoilla, joilla yksi ajokerta kerää vain kourallisen näytteitä.',
+			interpolationUnsupported:
+				'Ruutuinterpolointi vaatii NVIDIA Turing -näytönohjaimen tai uudemman{adapter}. Kaikki muu pitkässä valotuksessa toimii normaalisti.',
+			interpolationAdapter: ' (tämä kaappaus ajetaan laitteella {adapter})',
+			reshade:
+				'Pitkä valotus kaappaa natiivisti eikä käytä ReShadea, joten ReShade-tehosteet eivät näy lopputuloksessa.',
+		},
+	},
+
+	help: {
+		title: 'Ohje',
+		sections: 'Ohjeen osiot',
+		tabGeneral: 'Yleistä',
+		tabLongExposure: 'Pitkä valotus',
+
+		general: {
+			iracingSettings: 'iRacingin asetukset',
+			borderless: 'iRacingin on oltava Windowed Borderless -tilassa',
+			vram: 'Vähintään 8 Gt VRAM-muistia suositellaan 8K:n tai suurempien kuvakaappausten ottamiseen',
+			newerContent: 'Uudemmat radat ja autot vaativat enemmän VRAM-muistia',
+			shrinkUi:
+				'Pienennä käyttöliittymä mahdollisimman pieneksi ennen kuvakaappausta, jos käytät vesileiman rajausta; ”Control+PageDown” pienentää sitä. Jos se ei toimi, saatat joutua palauttamaan käyttöliittymän zoomauksen iRacingin asetuksista.',
+
+			screenshotFolder: 'Kuvakaappauskansio',
+			screenshotFolderBody:
+				'Kuvakaappaukset tallennetaan oletuksena kansioon ”C:\\Users\\user\\Pictures\\Screenshots”; tämän voi vaihtaa asetuksista.',
+
+			screenshotHotkey: 'Kuvakaappauksen pikanäppäin',
+			screenshotHotkeyBody:
+				'Oletuksena ”Control + PrintScreen” ottaa kuvakaappauksen nykyisillä asetuksilla; tämän voi vaihtaa asetuksista.',
+
+			issues: 'Ongelmat',
+			issuesBody: 'Jos kohtaat ongelmia, ilmoita niistä',
+			discord: 'Discordissa',
+
+			instructions: 'Ohjeet',
+			step1: 'iRacingin <b>on</b> oltava Windowed Borderless -tilassa',
+			step2: 'Käynnistä iRacing ja aseta kamera siihen kohtaan, josta haluat ottaa kuvakaappauksen',
+			step3: 'Valitse haluamasi tarkkuus (kokeile pienempiä tarkkuuksia ennen 8K:hon siirtymistä)',
+			step4: 'Päätä, haluatko rajata iRacingin vesileiman pois; jos haluat, pienennä ensin iRacingin käyttöliittymä pienimpään kokoon näppäimillä ”Control + PageDown”',
+			step5: 'Paina kuvakaappauspainiketta tai käytä pikanäppäintä ”Control + PrintScreen”',
+			step6: 'Valitusta tarkkuudesta riippuen tämä voi kestää muutaman sekunnin; kun iRacing-ikkuna palaa normaaliin kokoonsa, työ on valmis',
+			step7: 'Kuvakaappauksesi tallennetaan kansioon ”C:\\Users\\{User}\\Pictures\\Screenshots”',
+		},
+
+		longExposure: {
+			whatItDoes: 'Mitä se tekee',
+			whatItDoesBody:
+				'Pitkä valotus sulauttaa monta uusinnan ruutua yhdeksi kuvaksi, aivan kuten kameran suljin auki jättäminen: paikallaan olevat asiat pysyvät terävinä, liikkuvat piirtävät juovia. Työkalu ohjaa uusintaa itse, kaappaa jokaisen simulaattorin näyttämän ruudun ja laskee ne yhteen näytönohjaimella.',
+
+			shutter: 'Suljinaika',
+			shutterBody:
+				'Kuinka kauan valotus kestää <i>uusinnan ajassa</i>, yhden uusintaruudun murto-osasta kymmeneen sekuntiin. Tämä asetus ratkaisee juovien pituuden. Pidemmät suljinajat keräävät myös enemmän ruutuja, joten ne tarvitsevat vähemmän apua kaikelta alla olevalta; nopeimmat portaat kattavat yhden ainoan uusintaruudun ja keräävät vain kourallisen näytteitä.',
+
+			playback: 'Toistonopeus',
+			playbackBody:
+				'Uusintaa toistetaan hidastettuna valotuksen aikana, jolloin simulaattori näyttää enemmän ruutuja uusinta-aikasekuntia kohden ja sekoitus saa enemmän näytteitä. 1/16 kerää noin kuusitoista kertaa enemmän ruutuja kuin reaaliaika — ja kestää kuusitoista kertaa kauemmin todellista aikaa. Tämä on paneelin keskeisin vaihtokauppa: kärsivällisyyttä pehmeyttä vastaan.',
+			playbackAutoBody:
+				'”Automaattinen (näytetavoitteen mukaan)” valitsee nopeuden puolestasi <b>näytetavoitteen</b> perusteella: työkalu ratkaisee nopeimman toiston, joka yhä saavuttaa pyytämäsi määrän. Aseta sen sijaan kiinteä nopeus, jos haluat rajoittaa odotusaikaa.',
+
+			weighting: 'Painotus',
+			weightingBody:
+				'Kuinka paljon kukin kaapattu ruutu vaikuttaa lopputulokseen. <b>Box</b> painottaa kaikkia yhtä paljon ja tuottaa tasaisen juovan. <b>Lineaarinen</b> nousee ikkunan loppua kohti, joten kohde on terävin siellä, mihin se päätyi, ja haalistuu polkuaan pitkin. <b>Ease</b> on sama ajatus terävämmällä alulla ja pidemmällä hännällä.',
+
+			interpolation: 'Ruutuinterpolointi',
+			interpolationBody:
+				'Keksii ylimääräisiä ruutuja oikeiden väliin näytönohjaimen optisen virtauksen moottorilla ja täyttää juovan aukot. Vaatii NVIDIA Turing -kortin tai uudemman, ja se piilotetaan kokonaan laitteistolla, joka ei siihen pysty.',
+			interpolationCostBody:
+				'Se ei ole ilmaista: se kuluttaa GPU-aikaa jokaisella kaapatulla ruudulla, ja budjettina on yksi iRacingin ruutu. Jos se ei pysy mukana, se alkaa menettää <i>oikeita</i> ruutuja valmistaakseen synteettisiä, mikä on nettotappio — juovasta tulee lyhyempi ja karkeampi. Kustannus skaalautuu megapikselien ja kertoimen tulona, joten se mikä on mukavaa tarkkuudella 2560×1440 ei ole toteuttamiskelpoista 8K:ssa. Tarkista asia kuvaamalla sama hetki kahdesti, interpoloinnin kanssa ja ilman, ja vertaa oikeiden näytteiden määriä; sovellus myös varoittaa jälkikäteen, jos otos jäi vajaaksi.',
+
+			passes: 'Ajokerrat',
+			passesBody:
+				'Käy saman hetken läpi useita kertoja ja kerää kaiken yhteen kuvaan. Jokainen ajokerta nappaa ruutuja, jotka muilta sattuivat jäämään väliin, joten juova tasoittuu — ei kirkastu, koska tulos normalisoidaan sen mukaan, kuinka paljon valoa kullekin kuvapisteelle todella osui.',
+			passesTradeBody:
+				'Ajokerrat ostavat saman asian kuin interpolointi, mutta eri valuutalla: todellista aikaa GPU-ajan sijaan. Kahdeksan ajokertaa kestää noin kahdeksan kertaa kauemmin, mutta ne eivät voi koskaan maksaa sinulle oikeita ruutuja. Siksi ne ovat oikea keino suurilla tarkkuuksilla, joilla interpolointi ei pysy mukana, ja lyhyillä suljinajoilla, joilla yksi ajokerta kerää hyvin vähän näytteitä. Molempien käyttäminen yhtä aikaa on yleensä huonoin vaihtoehto — ne kilpailevat samasta ruutukohtaisesta budjetista.',
+
+			bracket: 'Suljinaikahaarukointi',
+			bracketBody:
+				'Tuottaa yhdestä kaappauksesta yhden kuvan jokaista suljinaikaporrasta kohden, joka on valitsemasi tai sitä nopeampi. Otos suljinajalla 1/60 antaa sinulle myös 1/125, 1/250, 1/500 ja 1/1000 — saman hetken asteittain lyhyemmillä juovilla — joten voit valita ilmeen jälkikäteen sen sijaan, että arvaisit ja kuvaisit uudelleen.',
+			bracketCostBody:
+				'Se ei maksa juuri lainkaan lisäaikaa. Jokainen porras päättyy samaan ruutuun ja eroaa vain siinä, kuinka kauas taaksepäin se yltää, joten nopeampi suljinaika on yksinkertaisesti jo ohi kulkevien ruutujen häntä — ne kaikki täytetään yhdellä uusinnan ajokerralla.',
+			bracketMemoryBody:
+				'Muistia se sen sijaan kuluttaa. Jokainen porras tarvitsee oman täysitarkkuisen kerääjänsä, joten yksitoista porrasta vaatii yksitoista kertaa yhden näyttömuistin, mikä 8K:ssa on enemmän kuin useimmilla korteilla on. Kaappaus tarkistaa tämän ennen aloitusta ja kieltäytyy mieluummin kuin kaataa iRacingin; jos haarukointi hylätään, laske tarkkuutta tai valitse nopeampi suljinaika — mikä lyhentää samalla porrasta.',
+			bracketNamingBody:
+				'Valitsemasi porras tallennetaan tavanomaisella nimellä ja se näkyy galleriassa; muut ovat sen vieressä, ja niiden suljinaika on tiedostonimessä.',
+
+			highlights: 'Huippuvalojen palautus',
+			highlightsBody:
+				'Korostaa lähes puhki palaneita huippuvaloja ennen ruutujen yhteenlaskua ja purkaa korostuksen lopuksi. iRacing luovuttaa kuvan, jolle on jo tehty sävykartoitus, joten ajovalo ja valkoinen seinä saapuvat samalla arvolla; niiden keskiarvoistaminen tekee osan valotuksesta läpi pyyhkäisevästä kirkkaasta valosta harmaan tahran kirkkaan jäljen sijaan. Tämä palauttaa epälineaarisuuden sinne, missä se oikeassa kennossa on. Mitataan aukkoina; 0 tarkoittaa pois päältä eikä muuta yhtään mitään.',
+
+			whatItSaves: 'Mitä se tallentaa',
+			whatItSavesBody:
+				'Koko, vesileiman rajaus ja tiedostomuoto noudattavat samoja säätimiä kuin tavallinen kuvakaappaus — yllä olevia Tarkkuus- ja Rajaa vesileima -asetuksia sekä asetuksissa määritettyä tulostemuotoa. Sivupalkin yläreunan ”Tuloste”-rivi näyttää tarkalleen, mitä saat.',
+			whatItSavesPngBody:
+				'PNG:n valinta kirjoittaa aidon 16-bittisen masterin, mikä kannattaa, jos aiot värimääritellä otoksen jälkikäteen, sekä 8-bittisen esikatselun galleriaa varten. Sen kirjoittaminen on myös paljon hitaampaa suurilla tarkkuuksilla — 33 megapikselin 16-bittinen PNG vie noin kymmenen sekuntia, kun sama ruutu JPEG-muodossa vie alle sekunnin.',
+
+			troubleshooting: 'Jos tulos näyttää väärältä',
+			troubleGhosts:
+				'<b>Erillisiä haamukuvia tasaisen juovan sijaan</b> — liian vähän näytteitä. Käytä hitaampaa toistonopeutta, useampia ajokertoja tai pienempää tarkkuutta.',
+			troubleShutter:
+				'<b>Et ole varma, minkä suljinajan halusit</b> — ota suljinaikahaarukointi käyttöön ja päätä jälkikäteen, samalla odotusajalla.',
+			troubleHighlights:
+				'<b>Puhki palaneet tai latteat huippuvalot</b> — kokeile 3–5 aukkoa huippuvalojen palautusta.',
+			troubleBlack:
+				'<b>Musta kuva</b> — iRacing on yksinomaisessa koko näytön tilassa. Aseta Display &gt; Full Screen tilaan OFF.',
+			troubleSidecar:
+				'Jokainen otos kirjaa käyttämänsä tarkat asetukset, näytteiden määrän ja sen, miten tasaisesti ne osuivat, .json-tiedostoon lokikansioon app.log-tiedoston viereen. Viimeiset 20 otosta säilytetään — haarukointi lasketaan yhdeksi — joten otos, josta kysyt, on yhä tallessa silloin kun kysyt siitä.',
+		},
+	},
+
+	update: {
+		checking: 'Tarkistetaan päivityksiä…',
+		newVersion: 'Uusi versio',
+		availableBusy:
+			'{version} on saatavilla. Kaappaus on käynnissä — voit ladata sen, kun kaappaus valmistuu.',
+		available: '{version} on saatavilla. Lataa se napsauttamalla.',
+		downloading: 'Ladataan versiota {version}…',
+		downloadingPercent: 'Ladataan versiota {version} — {percent} %',
+		downloadedBusy:
+			'{version} on valmis. Kaappaus on käynnissä, joten se asennetaan, kun suljet sovelluksen.',
+		downloaded:
+			'{version} on valmis. Napsauta käynnistääksesi uudelleen ja asentaaksesi.',
+		failed: 'Päivitysten tarkistus epäonnistui: {error}',
+		unknownError: 'tuntematon virhe',
+		neverChecked:
+			'Päivityksiä ei ole vielä tarkistettu (käytössäsi on v{version}).',
+		upToDate: 'Käytössäsi on uusin versio (v{version}).',
+
+		alreadyDownloading: 'Päivitystä ladataan jo.',
+		alreadyDownloaded: 'Päivitys on jo ladattu.',
+		nothingToDownload: 'Ladattavaa päivitystä ei ole.',
+		captureInProgress:
+			'Kaappaus on käynnissä. Yritä uudelleen, kun se on valmis.',
+		nothingToInstall: 'Mikään päivitys ei ole valmiina asennettavaksi.',
+		captureInProgressInstall:
+			'Kaappaus on käynnissä. Päivitys asentuu itsestään, kun suljet sovelluksen.',
+		devBuildOnly: 'Päivitysten tarkistus toimii vain asennetussa versiossa.',
+
+		installTitle: 'Asenna päivitys',
+		installMessage: 'Asennetaanko versio {version}?',
+		installFallbackVersion: 'päivitys',
+		installDetail:
+			'Sovellus sulkeutuu ja avautuu uudelleen, kun päivitys on asennettu. Jos valitset ”Myöhemmin”, se asentuu itsestään, kun seuraavan kerran suljet sovelluksen.',
+		installConfirm: 'Käynnistä uudelleen ja asenna',
+		installLater: 'Myöhemmin',
+	},
+
+	filenameFields: {
+		categories: {
+			Track: 'Rata',
+			Driver: 'Kuljettaja',
+			Session: 'Sessio',
+			Meta: 'Meta',
+		},
+		track: 'Rata',
+		trackFull: 'Rata koko nimi',
+		trackCity: 'Kaupunki',
+		trackCountry: 'Maa',
+		trackType: 'Radan tyyppi',
+		driver: 'Kuljettaja',
+		driverAbbrev: 'Kuljettaja lyhennettynä',
+		driverInitials: 'Nimikirjaimet',
+		team: 'Talli',
+		carNumber: 'Auton nro',
+		car: 'Auto',
+		carFull: 'Auto koko nimi',
+		carClass: 'Autoluokka',
+		iRating: 'iRating',
+		sessionType: 'Session tyyppi',
+		sessionName: 'Session nimi',
+		lap: 'Kierros',
+		date: 'Päivämäärä',
+		time: 'Kellonaika',
+		datetime: 'Päivämäärä+kellonaika',
+		counter: 'Laskuri',
+	},
+
+	iracingConfig: {
+		projections:
+			'Poista ”Render Scene Using 3 Projections” käytöstä iRacingissa (Display > Monitor -välilehti), jotta kuvakaappauksiin ei tule pystyraitoja',
+	},
+
+	wgc: {
+		cursorCaveat:
+			'Hiiren osoitin voi näkyä kaappauksissa tässä Windowsin versiossa. Windows 10 versio 2004 lisäsi asetuksen, joka piilottaa sen.',
+		addonUnavailable:
+			'Korkealaatuisen kaappauksen komponenttia ei voitu ladata tässä järjestelmässä.',
+		osUnsupported:
+			'Windows.Graphics.Capture ei ole käytettävissä tässä Windowsin versiossa. Se vaatii Windows 10 version 1903 tai uudemman.',
+		nativeCaptureOff: 'Korkealaatuinen kaappaus (WGC) on pois päältä',
+	},
+
+	capture: {
+		exclusiveFullscreen:
+			'iRacing on yksinomaisessa koko näytön tilassa, joten kuvakaappauksesta tulisi musta. Aseta iRacingissa Display > Full Screen tilaan OFF (käytä Borderless- tai Windowed-tilaa) ja yritä uudelleen.',
+		exclusiveFullscreenUnattributed:
+			'Jokin sovellus on yksinomaisessa koko näytön tilassa, mistä seuraa musta kaappaus. Jos iRacing on koko näytön tilassa, aseta Display > Full Screen tilaan OFF (käytä Borderless- tai Windowed-tilaa) ja yritä uudelleen.',
+		unknownError: 'Tuntematon kuvakaappausvirhe',
+		outputTooSmall: 'Kaappaus on liian pieni ({width}x{height})',
+		blackFrame:
+			'Kaapattu ruutu on musta — kaappauslähde saattoi epäonnistua (GPU-kiihdytettyä sisältöä ei aina saa kaapattua joissakin Windows-kokoonpanoissa)',
+		noSource: 'Ikkunalle {windowId} ei löytynyt työpöytäkaappauslähdettä',
+		metadataTimeout: 'Aikakatkaisu odotettaessa kaappauksen videometatietoja',
+		noVideoFrame: 'Kaappausvirta ei tuottanut yhtään videoruutua',
+		dimensionTimeout:
+			'Aikakatkaisu odotettaessa ikkunan mittoja {width}x{height}; jatketaan mitoilla {actualWidth}x{actualHeight}',
+	},
+
+	longExposureCapture: {
+		busy: 'Kaappaus on jo käynnissä.',
+		needsNativeCapture:
+			'Pitkä valotus vaatii korkealaatuisen kaappauksen (WGC). Ota se käyttöön asetuksista.',
+		unavailable: 'Pitkä valotus ei ole käytettävissä tällä koneella.',
+		noTelemetry:
+			'Pitkä valotus vaatii uusintatelemetrian iRacingista. Tarkista, että simulaattori on käynnissä ja sessiossa.',
+		windowNotFound: 'iRacing-ikkunaa ei löytynyt.',
+		cancelled: 'Kaappaus peruutettiin.',
+		seekTimeout:
+			'Uusinta ei ehtinyt ruutuun {frame} ajoissa. Se saattaa vielä latautua.',
+		noPasses: 'Kaappauksen on suoritettava vähintään yksi ajokerta.',
+		playbackStalled:
+			'Uusinta ei lähtenyt käyntiin. Tarkista, ettei jokin toinen työkalu ole pysäyttänyt iRacingia.',
+		exposureTimeout:
+			'Valotus ei ehtinyt ruutuun {frame} {seconds} sekunnissa.',
+		endedEarly: 'Valotus päättyi ennen kuin valittu hetki saavutettiin.',
+		noFramesPresented: 'iRacing ei näyttänyt yhtään kaapattavaa ruutua.',
+		subFrameNoSamples:
+			'Tämä suljinaika on lyhyempi kuin yksi uusintaruutu, eikä iRacing piirtänyt sen sisällä yhtään ruutua. Kokeile hitaampaa toistonopeutta tai seuraavaksi pidempää suljinaikaa.',
+		noSamples:
+			'Yhtään ruutua ei kertynyt. iRacing on saattanut lopettaa piirtämisen valotuksen aikana.',
+		withNativeError: '{reason} ({error})',
+		resolveFailed: 'Näytönohjain ei palauttanut kuvaa.',
+		bracketShortfall:
+			'Haarukointi pyysi {asked} porrasta, mutta {returned} palasi — loput eivät ratkenneet, tai tämä kaappauskomponentin versio on haarukointia vanhempi.',
+	},
+
+	validation: {
+		windowBeforeStart:
+			'Valotus tarvitsee {frames} uusintaruutua ennen valittua hetkeä, mutta se on vain {anchor} ruudun päässä uusinnan alusta. Valitse myöhempi hetki tai nopeampi suljinaika.',
+		pastEnd: 'Valittu hetki on uusinnan lopun jälkeen.',
+		sessionChanged:
+			'Uusinta on siirtynyt toiseen sessioon sen jälkeen, kun tämä otos määritettiin. Valitse hetki uudelleen.',
+		singleSampleMultiPass:
+			'Tämä suljinaika on niin lyhyt, että sen sisään osuu vain noin yksi ruutu ajokertaa kohden, joten {passes} ajokertaa kerää suunnilleen {passes} näytettä. Hitaampi toistonopeus tai pidempi suljinaika tuottaa huomattavasti enemmän.',
+		singleSample:
+			'Tämä suljinaika on niin lyhyt, että sen sisään osuu vain yksi ruutu, joten tuloksessa ei ole liike-epäterävyyttä. Hitaampi toistonopeus tai pidempi suljinaika tuottaa näytteitä.',
+		bracketVsInterpolation:
+			'Suljinaikahaarukointi ja {factor}x ruutuinterpolointi eivät voi toimia yhtä aikaa, joten tämä otos otetaan ilman interpolointia. Poista haarukointi käytöstä, jos väliruudut merkitsevät sinulle enemmän kuin lisäportaat.',
+		passesVsInterpolation:
+			'Sekä useat ajokerrat että {factor}x interpolointi ovat päällä. Ne kilpailevat keskenään: interpolointi hidastaa jokaista ajokertaa niin paljon, että se menettää oikeita ruutuja, joten sama odotusaika ostaa vähemmän oikeita näytteitä kuin pelkät ajokerrat. Interpoloinnin poistaminen tuottaa yleensä paremman otoksen.',
+		shortOfTarget:
+			'Jopa nopeudella 1/{divisor} tämä valotus yltää noin {samples} näytteeseen, mikä jää pyydetystä {target}:sta. Käytä pidempää suljinaikaa saadaksesi enemmän.',
+		longCaptureEscalate:
+			'Tämä kaappaus toistaa uusintaa nopeudella 1/{divisor} noin {duration} todellista aikaa{passSuffix}, eikä sitä voi kiirehtiä käynnistämisen jälkeen. {advice}',
+		longCaptureWarn:
+			'Tämä kaappaus kestää noin {duration} todellista aikaa toistonopeudella 1/{divisor}{passSuffix}.',
+		passSuffix: ', jaettuna {passes} ajokerralle saman hetken yli',
+		adviceFewerPasses:
+			'Harvemmat ajokerrat valmistuvat nopeammin, mutta vähemmillä näytteillä.',
+		adviceFasterPlayback:
+			'Nopeampi toistonopeus valmistuu nopeammin, mutta vähemmillä näytteillä.',
+		pastLogCap:
+			'Tämän kaappauksen ennustetaan keräävän noin {samples} näytettä {passes} ajokerran aikana, enemmän kuin diagnostiikkalokiin mahtuvat {cap}. Kuvaan tämä ei vaikuta — vain tasaisuus- ja aukkoluvut kuvaavat kaappauksen alkuosaa.',
+		interpolationLossy:
+			'Tässä koossa {factor}x interpolointi on aiemmin maksanut tälle koneelle oikeita näytteitä. Harkitse pienempää kerrointa, pienempää tarkkuutta tai useampia ajokertoja.',
+	},
+
+	duration: {
+		zero: '0 sekuntia',
+		seconds: {
+			one: '{count} sekunti',
+			other: '{count} sekuntia',
+		},
+		minutes: {
+			one: '{count} minuutti',
+			other: '{count} minuuttia',
+		},
+		minutesSeconds: '{minutes} min {seconds} s',
+	},
+};
+
+export default fi;

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -1,0 +1,482 @@
+// French. Translated from en.ts — see that file's header before editing.
+//
+// Product and technology names stay untranslated: iRacing, ReShade, Discord,
+// Windows.Graphics.Capture, WGC, VRAM, GPU, NVIDIA Turing and the file formats
+// are what the user sees in iRacing's own settings and on their hardware.
+
+import type { Catalog } from './index';
+
+const fr: Catalog = {
+	notice: {
+		danger: 'Problèmes',
+		warning: 'À savoir',
+		info: 'Remarques',
+	},
+
+	promo: {
+		greeting: 'Merci d’utiliser iRacing Screenshot Tool !',
+		signature: 'Conçu et maintenu par AR Media Solutions.',
+	},
+
+	changelog: {
+		title: 'Journal des modifications',
+		untitledRelease: 'Version',
+	},
+
+	gallery: {
+		menu: {
+			openExternally: 'Ouvrir dans une autre application',
+			openFolder: 'Ouvrir le dossier',
+			copy: 'Copier',
+			delete: 'Supprimer',
+		},
+		copiedToClipboard: '{name} copié dans le presse-papiers',
+	},
+
+	sidebar: {
+		resolution: 'Résolution',
+		width: 'Largeur',
+		height: 'Hauteur',
+		output: 'Sortie :',
+		cropWatermark: 'Rogner le filigrane',
+		keepAspectRatio: 'Conserver le rapport d’image',
+		screenshot: 'Capture d’écran',
+		custom: 'Personnalisée',
+		vramStatus: '{adapter}{free} libres sur {total}',
+		savedSuccessfully: '{name} enregistré avec succès',
+		screenshotFailed: 'Échec de la capture : {message}',
+		errorLogPrefix: 'Journal : ',
+		notices: {
+			exclusiveFullscreen:
+				'iRacing est en plein écran exclusif — les captures seront noires. Dans iRacing, mettez Display > Full Screen sur OFF (Borderless ou Windowed) pour permettre la capture.',
+			vramRisk:
+				'{resolution} nécessite environ {needed} de VRAM en plus, mais seuls {free} sont libres — iRacing va probablement manquer de mémoire et planter.',
+			vramCaution:
+				'{resolution} laisse peu de marge de VRAM ({free} libres) et peut planter sur les combinaisons circuit/voiture les plus lourdes.',
+			switchResolution: 'Passer en {resolution}',
+			vramStatic:
+				'Les résolutions élevées peuvent faire planter iRacing si la VRAM vient à manquer. Certaines combinaisons circuit/voiture demandent davantage de VRAM.',
+			reshade:
+				'Après avoir appuyé sur le bouton de capture dans iRacing Screenshot Tool, vous devrez utiliser votre raccourci de capture ReShade.',
+			crop: 'Le rognage du filigrane zoome légèrement l’image finale. Les zones proches des bords de l’écran seront coupées.',
+			aspectRatio:
+				'« Conserver le rapport d’image » ajuste la hauteur de la capture au rapport de votre écran (par exemple 21:9 ultra-large) au lieu du 16:9 par défaut. La résolution choisie définit la largeur.',
+		},
+	},
+
+	settings: {
+		title: 'Paramètres',
+		version: 'Version - {version}',
+		changelog: 'Journal des modifications',
+		openLogsFolder: 'Ouvrir le dossier des journaux',
+		checkForUpdates: 'Rechercher des mises à jour',
+		updateCheckFailed: 'Échec de la recherche de mise à jour : {message}',
+
+		language: 'Langue',
+		languageDescription:
+			'La langue utilisée dans toute l’application. Détectée depuis Windows au premier lancement.',
+
+		screenshotFolder: 'Dossier des captures',
+		selectFolder: 'Choisir un dossier',
+		screenshotKeybind: 'Raccourci de capture',
+		editBind: 'Modifier le raccourci',
+
+		customFilenameFormat: 'Format de nom de fichier personnalisé',
+		customFilenameFormatDescription:
+			'Utiliser un modèle personnalisé au lieu du format par défaut ({track}-{driver}-{counter})',
+		filenameFieldsHint:
+			'Cliquez sur les champs pour les ajouter au format. Saisissez directement les séparateurs (-, _, etc.).',
+		reset: 'Réinitialiser',
+		preview: 'Aperçu :',
+
+		outputFormat: 'Format de sortie',
+		formatJpeg: 'JPEG (qualité maximale)',
+		formatPng: 'PNG (sans perte)',
+		formatWebp: 'WebP (qualité 95 %)',
+
+		disableTooltips: 'Masquer les conseils',
+		disableTooltipsDescription:
+			'Laissez-moi tranquille, je sais ce que je fais',
+
+		cropTopLeft: 'Préférer le rognage du filigrane en haut à gauche',
+		cropTopLeftDescription:
+			'Ne rogne que le coin inférieur droit (3 %). Si l’option est désactivée, la capture est rognée uniformément sur tous les côtés (6 % au total) pour un résultat centré.',
+
+		manualWindowRestore: 'Restauration manuelle de la fenêtre',
+		manualWindowRestoreDescription:
+			'Remplace la restauration automatique de la fenêtre par une position et une taille personnalisées. Utile en ultra-large ou en Nvidia Surround.',
+		left: 'Gauche',
+		top: 'Haut',
+		width: 'Largeur',
+		height: 'Hauteur',
+		restoreNow: 'Restaurer maintenant',
+
+		nativeCapture: 'Capture haute fidélité (WGC)',
+		nativeCaptureDescription:
+			'Capture les couleurs réelles sans sous-échantillonnage via Windows.Graphics.Capture au lieu du pipeline par défaut (qui sous-échantillonne la couleur). Bascule automatiquement en cas d’échec d’une capture.',
+		nativeCaptureUnavailable:
+			'Indisponible sur ce système — la capture haute fidélité ne peut pas fonctionner ici.',
+		nativeCaptureUnverified:
+			'Windows indique que c’est pris en charge, mais une capture de test n’est pas revenue. Les captures basculeront automatiquement si l’échec persiste.',
+
+		reshade: 'Mode de compatibilité ReShade',
+		reshadeDescription:
+			'Avec ReShade, vous devez d’abord utiliser le raccourci d’iRacing Screenshot Tool ou appuyer sur le bouton, puis utiliser votre raccourci de capture ReShade une fois la fenêtre d’iRacing redimensionnée.',
+		reshadeIni: 'Fichier INI de ReShade',
+		selectFile: 'Choisir un fichier',
+	},
+
+	longExposure: {
+		title: 'Pose longue',
+		shutter: 'Vitesse d’obturation',
+		playbackSpeed: 'Vitesse de lecture',
+		playbackAuto: 'Automatique (d’après l’objectif d’échantillons)',
+		playbackRealTime: '1x (temps réel)',
+		targetSamples: 'Objectif d’échantillons',
+		advanced: 'Avancé',
+		defaultsSummary: '{count} valeurs par défaut',
+
+		weighting: 'Pondération',
+		weightingBox: 'Box (uniforme)',
+		weightingLinear: 'Linéaire (net à la fin)',
+		weightingEase: 'Ease (tête plus nette, longue traîne)',
+
+		interpolation: 'Interpolation d’images',
+		interpolationOff: 'Désactivée',
+		interpolation2: '2× (une image intermédiaire)',
+		interpolation4: '4× (trois images intermédiaires)',
+		interpolation8: '8× (sept images intermédiaires)',
+
+		passes: 'Passes',
+		passes1: '1 (passe unique)',
+		passes2: '2× — deux fois plus d’attente',
+		passes4: '4× — quatre fois plus d’attente',
+		passes8: '8× — huit fois plus d’attente',
+
+		bracket: 'Bracketing des vitesses',
+		highlightRecovery: 'Récupération des hautes lumières (IL)',
+
+		cancel: 'Annuler',
+		saved: 'Pose longue enregistrée — {count} échantillons',
+		failed: 'Échec de la pose longue',
+
+		modified: {
+			weighting_linear: 'linéaire',
+			weighting_ease: 'ease',
+			interpolation: 'interpolation {factor}×',
+			passes: {
+				one: '{count} passe',
+				other: '{count} passes',
+			},
+			bracketed: 'bracketing',
+			recovery: 'récupération de {stops} IL',
+		},
+
+		progress: {
+			working: 'Traitement…',
+			seeking: 'Recherche…{pass}',
+			accumulating: 'Exposition… {count} échantillons{pass}',
+			resolving: 'Développement…',
+			restoring: 'Restauration du replay…',
+			pass: ' (passe {current} sur {total})',
+		},
+
+		notices: {
+			needsNativeCapture:
+				'La pose longue nécessite la capture haute fidélité (WGC), actuellement désactivée. Activez-la dans les paramètres pour utiliser la pose longue.',
+			unavailableWithReason:
+				'La pose longue est indisponible sur cette machine : {reason}',
+			unavailable: 'La pose longue est indisponible sur cette machine.',
+			interpolationCost:
+				'L’interpolation invente des images entre les images réelles pour lisser la traînée. Elle coûte du temps GPU par image : comparez donc le nombre d’échantillons réels de la prise enregistrée avec la même prise sans interpolation. Si ce nombre baisse, elle achète des échantillons inventés avec des échantillons réels.',
+			passesAndInterpolation:
+				'Les passes et l’interpolation se disputent le même budget par image. Avec les deux activées, chaque passe capture moins d’images réelles — désactiver l’interpolation donne généralement une meilleure prise pour la même attente.',
+			passes:
+				'Chaque passe rejoue le même instant et rattrape les images que les autres ont manquées : la traînée devient plus régulière, pas plus lumineuse. Idéal sur les vitesses rapides, où une seule passe ne recueille qu’une poignée d’échantillons.',
+			interpolationUnsupported:
+				'L’interpolation d’images nécessite un GPU NVIDIA Turing ou plus récent{adapter}. Tout le reste de la pose longue fonctionne normalement.',
+			interpolationAdapter: ' (cette capture s’exécute sur {adapter})',
+			reshade:
+				'La pose longue capture nativement et n’utilise pas ReShade : les effets ReShade n’apparaîtront donc pas dans le résultat.',
+		},
+	},
+
+	help: {
+		title: 'Aide',
+		sections: 'Sections d’aide',
+		tabGeneral: 'Général',
+		tabLongExposure: 'Pose longue',
+
+		general: {
+			iracingSettings: 'Paramètres iRacing',
+			borderless:
+				'iRacing doit fonctionner en mode Windowed Borderless (fenêtré sans bordure)',
+			vram: 'Au moins 8 Go de VRAM sont recommandés pour des captures en 8K ou plus',
+			newerContent:
+				'Les circuits et voitures récents demandent davantage de VRAM',
+			shrinkUi:
+				'Réduisez l’interface au minimum avant de prendre une capture si vous utilisez l’option de rognage du filigrane. « Control+PageDown » la réduit ; si cela ne fonctionne pas, vous devrez peut-être réinitialiser le zoom de l’interface dans les paramètres d’iRacing.',
+
+			screenshotFolder: 'Dossier des captures',
+			screenshotFolderBody:
+				'Les captures sont enregistrées par défaut dans « C:\\Users\\user\\Pictures\\Screenshots » ; cela peut être modifié dans les paramètres.',
+
+			screenshotHotkey: 'Raccourci de capture',
+			screenshotHotkeyBody:
+				'Par défaut, « Control + PrintScreen » prend une capture avec les réglages actuels ; cela peut être modifié dans les paramètres.',
+
+			issues: 'Problèmes',
+			issuesBody: 'En cas de problème, merci de le signaler sur le',
+			discord: 'Discord',
+
+			instructions: 'Instructions',
+			step1: 'iRacing <b>doit</b> fonctionner en mode Windowed Borderless',
+			step2: 'Lancez iRacing et placez la caméra à l’endroit souhaité pour la capture',
+			step3: 'Choisissez la résolution voulue (essayez des résolutions plus basses avant de passer en 8K)',
+			step4: 'Décidez si vous voulez rogner le filigrane iRacing ; si oui, réduisez d’abord l’interface d’iRacing à sa plus petite taille avec « Control + PageDown »',
+			step5: 'Appuyez sur le bouton de capture ou utilisez le raccourci « Control + PrintScreen » pour prendre les captures',
+			step6: 'Selon la résolution choisie, cela peut prendre quelques secondes ; l’opération est terminée lorsque la fenêtre d’iRacing retrouve sa taille normale',
+			step7: 'Votre capture sera enregistrée dans « C:\\Users\\{User}\\Pictures\\Screenshots »',
+		},
+
+		longExposure: {
+			whatItDoes: 'Ce que ça fait',
+			whatItDoesBody:
+				'Une pose longue fond de nombreuses images d’un replay en une seule, comme le fait un obturateur laissé ouvert : ce qui est immobile reste net, ce qui bouge laisse une traînée. L’outil pilote lui-même le replay, capture chaque image présentée par le simulateur et les additionne sur le GPU.',
+
+			shutter: 'Vitesse d’obturation',
+			shutterBody:
+				'La durée de l’exposition <i>en temps de replay</i>, d’une fraction d’image de replay jusqu’à dix secondes. C’est ce réglage qui détermine la longueur des traînées. Les vitesses plus lentes recueillent aussi plus d’images et ont donc moins besoin de tout ce qui suit ; les crans les plus rapides couvrent une seule image de replay et ne recueillent qu’une poignée d’échantillons.',
+
+			playback: 'Vitesse de lecture',
+			playbackBody:
+				'Le replay est lu au ralenti pendant la capture de l’exposition : le simulateur présente donc plus d’images par seconde de temps de replay et le mélange obtient plus d’échantillons. 1/16 recueille environ seize fois plus d’images que le temps réel — et prend seize fois plus de temps réel. C’est le compromis principal de ce panneau : de la patience contre de la douceur.',
+			playbackAutoBody:
+				'« Automatique (d’après l’objectif d’échantillons) » choisit la vitesse à votre place à partir de l’<b>objectif d’échantillons</b> : l’outil détermine la lecture la plus rapide qui atteint encore le nombre demandé. Indiquez plutôt une vitesse explicite si vous préférez plafonner l’attente.',
+
+			weighting: 'Pondération',
+			weightingBody:
+				'La contribution de chaque image capturée au résultat. <b>Box</b> les pondère toutes également et donne une traînée uniforme. <b>Linéaire</b> monte vers la fin de la fenêtre : le sujet est le plus net là où il a terminé et s’estompe le long de son trajet. <b>Ease</b> reprend la même idée avec une tête plus nette et une traîne plus longue.',
+
+			interpolation: 'Interpolation d’images',
+			interpolationBody:
+				'Invente des images supplémentaires entre les images réelles à l’aide du moteur de flux optique du GPU, comblant les trous le long de la traînée. Nécessite une carte NVIDIA Turing ou plus récente et est entièrement masquée sur le matériel qui ne le permet pas.',
+			interpolationCostBody:
+				'Ce n’est pas gratuit : cela coûte du temps GPU sur chaque image capturée, et le budget est d’une image iRacing. Si elle ne suit pas, elle commence à manquer des images <i>réelles</i> pour en fabriquer des synthétiques, ce qui est une perte nette — la traînée ressort plus courte et plus grossière. Le coût évolue avec les mégapixels multipliés par le facteur : ce qui est confortable en 2560×1440 n’est pas viable en 8K. Pour vérifier, photographiez deux fois le même instant, avec et sans, et comparez le nombre d’échantillons réels ; l’application vous avertit aussi après coup si une prise est restée courte.',
+
+			passes: 'Passes',
+			passesBody:
+				'Visite plusieurs fois le même instant en accumulant dans une seule image. Chaque passe attrape des images que les autres ont manquées, la traînée devient donc plus régulière — pas plus lumineuse, car le résultat est normalisé par la quantité de lumière réellement reçue par chaque pixel.',
+			passesTradeBody:
+				'Les passes achètent la même chose que l’interpolation, dans une autre monnaie : du temps réel plutôt que du temps GPU. Huit passes prennent environ huit fois plus longtemps, mais elles ne peuvent jamais vous coûter d’images réelles. C’est donc le bon levier aux hautes résolutions, où l’interpolation ne suit pas, et sur les vitesses rapides, où une seule passe recueille très peu d’échantillons. Utiliser les deux à la fois est généralement le pire des deux mondes — elles se disputent le même budget par image.',
+
+			bracket: 'Bracketing des vitesses',
+			bracketBody:
+				'Produit une image par cran d’obturation égal ou plus rapide que celui choisi, à partir d’une seule capture. Une prise à 1/60 vous donne aussi 1/125, 1/250, 1/500 et 1/1000 — le même instant avec des traînées de plus en plus courtes — ce qui vous permet de choisir le rendu après coup au lieu de deviner et de refaire la prise.',
+			bracketCostBody:
+				'Cela ne coûte presque aucun temps supplémentaire. Chaque cran se termine sur la même image et ne diffère que par la profondeur de son retour en arrière : une vitesse plus rapide n’est que la fin des images qui défilent déjà — elles sont toutes remplies à partir d’une seule passe du replay.',
+			bracketMemoryBody:
+				'Ce que cela coûte, c’est de la mémoire. Chaque cran a besoin de son propre accumulateur en pleine résolution : onze crans demandent donc onze fois la mémoire vidéo d’un seul, ce qui, en 8K, dépasse ce dont disposent la plupart des cartes. La capture vérifie ce point avant de démarrer et refuse plutôt que de faire planter iRacing. Si un bracketing est refusé, baissez la résolution ou choisissez une vitesse plus rapide — ce qui raccourcit aussi l’échelle.',
+			bracketNamingBody:
+				'Le cran que vous avez choisi est enregistré sous le nom habituel et c’est celui qui apparaît dans la galerie ; les autres se placent à côté, avec leur vitesse dans le nom de fichier.',
+
+			highlights: 'Récupération des hautes lumières',
+			highlightsBody:
+				'Amplifie les hautes lumières proches de l’écrêtage avant l’addition des images, puis annule l’amplification à la fin. iRacing fournit une image déjà tonemappée : un phare et un mur blanc arrivent donc à la même valeur, et en moyenner cela transforme une lumière vive traversant une partie de l’exposition en une tache grise plutôt qu’en une traînée lumineuse. Cette option remet la non-linéarité là où un vrai capteur la place. Mesurée en IL ; 0 désactive l’option et ne change strictement rien.',
+
+			whatItSaves: 'Ce qui est enregistré',
+			whatItSavesBody:
+				'La taille, le rognage du filigrane et le format de fichier suivent les mêmes réglages qu’une capture normale — les options Résolution et Rogner le filigrane ci-dessus, et le format de sortie dans les paramètres. La ligne « Sortie » en haut de la barre latérale indique exactement ce que vous obtiendrez.',
+			whatItSavesPngBody:
+				'Choisir PNG écrit un véritable master 16 bits, ce qui vaut la peine si vous comptez étalonner la prise ensuite, plus un aperçu 8 bits pour la galerie. C’est aussi beaucoup plus lent à écrire en haute résolution — un PNG 16 bits de 33 mégapixels demande une dizaine de secondes là où la même image en JPEG prend moins d’une seconde.',
+
+			troubleshooting: 'Si le résultat semble incorrect',
+			troubleGhosts:
+				'<b>Des images fantômes distinctes au lieu d’une traînée régulière</b> — trop peu d’échantillons. Utilisez une vitesse de lecture plus lente, plus de passes, ou une résolution plus basse.',
+			troubleShutter:
+				'<b>Vous ne savez pas quelle vitesse vous vouliez</b> — activez le bracketing des vitesses et décidez après coup, pour la même attente.',
+			troubleHighlights:
+				'<b>Hautes lumières brûlées ou plates</b> — essayez 3 à 5 IL de récupération des hautes lumières.',
+			troubleBlack:
+				'<b>Une image noire</b> — iRacing est en plein écran exclusif. Mettez Display &gt; Full Screen sur OFF.',
+			troubleSidecar:
+				'Chaque prise consigne les réglages exacts utilisés, le nombre d’échantillons et leur régularité, dans un fichier .json placé dans le dossier des journaux à côté d’app.log. Les 20 dernières prises sont conservées — un bracketing compte pour une — de sorte que la prise sur laquelle vous vous interrogez est encore là pendant que vous vous interrogez.',
+		},
+	},
+
+	update: {
+		checking: 'Recherche de mises à jour…',
+		newVersion: 'Une nouvelle version',
+		availableBusy:
+			'{version} est disponible. Une capture est en cours — vous pourrez la télécharger une fois celle-ci terminée.',
+		available: '{version} est disponible. Cliquez pour la télécharger.',
+		downloading: 'Téléchargement de {version}…',
+		downloadingPercent: 'Téléchargement de {version} — {percent} %',
+		downloadedBusy:
+			'{version} est prête. Une capture est en cours : elle s’installera à la fermeture de l’application.',
+		downloaded:
+			'{version} est prête. Cliquez pour redémarrer et l’installer.',
+		failed: 'Échec de la recherche de mise à jour : {error}',
+		unknownError: 'erreur inconnue',
+		neverChecked:
+			'Aucune recherche de mise à jour n’a encore été faite (vous êtes en v{version}).',
+		upToDate: 'Vous êtes sur la dernière version (v{version}).',
+
+		alreadyDownloading: 'La mise à jour est déjà en cours de téléchargement.',
+		alreadyDownloaded: 'La mise à jour est déjà téléchargée.',
+		nothingToDownload: 'Aucune mise à jour à télécharger.',
+		captureInProgress:
+			'Une capture est en cours. Réessayez une fois celle-ci terminée.',
+		nothingToInstall: 'Aucune mise à jour prête à être installée.',
+		captureInProgressInstall:
+			'Une capture est en cours. La mise à jour s’installera d’elle-même à la fermeture de l’application.',
+		devBuildOnly:
+			'La recherche de mises à jour ne fonctionne que dans une version installée.',
+
+		installTitle: 'Installer la mise à jour',
+		installMessage: 'Installer la version {version} ?',
+		installFallbackVersion: 'mise à jour',
+		installDetail:
+			'L’application se fermera et se rouvrira une fois la mise à jour installée. Si vous choisissez « Plus tard », elle s’installera d’elle-même à la prochaine fermeture.',
+		installConfirm: 'Redémarrer et installer',
+		installLater: 'Plus tard',
+	},
+
+	filenameFields: {
+		categories: {
+			Track: 'Circuit',
+			Driver: 'Pilote',
+			Session: 'Session',
+			Meta: 'Méta',
+		},
+		track: 'Circuit',
+		trackFull: 'Circuit complet',
+		trackCity: 'Ville',
+		trackCountry: 'Pays',
+		trackType: 'Type de circuit',
+		driver: 'Pilote',
+		driverAbbrev: 'Pilote abrégé',
+		driverInitials: 'Initiales',
+		team: 'Équipe',
+		carNumber: 'N° voiture',
+		car: 'Voiture',
+		carFull: 'Voiture complète',
+		carClass: 'Catégorie',
+		iRating: 'iRating',
+		sessionType: 'Type de session',
+		sessionName: 'Nom de session',
+		lap: 'Tour',
+		date: 'Date',
+		time: 'Heure',
+		datetime: 'Date+heure',
+		counter: 'Compteur',
+	},
+
+	iracingConfig: {
+		projections:
+			'Désactivez « Render Scene Using 3 Projections » dans iRacing (onglet Display > Monitor) pour éviter les bandes verticales dans les captures',
+	},
+
+	wgc: {
+		cursorCaveat:
+			'Le curseur de la souris peut apparaître dans les captures sur cette version de Windows. Windows 10 version 2004 a ajouté le réglage qui le masque.',
+		addonUnavailable:
+			'Le composant de capture haute fidélité n’a pas pu être chargé sur ce système.',
+		osUnsupported:
+			'Windows.Graphics.Capture n’est pas disponible sur cette version de Windows. Il faut Windows 10 version 1903 ou plus récent.',
+		nativeCaptureOff: 'La capture haute fidélité (WGC) est désactivée',
+	},
+
+	capture: {
+		exclusiveFullscreen:
+			'iRacing est en plein écran exclusif : la capture serait donc noire. Dans iRacing, mettez Display > Full Screen sur OFF (utilisez Borderless ou Windowed) puis réessayez.',
+		exclusiveFullscreenUnattributed:
+			'Une application fonctionne en plein écran exclusif, ce qui produit une capture noire. Si iRacing est en plein écran, mettez Display > Full Screen sur OFF (utilisez Borderless ou Windowed) puis réessayez.',
+		unknownError: 'Erreur de capture inconnue',
+		outputTooSmall: 'La capture est trop petite ({width}x{height})',
+		blackFrame:
+			'L’image capturée est noire — la source de capture a peut-être échoué (le contenu accéléré par le GPU peut ne pas se capturer sur certaines configurations Windows)',
+		noSource:
+			'Aucune source de capture du bureau trouvée pour la fenêtre {windowId}',
+		metadataTimeout:
+			'Délai dépassé en attendant les métadonnées vidéo de la capture',
+		noVideoFrame: 'Le flux de capture n’a produit aucune image vidéo',
+		dimensionTimeout:
+			'Délai dépassé en attendant les dimensions de fenêtre {width}x{height} ; poursuite avec {actualWidth}x{actualHeight}',
+	},
+
+	longExposureCapture: {
+		busy: 'Une capture est déjà en cours.',
+		needsNativeCapture:
+			'La pose longue nécessite la capture haute fidélité (WGC). Activez-la dans les paramètres pour l’utiliser.',
+		unavailable: 'La pose longue n’est pas disponible sur cette machine.',
+		noTelemetry:
+			'La pose longue nécessite la télémétrie de replay d’iRacing. Vérifiez que le simulateur est lancé et dans une session.',
+		windowNotFound: 'Fenêtre iRacing introuvable.',
+		cancelled: 'Capture annulée.',
+		seekTimeout:
+			'Le replay n’a pas atteint l’image {frame} à temps. Il est peut-être encore en cours de chargement.',
+		noPasses: 'Une capture doit effectuer au moins une passe.',
+		playbackStalled:
+			'Le replay n’a pas démarré. Vérifiez qu’iRacing n’est pas mis en pause par un autre outil.',
+		exposureTimeout:
+			'L’exposition n’a pas atteint l’image {frame} en moins de {seconds} s.',
+		endedEarly:
+			'L’exposition s’est terminée avant d’atteindre l’instant choisi.',
+		noFramesPresented: 'iRacing n’a présenté aucune image à capturer.',
+		subFrameNoSamples:
+			'Cette vitesse d’obturation est plus courte qu’une image de replay, et iRacing n’a rendu aucune image pendant ce laps de temps. Essayez une vitesse de lecture plus lente, ou le cran d’obturation immédiatement plus lent.',
+		noSamples:
+			'Aucune image n’a été accumulée. iRacing a peut-être cessé de rendre pendant l’exposition.',
+		withNativeError: '{reason} ({error})',
+		resolveFailed: 'Le GPU n’a renvoyé aucune image.',
+		bracketShortfall:
+			'Le bracketing a demandé {asked} crans mais {returned} sont revenus — les autres n’ont pas pu être résolus, ou cette version du composant de capture est antérieure au bracketing.',
+	},
+
+	validation: {
+		windowBeforeStart:
+			'L’exposition nécessite {frames} images de replay avant l’instant choisi, or celui-ci ne se situe qu’à {anchor} images du début du replay. Choisissez un instant plus tardif ou une vitesse plus rapide.',
+		pastEnd: 'L’instant choisi se situe après la fin du replay.',
+		sessionChanged:
+			'Le replay est passé à une autre session depuis la préparation de cette prise. Sélectionnez à nouveau l’instant.',
+		singleSampleMultiPass:
+			'Cette vitesse est si courte qu’environ une seule image y tombe par passe : {passes} passes ne recueillent donc qu’environ {passes} échantillons. Une vitesse de lecture plus lente ou une vitesse d’obturation plus lente en apporte bien davantage.',
+		singleSample:
+			'Cette vitesse est si courte qu’une seule image y tombera : le résultat n’aura donc aucun flou de mouvement. Une vitesse de lecture plus lente ou une vitesse d’obturation plus lente apporte des échantillons.',
+		bracketVsInterpolation:
+			'Le bracketing des vitesses et l’interpolation d’images {factor}x ne peuvent pas fonctionner ensemble : cette prise sera donc faite sans interpolation. Désactivez le bracketing si les images intermédiaires comptent plus pour vous que les crans supplémentaires.',
+		passesVsInterpolation:
+			'Le multi-passe et l’interpolation {factor}x sont tous deux activés. Ils se concurrencent : l’interpolation ralentit chaque passe au point de lui coûter des images réelles, si bien que la même attente achète moins d’échantillons réels que les passes seules. Désactiver l’interpolation donne généralement une meilleure prise.',
+		shortOfTarget:
+			'Même à la vitesse 1/{divisor}, cette exposition n’atteint qu’environ {samples} échantillons, en deçà des {target} demandés. Utilisez une vitesse d’obturation plus lente pour en obtenir davantage.',
+		longCaptureEscalate:
+			'Cette capture lit le replay à la vitesse 1/{divisor} pendant environ {duration} de temps réel{passSuffix}, et ne peut pas être accélérée une fois lancée. {advice}',
+		longCaptureWarn:
+			'Cette capture prendra environ {duration} de temps réel à la vitesse de lecture 1/{divisor}{passSuffix}.',
+		passSuffix: ', réparties sur {passes} passes sur le même instant',
+		adviceFewerPasses:
+			'Moins de passes se terminent plus tôt, avec moins d’échantillons.',
+		adviceFasterPlayback:
+			'Une vitesse de lecture plus rapide se termine plus tôt, avec moins d’échantillons.',
+		pastLogCap:
+			'Cette capture devrait recueillir environ {samples} échantillons sur {passes} passes, au-delà des {cap} que contient le journal de diagnostic. L’image n’est pas affectée — seules les mesures de régularité et d’écart décriront la première partie de la capture.',
+		interpolationLossy:
+			'À cette taille, l’interpolation {factor}x a déjà coûté des échantillons réels à cette machine. Envisagez un facteur plus faible, une résolution plus basse, ou davantage de passes à la place.',
+	},
+
+	duration: {
+		zero: '0 seconde',
+		seconds: {
+			one: '{count} seconde',
+			other: '{count} secondes',
+		},
+		minutes: {
+			one: '{count} minute',
+			other: '{count} minutes',
+		},
+		minutesSeconds: '{minutes} min {seconds} s',
+	},
+};
+
+export default fr;

--- a/src/locales/index.ts
+++ b/src/locales/index.ts
@@ -1,0 +1,62 @@
+// The catalogue registry.
+//
+// Every locale is imported eagerly rather than fetched on demand. They are text,
+// they total well under a megabyte across all thirteen, and both processes need
+// them synchronously — main phrases a capture refusal inside an IPC handler that
+// has nowhere to await a dynamic import.
+
+import type { MessageCatalog, PluralForms } from '../utilities/i18n';
+import en from './en';
+import cs from './cs';
+import da from './da';
+import de from './de';
+import es from './es';
+import fi from './fi';
+import fr from './fr';
+import it from './it';
+import nl from './nl';
+import no from './no';
+import pl from './pl';
+import pt from './pt';
+import sv from './sv';
+
+// The shape every translation must have, derived from the English catalogue so
+// that a missing or misspelled key is a COMPILE error rather than something the
+// parity test catches later (or a user finds as an English sentence in a German
+// dialog).
+//
+// Plural leaves are deliberately relaxed to the full set of CLDR categories:
+// English needs `one`/`other` and Polish needs `one`/`few`/`many`/`other`, so
+// pinning translations to English's exact forms would make correct Polish a type
+// error. Everything else is exact.
+export type Localized<T> = {
+	[K in keyof T]: T[K] extends string
+		? string
+		: T[K] extends { other: string }
+			? PluralForms
+			: Localized<T[K]>;
+};
+
+export type Catalog = Localized<typeof en>;
+
+// Concrete object types have no string index signature, so they are not directly
+// assignable to MessageCatalog even though they satisfy it structurally. The
+// assertion is confined to this one helper rather than repeated thirteen times.
+const asCatalog = (catalog: Catalog): MessageCatalog =>
+	catalog as unknown as MessageCatalog;
+
+export const CATALOGS: Record<string, MessageCatalog> = {
+	en: asCatalog(en),
+	cs: asCatalog(cs),
+	da: asCatalog(da),
+	de: asCatalog(de),
+	es: asCatalog(es),
+	fi: asCatalog(fi),
+	fr: asCatalog(fr),
+	it: asCatalog(it),
+	nl: asCatalog(nl),
+	no: asCatalog(no),
+	pl: asCatalog(pl),
+	pt: asCatalog(pt),
+	sv: asCatalog(sv),
+};

--- a/src/locales/it.ts
+++ b/src/locales/it.ts
@@ -1,0 +1,479 @@
+// Italian. Translated from en.ts — see that file's header before editing.
+//
+// Product and technology names stay untranslated: iRacing, ReShade, Discord,
+// Windows.Graphics.Capture, WGC, VRAM, GPU, NVIDIA Turing and the file formats.
+
+import type { Catalog } from './index';
+
+const it: Catalog = {
+	notice: {
+		danger: 'Problemi',
+		warning: 'Da sapere',
+		info: 'Note',
+	},
+
+	promo: {
+		greeting: 'Grazie per usare iRacing Screenshot Tool!',
+		signature: 'Creato e mantenuto da AR Media Solutions.',
+	},
+
+	changelog: {
+		title: 'Registro delle modifiche',
+		untitledRelease: 'Versione',
+	},
+
+	gallery: {
+		menu: {
+			openExternally: 'Apri con un’altra applicazione',
+			openFolder: 'Apri cartella',
+			copy: 'Copia',
+			delete: 'Elimina',
+		},
+		copiedToClipboard: '{name} copiato negli appunti',
+	},
+
+	sidebar: {
+		resolution: 'Risoluzione',
+		width: 'Larghezza',
+		height: 'Altezza',
+		output: 'Output:',
+		cropWatermark: 'Ritaglia filigrana',
+		keepAspectRatio: 'Mantieni proporzioni',
+		screenshot: 'Screenshot',
+		custom: 'Personalizzata',
+		vramStatus: '{adapter}{free} liberi su {total}',
+		savedSuccessfully: '{name} salvato correttamente',
+		screenshotFailed: 'Screenshot non riuscito: {message}',
+		errorLogPrefix: 'Registro: ',
+		notices: {
+			exclusiveFullscreen:
+				'iRacing è a schermo intero esclusivo — gli screenshot risulteranno neri. In iRacing imposta Display > Full Screen su OFF (Borderless o Windowed) per abilitare la cattura.',
+			vramRisk:
+				'{resolution} richiede circa {needed} di VRAM in più, ma sono liberi solo {free} — è probabile che iRacing esaurisca la memoria e si chiuda.',
+			vramCaution:
+				'{resolution} lascia poco margine di VRAM ({free} liberi) e può bloccarsi con combinazioni impegnative di pista e vettura.',
+			switchResolution: 'Passa a {resolution}',
+			vramStatic:
+				'Le risoluzioni elevate possono far crashare iRacing se la VRAM si esaurisce. Alcune combinazioni di pista e vettura richiedono più VRAM.',
+			reshade:
+				'Dopo aver premuto il pulsante di screenshot in iRacing Screenshot Tool, dovrai premere la scorciatoia di ReShade per acquisire lo screenshot.',
+			crop: 'Il ritaglio della filigrana ingrandisce leggermente l’immagine finale. Le zone vicine ai bordi dello schermo verranno tagliate.',
+			aspectRatio:
+				'«Mantieni proporzioni» adatta l’altezza dello screenshot alle proporzioni del tuo monitor (per esempio 21:9 ultrawide) invece del 16:9 predefinito. La risoluzione scelta determina la larghezza.',
+		},
+	},
+
+	settings: {
+		title: 'Impostazioni',
+		version: 'Versione - {version}',
+		changelog: 'Registro delle modifiche',
+		openLogsFolder: 'Apri cartella dei registri',
+		checkForUpdates: 'Controlla aggiornamenti',
+		updateCheckFailed: 'Controllo aggiornamenti non riuscito: {message}',
+
+		language: 'Lingua',
+		languageDescription:
+			'La lingua usata in tutta l’applicazione. Rilevata da Windows al primo avvio.',
+
+		screenshotFolder: 'Cartella degli screenshot',
+		selectFolder: 'Scegli cartella',
+		screenshotKeybind: 'Scorciatoia screenshot',
+		editBind: 'Modifica scorciatoia',
+
+		customFilenameFormat: 'Formato nome file personalizzato',
+		customFilenameFormatDescription:
+			'Usa uno schema personalizzato invece di quello predefinito ({track}-{driver}-{counter})',
+		filenameFieldsHint:
+			'Fai clic sui campi per aggiungerli al formato. Digita direttamente i separatori (-, _, ecc.).',
+		reset: 'Ripristina',
+		preview: 'Anteprima:',
+
+		outputFormat: 'Formato di output',
+		formatJpeg: 'JPEG (qualità massima)',
+		formatPng: 'PNG (senza perdita)',
+		formatWebp: 'WebP (qualità 95%)',
+
+		disableTooltips: 'Nascondi i suggerimenti',
+		disableTooltipsDescription: 'Lasciami in pace, so quello che faccio',
+
+		cropTopLeft: 'Preferisci il ritaglio della filigrana in alto a sinistra',
+		cropTopLeftDescription:
+			'Ritaglia solo l’angolo in basso a destra (3%). Se disattivato, lo screenshot viene ritagliato in modo uniforme su tutti i lati (6% in totale) per un risultato centrato.',
+
+		manualWindowRestore: 'Ripristino manuale della finestra',
+		manualWindowRestoreDescription:
+			'Sostituisce il ripristino automatico della finestra con posizione e dimensioni personalizzate. Utile per chi usa un ultrawide o Nvidia Surround.',
+		left: 'Sinistra',
+		top: 'Alto',
+		width: 'Larghezza',
+		height: 'Altezza',
+		restoreNow: 'Ripristina ora',
+
+		nativeCapture: 'Cattura ad alta fedeltà (WGC)',
+		nativeCaptureDescription:
+			'Cattura il colore reale senza sottocampionamento tramite Windows.Graphics.Capture invece della pipeline predefinita (che sottocampiona il colore). Ricorre automaticamente al metodo alternativo se una cattura fallisce.',
+		nativeCaptureUnavailable:
+			'Non disponibile su questo sistema — la cattura ad alta fedeltà non può funzionare qui.',
+		nativeCaptureUnverified:
+			'Windows segnala che è supportata, ma una cattura di prova non è tornata. Le catture ricorreranno automaticamente al metodo alternativo se il problema persiste.',
+
+		reshade: 'Modalità compatibilità ReShade',
+		reshadeDescription:
+			'Usando ReShade dovrai prima usare la scorciatoia di iRacing Screenshot Tool o premere il pulsante, poi usare la scorciatoia di screenshot di ReShade una volta che la finestra di iRacing è stata ridimensionata.',
+		reshadeIni: 'INI di ReShade',
+		selectFile: 'Scegli file',
+	},
+
+	longExposure: {
+		title: 'Lunga esposizione',
+		shutter: 'Tempo di posa',
+		playbackSpeed: 'Velocità di riproduzione',
+		playbackAuto: 'Automatica (dall’obiettivo di campioni)',
+		playbackRealTime: '1x (tempo reale)',
+		targetSamples: 'Obiettivo di campioni',
+		advanced: 'Avanzate',
+		defaultsSummary: '{count} valori predefiniti',
+
+		weighting: 'Ponderazione',
+		weightingBox: 'Box (uniforme)',
+		weightingLinear: 'Lineare (nitida alla fine)',
+		weightingEase: 'Ease (testa più nitida, coda lunga)',
+
+		interpolation: 'Interpolazione dei fotogrammi',
+		interpolationOff: 'Disattivata',
+		interpolation2: '2× (un fotogramma intermedio)',
+		interpolation4: '4× (tre fotogrammi intermedi)',
+		interpolation8: '8× (sette fotogrammi intermedi)',
+
+		passes: 'Passaggi',
+		passes1: '1 (passaggio singolo)',
+		passes2: '2× — attesa doppia',
+		passes4: '4× — attesa quadrupla',
+		passes8: '8× — attesa ottupla',
+
+		bracket: 'Bracketing dei tempi',
+		highlightRecovery: 'Recupero delle alte luci (stop)',
+
+		cancel: 'Annulla',
+		saved: 'Lunga esposizione salvata — {count} campioni',
+		failed: 'Lunga esposizione non riuscita',
+
+		modified: {
+			weighting_linear: 'lineare',
+			weighting_ease: 'ease',
+			interpolation: 'interpolazione {factor}×',
+			passes: {
+				one: '{count} passaggio',
+				other: '{count} passaggi',
+			},
+			bracketed: 'bracketing',
+			recovery: 'recupero di {stops} stop',
+		},
+
+		progress: {
+			working: 'Elaborazione…',
+			seeking: 'Ricerca…{pass}',
+			accumulating: 'Esposizione… {count} campioni{pass}',
+			resolving: 'Sviluppo…',
+			restoring: 'Ripristino del replay…',
+			pass: ' (passaggio {current} di {total})',
+		},
+
+		notices: {
+			needsNativeCapture:
+				'La lunga esposizione richiede la cattura ad alta fedeltà (WGC), attualmente disattivata. Attivala nelle impostazioni per usarla.',
+			unavailableWithReason:
+				'La lunga esposizione non è disponibile su questa macchina: {reason}',
+			unavailable:
+				'La lunga esposizione non è disponibile su questa macchina.',
+			interpolationCost:
+				'L’interpolazione inventa fotogrammi tra quelli reali per rendere più fluida la scia. Costa tempo GPU per fotogramma, quindi confronta il numero di campioni reali dello scatto salvato con lo stesso scatto senza interpolazione: se quel numero cala, sta acquistando campioni inventati con campioni reali.',
+			passesAndInterpolation:
+				'Passaggi e interpolazione competono per lo stesso budget per fotogramma. Con entrambi attivi ogni passaggio cattura meno fotogrammi reali — disattivare l’interpolazione di solito dà uno scatto migliore a parità di attesa.',
+			passes:
+				'Ogni passaggio ripete lo stesso istante e recupera fotogrammi che gli altri hanno perso, così la scia diventa più uniforme anziché più luminosa. Ideale con tempi di posa rapidi, dove un singolo passaggio raccoglie pochissimi campioni.',
+			interpolationUnsupported:
+				'L’interpolazione dei fotogrammi richiede una GPU NVIDIA Turing o più recente{adapter}. Tutto il resto della lunga esposizione funziona normalmente.',
+			interpolationAdapter: ' (questa cattura viene eseguita su {adapter})',
+			reshade:
+				'La lunga esposizione cattura in modo nativo e non usa ReShade, quindi gli effetti ReShade non compariranno nel risultato.',
+		},
+	},
+
+	help: {
+		title: 'Guida',
+		sections: 'Sezioni della guida',
+		tabGeneral: 'Generale',
+		tabLongExposure: 'Lunga esposizione',
+
+		general: {
+			iracingSettings: 'Impostazioni di iRacing',
+			borderless: 'iRacing deve essere in esecuzione in Windowed Borderless',
+			vram: 'Per screenshot in 8K o superiori si consigliano almeno 8 GB di VRAM',
+			newerContent: 'Piste e vetture più recenti richiedono più VRAM',
+			shrinkUi:
+				'Riduci l’interfaccia al minimo prima di scattare se usi l’opzione di ritaglio della filigrana: «Control+PageDown» la rimpicciolisce. Se non funziona, potresti dover reimpostare lo zoom dell’interfaccia nelle impostazioni di iRacing.',
+
+			screenshotFolder: 'Cartella degli screenshot',
+			screenshotFolderBody:
+				'Gli screenshot vengono salvati per impostazione predefinita in «C:\\Users\\user\\Pictures\\Screenshots»; il percorso si può cambiare nelle impostazioni.',
+
+			screenshotHotkey: 'Scorciatoia screenshot',
+			screenshotHotkeyBody:
+				'Per impostazione predefinita «Control + PrintScreen» scatta uno screenshot con le impostazioni correnti; la scorciatoia si può cambiare nelle impostazioni.',
+
+			issues: 'Problemi',
+			issuesBody: 'Se riscontri problemi, segnalali sul',
+			discord: 'Discord',
+
+			instructions: 'Istruzioni',
+			step1: 'iRacing <b>deve</b> essere in esecuzione in modalità Windowed Borderless',
+			step2: 'Avvia iRacing e posiziona la telecamera dove vuoi scattare',
+			step3: 'Scegli la risoluzione desiderata (prova risoluzioni più basse prima di passare all’8K)',
+			step4: 'Decidi se ritagliare la filigrana di iRacing; in tal caso dovrai prima ridurre l’interfaccia di iRacing alla dimensione minima con «Control + PageDown»',
+			step5: 'Premi il pulsante di screenshot o usa la scorciatoia «Control + PrintScreen» per scattare',
+			step6: 'A seconda della risoluzione scelta possono volerci alcuni secondi; quando la finestra di iRacing torna alle dimensioni normali, l’operazione è conclusa',
+			step7: 'Lo screenshot verrà salvato in «C:\\Users\\{User}\\Pictures\\Screenshots»',
+		},
+
+		longExposure: {
+			whatItDoes: 'Che cosa fa',
+			whatItDoesBody:
+				'Una lunga esposizione fonde molti fotogrammi di un replay in una sola immagine, come fa un otturatore lasciato aperto: ciò che è fermo resta nitido, ciò che si muove lascia una scia. Lo strumento pilota il replay stesso, cattura ogni fotogramma presentato dal simulatore e li somma sulla GPU.',
+
+			shutter: 'Tempo di posa',
+			shutterBody:
+				'Quanto dura l’esposizione <i>in tempo di replay</i>, da una frazione di un fotogramma di replay fino a dieci secondi. È questa impostazione a decidere la lunghezza delle scie. I tempi più lunghi raccolgono anche più fotogrammi, quindi hanno meno bisogno di tutto ciò che segue; gli scatti più rapidi coprono un solo fotogramma di replay e raccolgono appena una manciata di campioni.',
+
+			playback: 'Velocità di riproduzione',
+			playbackBody:
+				'Il replay viene riprodotto al rallentatore mentre l’esposizione viene catturata, così il simulatore presenta più fotogrammi per secondo di tempo di replay e la fusione ottiene più campioni. 1/16 raccoglie circa sedici volte i fotogrammi del tempo reale — e richiede sedici volte il tempo effettivo. È il compromesso principale di questo pannello: pazienza in cambio di morbidezza.',
+			playbackAutoBody:
+				'«Automatica (dall’obiettivo di campioni)» sceglie la velocità al posto tuo partendo dall’<b>obiettivo di campioni</b>: lo strumento calcola la riproduzione più rapida che raggiunge ancora il numero richiesto. Imposta invece una velocità esplicita se preferisci limitare l’attesa.',
+
+			weighting: 'Ponderazione',
+			weightingBody:
+				'Quanto ogni fotogramma catturato contribuisce al risultato. <b>Box</b> li pesa tutti allo stesso modo e dà una scia uniforme. <b>Lineare</b> cresce verso la fine della finestra, così il soggetto è più nitido dove ha terminato e sfuma lungo il suo percorso. <b>Ease</b> è la stessa idea con una testa più nitida e una coda più lunga.',
+
+			interpolation: 'Interpolazione dei fotogrammi',
+			interpolationBody:
+				'Inventa fotogrammi aggiuntivi tra quelli reali usando il motore di flusso ottico della GPU, colmando i vuoti lungo la scia. Richiede una scheda NVIDIA Turing o più recente ed è completamente nascosta sull’hardware che non può farlo.',
+			interpolationCostBody:
+				'Non è gratis: costa tempo GPU su ogni fotogramma catturato, e il budget è un fotogramma di iRacing. Se non tiene il passo comincia a perdere fotogrammi <i>reali</i> per fabbricarne di sintetici, il che è una perdita netta: la scia risulta più corta e più grossolana. Il costo cresce con i megapixel moltiplicati per il fattore, quindi ciò che è comodo a 2560×1440 non è praticabile in 8K. Per verificarlo, scatta due volte lo stesso istante, con e senza, e confronta il numero di campioni reali; l’app ti avvisa anche a posteriori se uno scatto è rimasto corto.',
+
+			passes: 'Passaggi',
+			passesBody:
+				'Visita più volte lo stesso istante, accumulando in un’unica immagine. Ogni passaggio recupera fotogrammi che gli altri hanno mancato, così la scia diventa più uniforme — non più luminosa, perché il risultato è normalizzato in base alla luce realmente arrivata su ciascun pixel.',
+			passesTradeBody:
+				'I passaggi comprano la stessa cosa dell’interpolazione, ma con un’altra moneta: tempo effettivo invece di tempo GPU. Otto passaggi richiedono circa otto volte il tempo, ma non possono mai costarti fotogrammi reali. Questo li rende la leva giusta alle alte risoluzioni, dove l’interpolazione non tiene il passo, e con tempi di posa rapidi, dove un singolo passaggio raccoglie pochissimi campioni. Usarli entrambi insieme è di solito il peggio dei due — competono per lo stesso budget per fotogramma.',
+
+			bracket: 'Bracketing dei tempi',
+			bracketBody:
+				'Produce un’immagine per ogni tempo di posa uguale o più rapido di quello scelto, da una singola cattura. Uno scatto a 1/60 ti dà anche 1/125, 1/250, 1/500 e 1/1000 — lo stesso istante con scie via via più corte — così puoi scegliere l’effetto dopo, invece di tirare a indovinare e riscattare.',
+			bracketCostBody:
+				'Non costa quasi tempo aggiuntivo. Ogni tempo termina sullo stesso fotogramma e differisce solo per quanto indietro arriva, quindi un tempo più rapido è semplicemente la coda dei fotogrammi che stanno già passando: vengono riempiti tutti da un solo passaggio del replay.',
+			bracketMemoryBody:
+				'Ciò che costa davvero è la memoria. Ogni tempo ha bisogno del proprio accumulatore a piena risoluzione, quindi undici tempi richiedono undici volte la memoria video di uno solo, che in 8K è più di quanta ne abbiano la maggior parte delle schede. La cattura lo verifica prima di iniziare e rifiuta anziché far crashare iRacing: se un bracketing viene rifiutato, abbassa la risoluzione o scegli un tempo più rapido, il che accorcia anche la scala.',
+			bracketNamingBody:
+				'Il tempo che hai scelto viene salvato con il nome consueto ed è quello che compare nella galleria; gli altri restano accanto, con il loro tempo di posa nel nome del file.',
+
+			highlights: 'Recupero delle alte luci',
+			highlightsBody:
+				'Esalta le alte luci prossime al clipping prima che i fotogrammi vengano sommati, poi annulla l’esaltazione alla fine. iRacing consegna un’immagine già sottoposta a tone mapping, quindi un faro e un muro bianco arrivano con lo stesso valore; mediarli trasforma una luce intensa che attraversa parte dell’esposizione in una macchia grigia invece che in una scia luminosa. Questo riporta la non linearità dove ce l’ha un sensore reale. Si misura in stop; 0 la disattiva e non cambia assolutamente nulla.',
+
+			whatItSaves: 'Che cosa salva',
+			whatItSavesBody:
+				'Dimensioni, ritaglio della filigrana e formato del file seguono gli stessi controlli di uno screenshot normale — le impostazioni Risoluzione e Ritaglia filigrana qui sopra e il formato di output nelle impostazioni. La riga «Output» in cima alla barra laterale mostra esattamente ciò che otterrai.',
+			whatItSavesPngBody:
+				'Scegliere PNG scrive un vero master a 16 bit, utile se intendi fare la color correction dopo, più un’anteprima a 8 bit per la galleria. È anche molto più lento da scrivere alle alte risoluzioni: un PNG a 16 bit da 33 megapixel richiede una decina di secondi, mentre lo stesso fotogramma in JPEG meno di uno.',
+
+			troubleshooting: 'Se il risultato non convince',
+			troubleGhosts:
+				'<b>Fantasmi distinti invece di una scia uniforme</b> — troppo pochi campioni. Usa una velocità di riproduzione più lenta, più passaggi o una risoluzione inferiore.',
+			troubleShutter:
+				'<b>Non sai quale tempo volevi</b> — attiva il bracketing dei tempi e decidi dopo, a parità di attesa.',
+			troubleHighlights:
+				'<b>Alte luci bruciate o piatte</b> — prova da 3 a 5 stop di recupero delle alte luci.',
+			troubleBlack:
+				'<b>Un’immagine nera</b> — iRacing è a schermo intero esclusivo. Imposta Display &gt; Full Screen su OFF.',
+			troubleSidecar:
+				'Ogni scatto registra le impostazioni esatte usate, il numero di campioni e quanto uniformemente sono caduti, in un file .json nella cartella dei registri accanto ad app.log. Vengono conservati gli ultimi 20 scatti — un bracketing conta come uno — così lo scatto di cui stai chiedendo è ancora lì mentre lo chiedi.',
+		},
+	},
+
+	update: {
+		checking: 'Ricerca di aggiornamenti…',
+		newVersion: 'Una nuova versione',
+		availableBusy:
+			'{version} è disponibile. È in corso una cattura — potrai scaricarla non appena sarà terminata.',
+		available: '{version} è disponibile. Fai clic per scaricarla.',
+		downloading: 'Download di {version}…',
+		downloadingPercent: 'Download di {version} — {percent}%',
+		downloadedBusy:
+			'{version} è pronta. È in corso una cattura, quindi verrà installata alla chiusura dell’applicazione.',
+		downloaded: '{version} è pronta. Fai clic per riavviare e installarla.',
+		failed: 'Controllo aggiornamenti non riuscito: {error}',
+		unknownError: 'errore sconosciuto',
+		neverChecked:
+			'Non è ancora stato effettuato alcun controllo degli aggiornamenti (stai usando la v{version}).',
+		upToDate: 'Stai usando la versione più recente (v{version}).',
+
+		alreadyDownloading: 'L’aggiornamento è già in fase di download.',
+		alreadyDownloaded: 'L’aggiornamento è già stato scaricato.',
+		nothingToDownload: 'Non c’è alcun aggiornamento da scaricare.',
+		captureInProgress:
+			'È in corso una cattura. Riprova quando sarà terminata.',
+		nothingToInstall: 'Nessun aggiornamento pronto per l’installazione.',
+		captureInProgressInstall:
+			'È in corso una cattura. L’aggiornamento si installerà da solo alla chiusura dell’applicazione.',
+		devBuildOnly:
+			'Il controllo degli aggiornamenti funziona solo in una versione installata.',
+
+		installTitle: 'Installa aggiornamento',
+		installMessage: 'Installare la versione {version}?',
+		installFallbackVersion: 'aggiornamento',
+		installDetail:
+			'L’applicazione si chiuderà e si riaprirà una volta installato l’aggiornamento. Se scegli «Più tardi», si installerà da solo alla prossima chiusura.',
+		installConfirm: 'Riavvia e installa',
+		installLater: 'Più tardi',
+	},
+
+	filenameFields: {
+		categories: {
+			Track: 'Pista',
+			Driver: 'Pilota',
+			Session: 'Sessione',
+			Meta: 'Meta',
+		},
+		track: 'Pista',
+		trackFull: 'Pista completa',
+		trackCity: 'Città',
+		trackCountry: 'Paese',
+		trackType: 'Tipo di pista',
+		driver: 'Pilota',
+		driverAbbrev: 'Pilota abbreviato',
+		driverInitials: 'Iniziali',
+		team: 'Team',
+		carNumber: 'N. vettura',
+		car: 'Vettura',
+		carFull: 'Vettura completa',
+		carClass: 'Classe vettura',
+		iRating: 'iRating',
+		sessionType: 'Tipo di sessione',
+		sessionName: 'Nome sessione',
+		lap: 'Giro',
+		date: 'Data',
+		time: 'Ora',
+		datetime: 'Data+ora',
+		counter: 'Contatore',
+	},
+
+	iracingConfig: {
+		projections:
+			'Disattiva «Render Scene Using 3 Projections» in iRacing (scheda Display > Monitor) per evitare bande verticali negli screenshot',
+	},
+
+	wgc: {
+		cursorCaveat:
+			'Il puntatore del mouse può comparire nelle catture su questa versione di Windows. Windows 10 versione 2004 ha introdotto il controllo che lo nasconde.',
+		addonUnavailable:
+			'Non è stato possibile caricare il componente di cattura ad alta fedeltà su questo sistema.',
+		osUnsupported:
+			'Windows.Graphics.Capture non è disponibile su questa versione di Windows. Richiede Windows 10 versione 1903 o successiva.',
+		nativeCaptureOff: 'La cattura ad alta fedeltà (WGC) è disattivata',
+	},
+
+	capture: {
+		exclusiveFullscreen:
+			'iRacing è a schermo intero esclusivo, quindi lo screenshot risulterebbe nero. In iRacing imposta Display > Full Screen su OFF (usa Borderless o Windowed) e riprova.',
+		exclusiveFullscreenUnattributed:
+			'Un’applicazione è a schermo intero esclusivo, il che produce una cattura nera. Se iRacing è a schermo intero, imposta Display > Full Screen su OFF (usa Borderless o Windowed) e riprova.',
+		unknownError: 'Errore sconosciuto dello screenshot',
+		outputTooSmall: 'La cattura è troppo piccola ({width}x{height})',
+		blackFrame:
+			'Il fotogramma catturato è nero — la sorgente di cattura potrebbe non aver funzionato (su alcune configurazioni Windows i contenuti accelerati dalla GPU non si lasciano catturare)',
+		noSource:
+			'Nessuna sorgente di cattura del desktop trovata per la finestra {windowId}',
+		metadataTimeout:
+			'Tempo scaduto in attesa dei metadati video della cattura',
+		noVideoFrame:
+			'Il flusso di cattura non ha prodotto alcun fotogramma video',
+		dimensionTimeout:
+			'Tempo scaduto in attesa delle dimensioni della finestra {width}x{height}; si procede con {actualWidth}x{actualHeight}',
+	},
+
+	longExposureCapture: {
+		busy: 'È già in corso una cattura.',
+		needsNativeCapture:
+			'La lunga esposizione richiede la cattura ad alta fedeltà (WGC). Attivala nelle impostazioni per usarla.',
+		unavailable: 'La lunga esposizione non è disponibile su questa macchina.',
+		noTelemetry:
+			'La lunga esposizione richiede la telemetria di replay di iRacing. Verifica che il simulatore sia in esecuzione e all’interno di una sessione.',
+		windowNotFound: 'Finestra di iRacing non trovata.',
+		cancelled: 'Cattura annullata.',
+		seekTimeout:
+			'Il replay non ha raggiunto il fotogramma {frame} in tempo. Potrebbe essere ancora in caricamento.',
+		noPasses: 'Una cattura deve eseguire almeno un passaggio.',
+		playbackStalled:
+			'Il replay non è partito. Verifica che iRacing non sia stato messo in pausa da un altro strumento.',
+		exposureTimeout:
+			'L’esposizione non ha raggiunto il fotogramma {frame} entro {seconds} s.',
+		endedEarly:
+			'L’esposizione è terminata prima di raggiungere l’istante selezionato.',
+		noFramesPresented:
+			'iRacing non ha presentato alcun fotogramma da catturare.',
+		subFrameNoSamples:
+			'Questo tempo di posa è più breve di un fotogramma di replay e iRacing non ne ha renderizzato nessuno al suo interno. Prova una velocità di riproduzione più lenta, o il tempo di posa immediatamente più lungo.',
+		noSamples:
+			'Non è stato accumulato alcun fotogramma. iRacing potrebbe aver smesso di renderizzare durante l’esposizione.',
+		withNativeError: '{reason} ({error})',
+		resolveFailed: 'La GPU non ha restituito alcuna immagine.',
+		bracketShortfall:
+			'Il bracketing ha richiesto {asked} tempi ma ne sono tornati {returned} — gli altri non si sono risolti, oppure questa versione del componente di cattura è precedente al bracketing.',
+	},
+
+	validation: {
+		windowBeforeStart:
+			'L’esposizione richiede {frames} fotogrammi di replay prima dell’istante selezionato, ma questo si trova solo a {anchor} fotogrammi dall’inizio del replay. Scegli un istante successivo o un tempo di posa più rapido.',
+		pastEnd: 'L’istante selezionato è oltre la fine del replay.',
+		sessionChanged:
+			'Il replay è passato a un’altra sessione da quando questo scatto è stato impostato. Seleziona di nuovo l’istante.',
+		singleSampleMultiPass:
+			'Questo tempo di posa è così breve che vi cade circa un solo fotogramma per passaggio, quindi {passes} passaggi raccolgono all’incirca {passes} campioni. Una velocità di riproduzione o un tempo di posa più lenti ne portano molti di più.',
+		singleSample:
+			'Questo tempo di posa è così breve che vi cadrà un solo fotogramma, quindi il risultato non avrà alcuna sfocatura di movimento. Una velocità di riproduzione o un tempo di posa più lenti portano campioni.',
+		bracketVsInterpolation:
+			'Il bracketing dei tempi e l’interpolazione dei fotogrammi {factor}x non possono funzionare insieme, quindi questo scatto sarà eseguito senza interpolazione. Disattiva il bracketing se i fotogrammi intermedi contano più dei tempi aggiuntivi.',
+		passesVsInterpolation:
+			'Sono attivi sia i passaggi multipli sia l’interpolazione {factor}x. Competono tra loro: l’interpolazione rallenta ogni passaggio al punto da fargli perdere fotogrammi reali, così la stessa attesa compra meno campioni reali di quanti ne comprerebbero i soli passaggi. Disattivare l’interpolazione di solito dà uno scatto migliore.',
+		shortOfTarget:
+			'Anche a velocità 1/{divisor} questa esposizione raggiunge circa {samples} campioni, meno dei {target} richiesti. Usa un tempo di posa più lungo per ottenerne di più.',
+		longCaptureEscalate:
+			'Questa cattura riproduce il replay a velocità 1/{divisor} per circa {duration} di tempo reale{passSuffix} e non può essere accelerata una volta avviata. {advice}',
+		longCaptureWarn:
+			'Questa cattura richiederà circa {duration} di tempo reale a velocità di riproduzione 1/{divisor}{passSuffix}.',
+		passSuffix: ', distribuiti su {passes} passaggi sullo stesso istante',
+		adviceFewerPasses: 'Meno passaggi finiscono prima, con meno campioni.',
+		adviceFasterPlayback:
+			'Una velocità di riproduzione più alta finisce prima, con meno campioni.',
+		pastLogCap:
+			'Si prevede che questa cattura raccolga circa {samples} campioni su {passes} passaggi, oltre i {cap} che il registro diagnostico può contenere. L’immagine non ne risente — solo i dati di uniformità e di intervallo descriveranno la prima parte della cattura.',
+		interpolationLossy:
+			'A queste dimensioni, l’interpolazione {factor}x è già costata campioni reali a questa macchina. Valuta un fattore più basso, una risoluzione inferiore o, in alternativa, più passaggi.',
+	},
+
+	duration: {
+		zero: '0 secondi',
+		seconds: {
+			one: '{count} secondo',
+			other: '{count} secondi',
+		},
+		minutes: {
+			one: '{count} minuto',
+			other: '{count} minuti',
+		},
+		minutesSeconds: '{minutes} min {seconds} s',
+	},
+};
+
+export default it;

--- a/src/locales/nl.ts
+++ b/src/locales/nl.ts
@@ -1,0 +1,477 @@
+// Dutch. Translated from en.ts — see that file's header before editing.
+//
+// Product and technology names stay untranslated: iRacing, ReShade, Discord,
+// Windows.Graphics.Capture, WGC, VRAM, GPU, NVIDIA Turing and the file formats.
+
+import type { Catalog } from './index';
+
+const nl: Catalog = {
+	notice: {
+		danger: 'Problemen',
+		warning: 'Goed om te weten',
+		info: 'Opmerkingen',
+	},
+
+	promo: {
+		greeting: 'Bedankt voor het gebruik van iRacing Screenshot Tool!',
+		signature: 'Gemaakt en onderhouden door AR Media Solutions.',
+	},
+
+	changelog: {
+		title: 'Wijzigingslogboek',
+		untitledRelease: 'Versie',
+	},
+
+	gallery: {
+		menu: {
+			openExternally: 'Openen met andere app',
+			openFolder: 'Map openen',
+			copy: 'Kopiëren',
+			delete: 'Verwijderen',
+		},
+		copiedToClipboard: '{name} gekopieerd naar het klembord',
+	},
+
+	sidebar: {
+		resolution: 'Resolutie',
+		width: 'Breedte',
+		height: 'Hoogte',
+		output: 'Uitvoer:',
+		cropWatermark: 'Watermerk bijsnijden',
+		keepAspectRatio: 'Beeldverhouding behouden',
+		screenshot: 'Schermafbeelding',
+		custom: 'Aangepast',
+		vramStatus: '{adapter}{free} vrij van {total}',
+		savedSuccessfully: '{name} succesvol opgeslagen',
+		screenshotFailed: 'Schermafbeelding mislukt: {message}',
+		errorLogPrefix: 'Logboek: ',
+		notices: {
+			exclusiveFullscreen:
+				'iRacing draait in exclusief volledig scherm — schermafbeeldingen worden zwart. Zet in iRacing Display > Full Screen op OFF (Borderless of Windowed) om vastleggen mogelijk te maken.',
+			vramRisk:
+				'{resolution} heeft ongeveer {needed} extra VRAM nodig, maar er is slechts {free} vrij — iRacing raakt waarschijnlijk zonder geheugen en loopt vast.',
+			vramCaution:
+				'{resolution} laat weinig VRAM-marge over ({free} vrij) en kan vastlopen bij zware baan-/autocombinaties.',
+			switchResolution: 'Overschakelen naar {resolution}',
+			vramStatic:
+				'Hoge resoluties kunnen iRacing laten vastlopen als je zonder VRAM komt te zitten. Bepaalde baan-/autocombinaties vragen meer VRAM.',
+			reshade:
+				'Nadat je in iRacing Screenshot Tool op de knop hebt gedrukt, moet je nog je ReShade-sneltoets voor schermafbeeldingen indrukken.',
+			crop: 'Het bijsnijden van het watermerk zoomt de uiteindelijke afbeelding iets in. Gebieden dicht bij de schermranden vallen weg.',
+			aspectRatio:
+				'„Beeldverhouding behouden” past de hoogte van de schermafbeelding aan de verhouding van je monitor aan (bijvoorbeeld 21:9 ultrawide) in plaats van de standaard 16:9. De gekozen resolutie bepaalt de breedte.',
+		},
+	},
+
+	settings: {
+		title: 'Instellingen',
+		version: 'Versie - {version}',
+		changelog: 'Wijzigingslogboek',
+		openLogsFolder: 'Logboekmap openen',
+		checkForUpdates: 'Controleren op updates',
+		updateCheckFailed: 'Controle op updates mislukt: {message}',
+
+		language: 'Taal',
+		languageDescription:
+			'De taal die in de hele app wordt gebruikt. Bij de eerste start overgenomen uit Windows.',
+
+		screenshotFolder: 'Map voor schermafbeeldingen',
+		selectFolder: 'Map kiezen',
+		screenshotKeybind: 'Sneltoets voor schermafbeelding',
+		editBind: 'Sneltoets wijzigen',
+
+		customFilenameFormat: 'Aangepaste bestandsnaamindeling',
+		customFilenameFormatDescription:
+			'Gebruik een eigen patroon in plaats van de standaard ({track}-{driver}-{counter})',
+		filenameFieldsHint:
+			'Klik op velden om ze aan de indeling toe te voegen. Typ scheidingstekens (-, _, enz.) rechtstreeks.',
+		reset: 'Herstellen',
+		preview: 'Voorbeeld:',
+
+		outputFormat: 'Uitvoerformaat',
+		formatJpeg: 'JPEG (maximale kwaliteit)',
+		formatPng: 'PNG (verliesvrij)',
+		formatWebp: 'WebP (kwaliteit 95%)',
+
+		disableTooltips: 'Tips verbergen',
+		disableTooltipsDescription: 'Laat me met rust, ik weet wat ik doe',
+
+		cropTopLeft: 'Watermerk bij voorkeur linksboven bijsnijden',
+		cropTopLeftDescription:
+			'Snijdt alleen de rechteronderhoek bij (3%). Staat dit uit, dan wordt de schermafbeelding gelijkmatig aan alle kanten bijgesneden (6% in totaal), voor een gecentreerd resultaat.',
+
+		manualWindowRestore: 'Venster handmatig herstellen',
+		manualWindowRestoreDescription:
+			'Vervangt het automatisch herstellen van het venster door een eigen positie en grootte. Handig voor gebruikers van een ultrawide of Nvidia Surround.',
+		left: 'Links',
+		top: 'Boven',
+		width: 'Breedte',
+		height: 'Hoogte',
+		restoreNow: 'Nu herstellen',
+
+		nativeCapture: 'High-fidelity vastlegging (WGC)',
+		nativeCaptureDescription:
+			'Legt echte, niet-gesubsampelde kleur vast via Windows.Graphics.Capture in plaats van via de standaardpijplijn (die kleur subsampelt). Valt automatisch terug als een opname mislukt.',
+		nativeCaptureUnavailable:
+			'Niet beschikbaar op dit systeem — high-fidelity vastlegging kan hier niet werken.',
+		nativeCaptureUnverified:
+			'Windows meldt dat dit wordt ondersteund, maar een testopname kwam niet terug. Opnames vallen automatisch terug als het blijft mislukken.',
+
+		reshade: 'ReShade-compatibiliteitsmodus',
+		reshadeDescription:
+			'Bij gebruik van ReShade moet je eerst de sneltoets van iRacing Screenshot Tool gebruiken of op de knop drukken, en daarna je ReShade-sneltoets voor schermafbeeldingen zodra het iRacing-venster van formaat is veranderd.',
+		reshadeIni: 'ReShade-INI',
+		selectFile: 'Bestand kiezen',
+	},
+
+	longExposure: {
+		title: 'Lange sluitertijd',
+		shutter: 'Sluitertijd',
+		playbackSpeed: 'Afspeelsnelheid',
+		playbackAuto: 'Automatisch (op basis van doelaantal)',
+		playbackRealTime: '1x (realtime)',
+		targetSamples: 'Doelaantal samples',
+		advanced: 'Geavanceerd',
+		defaultsSummary: '{count} standaardwaarden',
+
+		weighting: 'Weging',
+		weightingBox: 'Box (gelijkmatig)',
+		weightingLinear: 'Lineair (scherp aan het eind)',
+		weightingEase: 'Ease (scherpere kop, lange staart)',
+
+		interpolation: 'Beeldinterpolatie',
+		interpolationOff: 'Uit',
+		interpolation2: '2× (één tussenbeeld)',
+		interpolation4: '4× (drie tussenbeelden)',
+		interpolation8: '8× (zeven tussenbeelden)',
+
+		passes: 'Doorgangen',
+		passes1: '1 (één doorgang)',
+		passes2: '2× — twee keer zo lang wachten',
+		passes4: '4× — vier keer zo lang wachten',
+		passes8: '8× — acht keer zo lang wachten',
+
+		bracket: 'Sluitertijdenreeks',
+		highlightRecovery: 'Hoge lichten herstellen (stops)',
+
+		cancel: 'Annuleren',
+		saved: 'Lange sluitertijd opgeslagen — {count} samples',
+		failed: 'Lange sluitertijd mislukt',
+
+		modified: {
+			weighting_linear: 'lineair',
+			weighting_ease: 'ease',
+			interpolation: '{factor}× interpolatie',
+			passes: {
+				one: '{count} doorgang',
+				other: '{count} doorgangen',
+			},
+			bracketed: 'reeks',
+			recovery: '{stops} stops herstel',
+		},
+
+		progress: {
+			working: 'Bezig…',
+			seeking: 'Zoeken…{pass}',
+			accumulating: 'Belichten… {count} samples{pass}',
+			resolving: 'Ontwikkelen…',
+			restoring: 'Replay herstellen…',
+			pass: ' (doorgang {current} van {total})',
+		},
+
+		notices: {
+			needsNativeCapture:
+				'Lange sluitertijd vereist high-fidelity vastlegging (WGC), die momenteel uitstaat. Schakel deze in bij de instellingen om lange sluitertijd te gebruiken.',
+			unavailableWithReason:
+				'Lange sluitertijd is niet beschikbaar op deze machine: {reason}',
+			unavailable: 'Lange sluitertijd is niet beschikbaar op deze machine.',
+			interpolationCost:
+				'Interpolatie verzint beelden tussen de echte om de streep gelijkmatiger te maken. Het kost GPU-tijd per beeld, dus vergelijk het aantal echte samples van de opgeslagen opname met dezelfde opname zonder interpolatie — daalt dat aantal, dan koopt zij verzonnen samples met echte.',
+			passesAndInterpolation:
+				'Doorgangen en interpolatie concurreren om hetzelfde budget per beeld. Staan beide aan, dan legt elke doorgang minder echte beelden vast — interpolatie uitzetten levert meestal een betere opname op bij dezelfde wachttijd.',
+			passes:
+				'Elke doorgang speelt hetzelfde moment opnieuw af en vangt beelden op die de andere misten, zodat de streep gelijkmatiger wordt in plaats van helderder. Vooral nuttig bij korte sluitertijden, waar één doorgang maar een handjevol samples oplevert.',
+			interpolationUnsupported:
+				'Beeldinterpolatie vereist een NVIDIA Turing-GPU of nieuwer{adapter}. Al het andere aan lange sluitertijd werkt gewoon.',
+			interpolationAdapter: ' (deze opname draait op {adapter})',
+			reshade:
+				'Lange sluitertijd legt natively vast en gebruikt ReShade niet, dus ReShade-effecten verschijnen niet in het resultaat.',
+		},
+	},
+
+	help: {
+		title: 'Help',
+		sections: 'Helponderdelen',
+		tabGeneral: 'Algemeen',
+		tabLongExposure: 'Lange sluitertijd',
+
+		general: {
+			iracingSettings: 'iRacing-instellingen',
+			borderless: 'iRacing moet draaien in Windowed Borderless',
+			vram: 'Minstens 8 GB VRAM wordt aanbevolen voor schermafbeeldingen van 8K of hoger',
+			newerContent: 'Nieuwere banen en auto’s vragen meer VRAM',
+			shrinkUi:
+				'Verklein de interface zo ver mogelijk voordat je een schermafbeelding maakt als je het watermerk laat bijsnijden; „Control+PageDown” verkleint hem. Werkt dat niet, dan moet je mogelijk de UI-zoom in de iRacing-instellingen herstellen.',
+
+			screenshotFolder: 'Map voor schermafbeeldingen',
+			screenshotFolderBody:
+				'Schermafbeeldingen worden standaard opgeslagen in „C:\\Users\\user\\Pictures\\Screenshots”; dit kan bij de instellingen worden gewijzigd.',
+
+			screenshotHotkey: 'Sneltoets voor schermafbeelding',
+			screenshotHotkeyBody:
+				'Standaard maakt „Control + PrintScreen” een schermafbeelding met de huidige instellingen; dit kan bij de instellingen worden gewijzigd.',
+
+			issues: 'Problemen',
+			issuesBody: 'Heb je problemen, meld ze dan op de',
+			discord: 'Discord',
+
+			instructions: 'Instructies',
+			step1: 'iRacing <b>moet</b> draaien in de modus Windowed Borderless',
+			step2: 'Start iRacing en zet de camera op de plek waar je de schermafbeelding wilt maken',
+			step3: 'Kies de gewenste resolutie (probeer lagere resoluties voordat je naar 8K gaat)',
+			step4: 'Bepaal of je het iRacing-watermerk wilt bijsnijden; zo ja, verklein dan eerst de iRacing-interface met „Control + PageDown” tot de kleinste stand',
+			step5: 'Druk op de knop voor schermafbeeldingen of gebruik de sneltoets „Control + PrintScreen” om de opnames te maken',
+			step6: 'Afhankelijk van de gekozen resolutie kan dit enkele seconden duren; zodra je iRacing-venster weer zijn normale formaat heeft, is het klaar',
+			step7: 'Je schermafbeelding wordt opgeslagen in „C:\\Users\\{User}\\Pictures\\Screenshots”',
+		},
+
+		longExposure: {
+			whatItDoes: 'Wat het doet',
+			whatItDoesBody:
+				'Een lange sluitertijd mengt veel beelden uit een replay tot één afbeelding, net zoals het openlaten van een camerasluiter: wat stilstaat blijft scherp, wat beweegt trekt een streep. De tool bestuurt de replay zelf, legt elk beeld vast dat de sim toont en telt ze op de GPU bij elkaar op.',
+
+			shutter: 'Sluitertijd',
+			shutterBody:
+				'Hoe lang de belichting duurt <i>in replaytijd</i>, van een fractie van één replaybeeld tot tien seconden. Deze instelling bepaalt hoe lang de strepen worden. Langere sluitertijden verzamelen ook meer beelden en hebben daardoor minder hulp nodig van al het onderstaande; de kortste standen beslaan één enkel replaybeeld en verzamelen maar een handjevol samples.',
+
+			playback: 'Afspeelsnelheid',
+			playbackBody:
+				'De replay wordt vertraagd afgespeeld terwijl de belichting wordt vastgelegd, zodat de sim meer beelden per seconde replaytijd toont en de menging meer samples krijgt. 1/16 verzamelt ruwweg zestien keer zoveel beelden als realtime — en duurt zestien keer zo lang in werkelijke tijd. Dat is de voornaamste afweging in dit paneel: geduld tegen gelijkmatigheid.',
+			playbackAutoBody:
+				'„Automatisch (op basis van doelaantal)” kiest de snelheid voor je aan de hand van het <b>doelaantal samples</b>: de tool zoekt de snelste weergave die het gevraagde aantal nog haalt. Stel in plaats daarvan een vaste snelheid in als je de wachttijd liever begrenst.',
+
+			weighting: 'Weging',
+			weightingBody:
+				'Hoeveel elk vastgelegd beeld bijdraagt aan het resultaat. <b>Box</b> weegt ze allemaal even zwaar en geeft een gelijkmatige streep. <b>Lineair</b> loopt op naar het einde van het venster, zodat het onderwerp het scherpst is waar het eindigde en langs zijn baan vervaagt. <b>Ease</b> is hetzelfde idee met een scherpere kop en een langere staart.',
+
+			interpolation: 'Beeldinterpolatie',
+			interpolationBody:
+				'Verzint extra beelden tussen de echte met de optical-flow-engine van de GPU en vult zo de gaten in de streep op. Vereist een NVIDIA Turing-kaart of nieuwer en wordt volledig verborgen op hardware die dit niet aankan.',
+			interpolationCostBody:
+				'Het is niet gratis: het kost GPU-tijd bij elk vastgelegd beeld, en het budget is één iRacing-beeld. Kan het dat niet bijhouden, dan begint het <i>echte</i> beelden te missen om synthetische te fabriceren, wat per saldo verlies is — de streep wordt korter en grover. De kosten schalen met megapixels maal de factor, dus wat comfortabel is op 2560×1440 is niet haalbaar op 8K. Om dit te controleren maak je dezelfde opname twee keer, met en zonder, en vergelijk je het aantal echte samples; de app waarschuwt je achteraf ook als een opname tekortschoot.',
+
+			passes: 'Doorgangen',
+			passesBody:
+				'Bezoekt hetzelfde moment meerdere keren en verzamelt alles in één afbeelding. Elke doorgang vangt beelden op die de andere toevallig misten, zodat de streep gelijkmatiger wordt — niet helderder, want het resultaat wordt genormaliseerd naar hoeveel licht er werkelijk op elke pixel viel.',
+			passesTradeBody:
+				'Doorgangen kopen hetzelfde als interpolatie, maar met een andere munt: werkelijke tijd in plaats van GPU-tijd. Acht doorgangen duren ruwweg acht keer zo lang, maar kunnen je nooit echte beelden kosten. Daarmee zijn ze de juiste hefboom bij hoge resoluties, waar interpolatie het niet bijhoudt, en bij korte sluitertijden, waar één doorgang heel weinig samples oplevert. Beide tegelijk gebruiken is meestal het slechtste van twee werelden — ze concurreren om hetzelfde budget per beeld.',
+
+			bracket: 'Sluitertijdenreeks',
+			bracketBody:
+				'Levert één afbeelding per sluitertijdstand die gelijk is aan of korter dan de gekozen stand, uit één enkele opname. Een opname op 1/60 geeft je ook 1/125, 1/250, 1/500 en 1/1000 — hetzelfde moment met steeds kortere strepen — zodat je de look achteraf kunt kiezen in plaats van te gokken en opnieuw op te nemen.',
+			bracketCostBody:
+				'Het kost vrijwel geen extra tijd. Elke stand eindigt op hetzelfde beeld en verschilt alleen in hoe ver hij terugreikt, dus een kortere sluitertijd is simpelweg het staartje van de beelden die toch al voorbijkomen — ze worden allemaal uit één doorgang van de replay gevuld.',
+			bracketMemoryBody:
+				'Wat het wél kost, is geheugen. Elke stand heeft een eigen accumulator op volledige resolutie nodig, dus elf standen vragen elf keer het videogeheugen van één, wat op 8K meer is dan de meeste kaarten hebben. De opname controleert dit vooraf en weigert in plaats van iRacing te laten vastlopen; wordt een reeks geweigerd, verlaag dan de resolutie of kies een kortere sluitertijd — wat meteen ook een kortere ladder oplevert.',
+			bracketNamingBody:
+				'De stand die je koos wordt onder de gebruikelijke naam opgeslagen en is degene die in de galerij verschijnt; de andere staan ernaast, met hun sluitertijd in de bestandsnaam.',
+
+			highlights: 'Hoge lichten herstellen',
+			highlightsBody:
+				'Versterkt bijna uitgeknipte hoge lichten voordat de beelden worden opgeteld en draait die versterking aan het eind weer terug. iRacing levert een beeld af waarop al tone mapping is toegepast, dus een koplamp en een witte muur komen met dezelfde waarde binnen; dat middelen maakt van een fel licht dat door een deel van de belichting trekt een grijze veeg in plaats van een heldere streep. Dit zet de niet-lineariteit terug waar een echte sensor haar heeft. Gemeten in stops; 0 staat uit en verandert helemaal niets.',
+
+			whatItSaves: 'Wat het opslaat',
+			whatItSavesBody:
+				'Formaat, het bijsnijden van het watermerk en het bestandsformaat volgen dezelfde instellingen als een gewone schermafbeelding — de instellingen Resolutie en Watermerk bijsnijden hierboven, en het uitvoerformaat bij de instellingen. De regel „Uitvoer” boven aan de zijbalk laat precies zien wat je krijgt.',
+			whatItSavesPngBody:
+				'Kies je PNG, dan wordt een echte 16-bits master weggeschreven, wat de moeite waard is als je de opname later wilt graden, plus een 8-bits voorbeeld voor de galerij. Het is bij hoge resoluties ook veel trager om weg te schrijven — een 16-bits PNG van 33 megapixel duurt ongeveer tien seconden, terwijl hetzelfde beeld als JPEG minder dan één seconde kost.',
+
+			troubleshooting: 'Als het resultaat niet klopt',
+			troubleGhosts:
+				'<b>Losse spookbeelden in plaats van een vloeiende streep</b> — te weinig samples. Gebruik een tragere afspeelsnelheid, meer doorgangen of een lagere resolutie.',
+			troubleShutter:
+				'<b>Weet je niet welke sluitertijd je wilde</b> — zet de sluitertijdenreeks aan en beslis achteraf, bij dezelfde wachttijd.',
+			troubleHighlights:
+				'<b>Uitgebeten of vlakke hoge lichten</b> — probeer 3 tot 5 stops herstel van hoge lichten.',
+			troubleBlack:
+				'<b>Een zwarte afbeelding</b> — iRacing draait in exclusief volledig scherm. Zet Display &gt; Full Screen op OFF.',
+			troubleSidecar:
+				'Elke opname legt de precies gebruikte instellingen vast, het aantal samples en hoe gelijkmatig ze vielen, als een .json-bestand in de logboekmap naast app.log. De laatste 20 opnames worden bewaard — een reeks telt als één — zodat de opname waarover je een vraag hebt er nog is terwijl je die vraag stelt.',
+		},
+	},
+
+	update: {
+		checking: 'Zoeken naar updates…',
+		newVersion: 'Een nieuwe versie',
+		availableBusy:
+			'{version} is beschikbaar. Er loopt een opname — je kunt hem downloaden zodra die klaar is.',
+		available: '{version} is beschikbaar. Klik om te downloaden.',
+		downloading: '{version} wordt gedownload…',
+		downloadingPercent: '{version} wordt gedownload — {percent}%',
+		downloadedBusy:
+			'{version} staat klaar. Er loopt een opname, dus hij wordt geïnstalleerd zodra je de app sluit.',
+		downloaded:
+			'{version} staat klaar. Klik om opnieuw te starten en te installeren.',
+		failed: 'Controle op updates mislukt: {error}',
+		unknownError: 'onbekende fout',
+		neverChecked:
+			'Er is nog niet op updates gecontroleerd (je gebruikt v{version}).',
+		upToDate: 'Je gebruikt de nieuwste versie (v{version}).',
+
+		alreadyDownloading: 'De update wordt al gedownload.',
+		alreadyDownloaded: 'De update is al gedownload.',
+		nothingToDownload: 'Er is geen update om te downloaden.',
+		captureInProgress:
+			'Er loopt een opname. Probeer het opnieuw zodra die klaar is.',
+		nothingToInstall: 'Er staat geen update klaar om te installeren.',
+		captureInProgressInstall:
+			'Er loopt een opname. De update installeert zichzelf zodra je de app sluit.',
+		devBuildOnly:
+			'Controleren op updates werkt alleen in een geïnstalleerde versie.',
+
+		installTitle: 'Update installeren',
+		installMessage: 'Versie {version} installeren?',
+		installFallbackVersion: 'update',
+		installDetail:
+			'De app sluit en opent opnieuw zodra de update is geïnstalleerd. Kies je „Later”, dan installeert hij zichzelf de volgende keer dat je de app sluit.',
+		installConfirm: 'Opnieuw starten en installeren',
+		installLater: 'Later',
+	},
+
+	filenameFields: {
+		categories: {
+			Track: 'Baan',
+			Driver: 'Coureur',
+			Session: 'Sessie',
+			Meta: 'Meta',
+		},
+		track: 'Baan',
+		trackFull: 'Baan volledig',
+		trackCity: 'Stad',
+		trackCountry: 'Land',
+		trackType: 'Baantype',
+		driver: 'Coureur',
+		driverAbbrev: 'Coureur afgekort',
+		driverInitials: 'Initialen',
+		team: 'Team',
+		carNumber: 'Startnr.',
+		car: 'Auto',
+		carFull: 'Auto volledig',
+		carClass: 'Autoklasse',
+		iRating: 'iRating',
+		sessionType: 'Sessietype',
+		sessionName: 'Sessienaam',
+		lap: 'Ronde',
+		date: 'Datum',
+		time: 'Tijd',
+		datetime: 'Datum+tijd',
+		counter: 'Teller',
+	},
+
+	iracingConfig: {
+		projections:
+			'Schakel „Render Scene Using 3 Projections” uit in iRacing (tabblad Display > Monitor) om verticale banden in schermafbeeldingen te voorkomen',
+	},
+
+	wgc: {
+		cursorCaveat:
+			'De muisaanwijzer kan in opnames verschijnen op deze versie van Windows. Windows 10 versie 2004 introduceerde de instelling die hem verbergt.',
+		addonUnavailable:
+			'Het onderdeel voor high-fidelity vastlegging kon op dit systeem niet worden geladen.',
+		osUnsupported:
+			'Windows.Graphics.Capture is niet beschikbaar op deze versie van Windows. Het vereist Windows 10 versie 1903 of nieuwer.',
+		nativeCaptureOff: 'High-fidelity vastlegging (WGC) staat uit',
+	},
+
+	capture: {
+		exclusiveFullscreen:
+			'iRacing draait in exclusief volledig scherm, dus de schermafbeelding zou zwart worden. Zet in iRacing Display > Full Screen op OFF (gebruik Borderless of Windowed) en probeer het opnieuw.',
+		exclusiveFullscreenUnattributed:
+			'Er draait een toepassing in exclusief volledig scherm, wat een zwarte opname oplevert. Draait iRacing in volledig scherm, zet dan Display > Full Screen op OFF (gebruik Borderless of Windowed) en probeer het opnieuw.',
+		unknownError: 'Onbekende fout bij schermafbeelding',
+		outputTooSmall: 'De opname is te klein ({width}x{height})',
+		blackFrame:
+			'Het vastgelegde beeld is zwart — mogelijk is de opnamebron mislukt (GPU-versnelde inhoud laat zich op sommige Windows-configuraties niet vastleggen)',
+		noSource: 'Geen bureaubladopnamebron gevonden voor venster {windowId}',
+		metadataTimeout:
+			'Time-out bij het wachten op de videometadata van de opname',
+		noVideoFrame: 'De opnamestream leverde geen videobeeld op',
+		dimensionTimeout:
+			'Time-out bij het wachten op vensterafmetingen {width}x{height}; er wordt doorgegaan met {actualWidth}x{actualHeight}',
+	},
+
+	longExposureCapture: {
+		busy: 'Er loopt al een opname.',
+		needsNativeCapture:
+			'Lange sluitertijd vereist high-fidelity vastlegging (WGC). Schakel deze in bij de instellingen om hem te gebruiken.',
+		unavailable: 'Lange sluitertijd is niet beschikbaar op deze machine.',
+		noTelemetry:
+			'Lange sluitertijd vereist replaytelemetrie van iRacing. Controleer of de sim draait en in een sessie zit.',
+		windowNotFound: 'iRacing-venster niet gevonden.',
+		cancelled: 'Opname geannuleerd.',
+		seekTimeout:
+			'De replay bereikte beeld {frame} niet op tijd. Mogelijk wordt hij nog geladen.',
+		noPasses: 'Een opname moet minstens één doorgang uitvoeren.',
+		playbackStalled:
+			'De replay begon niet af te spelen. Controleer of iRacing niet door een ander programma is gepauzeerd.',
+		exposureTimeout:
+			'De belichting bereikte beeld {frame} niet binnen {seconds} s.',
+		endedEarly:
+			'De belichting eindigde voordat het gekozen moment was bereikt.',
+		noFramesPresented: 'iRacing toonde geen beelden om vast te leggen.',
+		subFrameNoSamples:
+			'Deze sluitertijd is korter dan één replaybeeld, en iRacing heeft er geen beeld binnen gerenderd. Probeer een tragere afspeelsnelheid of de eerstvolgende langere sluitertijd.',
+		noSamples:
+			'Er zijn geen beelden verzameld. Mogelijk is iRacing tijdens de belichting gestopt met renderen.',
+		withNativeError: '{reason} ({error})',
+		resolveFailed: 'De GPU gaf geen afbeelding terug.',
+		bracketShortfall:
+			'De reeks vroeg om {asked} standen maar er kwamen er {returned} terug — de rest kon niet worden opgelost, of deze versie van het opnameonderdeel is ouder dan de reeksfunctie.',
+	},
+
+	validation: {
+		windowBeforeStart:
+			'De belichting heeft {frames} replaybeelden vóór het gekozen moment nodig, maar dat ligt slechts {anchor} beelden na het begin van de replay. Kies een later moment of een kortere sluitertijd.',
+		pastEnd: 'Het gekozen moment ligt voorbij het einde van de replay.',
+		sessionChanged:
+			'De replay is naar een andere sessie gegaan sinds deze opname werd voorbereid. Kies het moment opnieuw.',
+		singleSampleMultiPass:
+			'Deze sluitertijd is zo kort dat er per doorgang maar ongeveer één beeld in valt, dus {passes} doorgangen verzamelen ruwweg {passes} samples. Een tragere afspeelsnelheid of een langere sluitertijd levert veel meer op.',
+		singleSample:
+			'Deze sluitertijd is zo kort dat er maar één beeld in valt, dus het resultaat heeft geen bewegingsonscherpte. Een tragere afspeelsnelheid of een langere sluitertijd levert samples op.',
+		bracketVsInterpolation:
+			'Een sluitertijdenreeks en {factor}x beeldinterpolatie kunnen niet allebei draaien, dus deze opname wordt zonder interpolatie gemaakt. Zet de reeks uit als de tussenbeelden je meer waard zijn dan de extra standen.',
+		passesVsInterpolation:
+			'Zowel meerdere doorgangen als {factor}x interpolatie staan aan. Ze concurreren: interpolatie vertraagt elke doorgang zodanig dat die echte beelden misloopt, waardoor dezelfde wachttijd minder echte samples oplevert dan doorgangen alleen. Interpolatie uitzetten geeft meestal de betere opname.',
+		shortOfTarget:
+			'Zelfs op snelheid 1/{divisor} haalt deze belichting ongeveer {samples} samples, minder dan de gevraagde {target}. Gebruik een langere sluitertijd voor meer.',
+		longCaptureEscalate:
+			'Deze opname speelt de replay af op snelheid 1/{divisor} gedurende ongeveer {duration} werkelijke tijd{passSuffix}, en kan na de start niet worden versneld. {advice}',
+		longCaptureWarn:
+			'Deze opname duurt ongeveer {duration} werkelijke tijd bij afspeelsnelheid 1/{divisor}{passSuffix}.',
+		passSuffix: ', verdeeld over {passes} doorgangen op hetzelfde moment',
+		adviceFewerPasses:
+			'Minder doorgangen zijn eerder klaar, met minder samples.',
+		adviceFasterPlayback:
+			'Een hogere afspeelsnelheid is eerder klaar, met minder samples.',
+		pastLogCap:
+			'Naar verwachting verzamelt deze opname ongeveer {samples} samples over {passes} doorgangen, meer dan de {cap} die het diagnostische logboek bevat. De afbeelding blijft onaangetast — alleen de gelijkmatigheids- en gatcijfers beschrijven dan het eerste deel van de opname.',
+		interpolationLossy:
+			'Op dit formaat heeft {factor}x interpolatie deze machine eerder al echte samples gekost. Overweeg een lagere factor, een lagere resolutie of in plaats daarvan meer doorgangen.',
+	},
+
+	duration: {
+		zero: '0 seconden',
+		seconds: {
+			one: '{count} seconde',
+			other: '{count} seconden',
+		},
+		minutes: {
+			one: '{count} minuut',
+			other: '{count} minuten',
+		},
+		minutesSeconds: '{minutes} min {seconds} s',
+	},
+};
+
+export default nl;

--- a/src/locales/no.ts
+++ b/src/locales/no.ts
@@ -1,0 +1,481 @@
+// Norwegian (Bokmål). Translated from en.ts — see that file's header before
+// editing.
+//
+// Registered under the macrolanguage code `no` because that is what the picker
+// lists, but Windows reports `nb` or `nn` — resolveLocale maps both onto this
+// catalogue. See i18n.ts.
+//
+// Product and technology names stay untranslated: iRacing, ReShade, Discord,
+// Windows.Graphics.Capture, WGC, VRAM, GPU, NVIDIA Turing and the file formats.
+
+import type { Catalog } from './index';
+
+const no: Catalog = {
+	notice: {
+		danger: 'Problemer',
+		warning: 'Verdt å vite',
+		info: 'Merknader',
+	},
+
+	promo: {
+		greeting: 'Takk for at du bruker iRacing Screenshot Tool!',
+		signature: 'Laget og vedlikeholdt av AR Media Solutions.',
+	},
+
+	changelog: {
+		title: 'Endringslogg',
+		untitledRelease: 'Versjon',
+	},
+
+	gallery: {
+		menu: {
+			openExternally: 'Åpne i et annet program',
+			openFolder: 'Åpne mappe',
+			copy: 'Kopier',
+			delete: 'Slett',
+		},
+		copiedToClipboard: '{name} kopiert til utklippstavlen',
+	},
+
+	sidebar: {
+		resolution: 'Oppløsning',
+		width: 'Bredde',
+		height: 'Høyde',
+		output: 'Utdata:',
+		cropWatermark: 'Beskjær vannmerke',
+		keepAspectRatio: 'Behold sideforhold',
+		screenshot: 'Skjermbilde',
+		custom: 'Egendefinert',
+		vramStatus: '{adapter}{free} ledig av {total}',
+		savedSuccessfully: '{name} ble lagret',
+		screenshotFailed: 'Skjermbildet mislyktes: {message}',
+		errorLogPrefix: 'Logg: ',
+		notices: {
+			exclusiveFullscreen:
+				'iRacing kjører i eksklusiv fullskjerm — skjermbildene blir svarte. Sett Display > Full Screen til OFF i iRacing (Borderless eller Windowed) for å gjøre opptak mulig.',
+			vramRisk:
+				'{resolution} trenger omtrent {needed} mer VRAM, men bare {free} er ledig — iRacing går sannsynligvis tom for minne og krasjer.',
+			vramCaution:
+				'{resolution} etterlater lite VRAM-margin ({free} ledig) og kan krasje ved krevende bane-/bilkombinasjoner.',
+			switchResolution: 'Bytt til {resolution}',
+			vramStatic:
+				'Høye oppløsninger kan få iRacing til å krasje hvis VRAM tar slutt. Enkelte bane-/bilkombinasjoner krever mer VRAM.',
+			reshade:
+				'Etter at du har trykket på skjermbildeknappen i iRacing Screenshot Tool, må du også trykke på ReShades hurtigtast for skjermbilder.',
+			crop: 'Beskjæring av vannmerket zoomer det ferdige bildet litt inn. Områder nær skjermkantene blir kuttet bort.',
+			aspectRatio:
+				'«Behold sideforhold» tilpasser høyden på skjermbildet til sideforholdet på skjermen din (for eksempel 21:9 ultrabred) i stedet for standard 16:9. Valgt oppløsning bestemmer bredden.',
+		},
+	},
+
+	settings: {
+		title: 'Innstillinger',
+		version: 'Versjon - {version}',
+		changelog: 'Endringslogg',
+		openLogsFolder: 'Åpne loggmappen',
+		checkForUpdates: 'Se etter oppdateringer',
+		updateCheckFailed: 'Søket etter oppdateringer mislyktes: {message}',
+
+		language: 'Språk',
+		languageDescription:
+			'Språket som brukes i hele appen. Hentes fra Windows første gang appen kjøres.',
+
+		screenshotFolder: 'Mappe for skjermbilder',
+		selectFolder: 'Velg mappe',
+		screenshotKeybind: 'Hurtigtast for skjermbilde',
+		editBind: 'Endre hurtigtast',
+
+		customFilenameFormat: 'Egendefinert filnavnformat',
+		customFilenameFormatDescription:
+			'Bruk et eget mønster i stedet for standarden ({track}-{driver}-{counter})',
+		filenameFieldsHint:
+			'Klikk på feltene for å legge dem til i formatet. Skriv skilletegn (-, _ osv.) direkte.',
+		reset: 'Tilbakestill',
+		preview: 'Forhåndsvisning:',
+
+		outputFormat: 'Utdataformat',
+		formatJpeg: 'JPEG (høyeste kvalitet)',
+		formatPng: 'PNG (tapsfri)',
+		formatWebp: 'WebP (kvalitet 95 %)',
+
+		disableTooltips: 'Skjul tips',
+		disableTooltipsDescription: 'La meg være, jeg vet hva jeg gjør',
+
+		cropTopLeft: 'Foretrekk beskjæring av vannmerket øverst til venstre',
+		cropTopLeftDescription:
+			'Beskjærer bare nedre høyre hjørne (3 %). Når den er av, beskjæres skjermbildet like mye fra alle sider (6 % totalt), noe som gir et sentrert resultat.',
+
+		manualWindowRestore: 'Manuell gjenoppretting av vindu',
+		manualWindowRestoreDescription:
+			'Erstatter automatisk gjenoppretting av vinduet med egen posisjon og størrelse. Nyttig ved ultrabrede skjermer eller Nvidia Surround.',
+		left: 'Venstre',
+		top: 'Øverst',
+		width: 'Bredde',
+		height: 'Høyde',
+		restoreNow: 'Gjenopprett nå',
+
+		nativeCapture: 'Opptak i høy kvalitet (WGC)',
+		nativeCaptureDescription:
+			'Fanger ekte farge uten undersampling via Windows.Graphics.Capture i stedet for standardveien (som undersampler fargen). Faller automatisk tilbake hvis et opptak mislykkes.',
+		nativeCaptureUnavailable:
+			'Ikke tilgjengelig på dette systemet — opptak i høy kvalitet kan ikke kjøre her.',
+		nativeCaptureUnverified:
+			'Windows melder at det støttes, men et testopptak kom ikke tilbake. Opptak faller automatisk tilbake hvis det fortsetter å mislykkes.',
+
+		reshade: 'ReShade-kompatibilitetsmodus',
+		reshadeDescription:
+			'Med ReShade må du først bruke hurtigtasten for iRacing Screenshot Tool eller trykke på knappen, og deretter bruke ReShade-hurtigtasten for skjermbilder når iRacing-vinduet har endret størrelse.',
+		reshadeIni: 'ReShade-INI',
+		selectFile: 'Velg fil',
+	},
+
+	longExposure: {
+		title: 'Lang eksponering',
+		shutter: 'Lukkertid',
+		playbackSpeed: 'Avspillingshastighet',
+		playbackAuto: 'Automatisk (fra måltall for prøver)',
+		playbackRealTime: '1x (sanntid)',
+		targetSamples: 'Måltall for prøver',
+		advanced: 'Avansert',
+		defaultsSummary: '{count} standardverdier',
+
+		weighting: 'Vekting',
+		weightingBox: 'Box (jevn)',
+		weightingLinear: 'Lineær (skarp til slutt)',
+		weightingEase: 'Ease (skarpere start, lang hale)',
+
+		interpolation: 'Bildeinterpolering',
+		interpolationOff: 'Av',
+		interpolation2: '2× (ett mellombilde)',
+		interpolation4: '4× (tre mellombilder)',
+		interpolation8: '8× (sju mellombilder)',
+
+		passes: 'Gjennomkjøringer',
+		passes1: '1 (én gjennomkjøring)',
+		passes2: '2× — dobbelt så lang ventetid',
+		passes4: '4× — fire ganger så lang ventetid',
+		passes8: '8× — åtte ganger så lang ventetid',
+
+		bracket: 'Lukkertidsbracketing',
+		highlightRecovery: 'Gjenoppretting av høylys (trinn)',
+
+		cancel: 'Avbryt',
+		saved: 'Lang eksponering lagret — {count} prøver',
+		failed: 'Den lange eksponeringen mislyktes',
+
+		modified: {
+			weighting_linear: 'lineær',
+			weighting_ease: 'ease',
+			interpolation: '{factor}× interpolering',
+			passes: {
+				one: '{count} gjennomkjøring',
+				other: '{count} gjennomkjøringer',
+			},
+			bracketed: 'bracketing',
+			recovery: '{stops} trinns gjenoppretting',
+		},
+
+		progress: {
+			working: 'Arbeider…',
+			seeking: 'Søker…{pass}',
+			accumulating: 'Eksponerer… {count} prøver{pass}',
+			resolving: 'Fremkaller…',
+			restoring: 'Gjenoppretter reprisen…',
+			pass: ' (gjennomkjøring {current} av {total})',
+		},
+
+		notices: {
+			needsNativeCapture:
+				'Lang eksponering krever opptak i høy kvalitet (WGC), som nå er slått av. Slå det på i innstillingene for å kunne bruke lang eksponering.',
+			unavailableWithReason:
+				'Lang eksponering er ikke tilgjengelig på denne maskinen: {reason}',
+			unavailable:
+				'Lang eksponering er ikke tilgjengelig på denne maskinen.',
+			interpolationCost:
+				'Interpolering finner opp bilder mellom de virkelige for å jevne ut stripen. Det koster GPU-tid per bilde, så sammenlign antallet virkelige prøver i det lagrede bildet med det samme bildet uten interpolering — synker det tallet, kjøper den oppdiktede prøver med virkelige.',
+			passesAndInterpolation:
+				'Gjennomkjøringer og interpolering konkurrerer om det samme budsjettet per bilde. Med begge på fanger hver gjennomkjøring færre virkelige bilder — å slå av interpoleringen gir som regel et bedre bilde for den samme ventetiden.',
+			passes:
+				'Hver gjennomkjøring spiller av det samme øyeblikket på nytt og fanger bilder de andre gikk glipp av, slik at stripen blir jevnere heller enn lysere. Best ved korte lukkertider, der én enkelt gjennomkjøring bare samler en håndfull prøver.',
+			interpolationUnsupported:
+				'Bildeinterpolering krever en NVIDIA Turing-GPU eller nyere{adapter}. Alt annet ved lang eksponering fungerer som normalt.',
+			interpolationAdapter: ' (dette opptaket kjører på {adapter})',
+			reshade:
+				'Lang eksponering tar opp nativt og bruker ikke ReShade, så ReShade-effekter vises ikke i resultatet.',
+		},
+	},
+
+	help: {
+		title: 'Hjelp',
+		sections: 'Hjelpeseksjoner',
+		tabGeneral: 'Generelt',
+		tabLongExposure: 'Lang eksponering',
+
+		general: {
+			iracingSettings: 'iRacing-innstillinger',
+			borderless: 'iRacing må kjøre i Windowed Borderless',
+			vram: 'Minst 8 GB VRAM anbefales for skjermbilder i 8K eller høyere',
+			newerContent: 'Nyere baner og biler krever mer VRAM',
+			shrinkUi:
+				'Krymp brukergrensesnittet så mye som mulig før du tar et skjermbilde hvis du bruker beskjæring av vannmerket; «Control+PageDown» krymper det. Fungerer det ikke, kan du måtte tilbakestille grensesnittets zoom i iRacings innstillinger.',
+
+			screenshotFolder: 'Mappe for skjermbilder',
+			screenshotFolderBody:
+				'Skjermbilder lagres som standard i «C:\\Users\\user\\Pictures\\Screenshots»; dette kan endres i innstillingene.',
+
+			screenshotHotkey: 'Hurtigtast for skjermbilde',
+			screenshotHotkeyBody:
+				'Som standard tar «Control + PrintScreen» et skjermbilde med gjeldende innstillinger; dette kan endres i innstillingene.',
+
+			issues: 'Problemer',
+			issuesBody: 'Har du problemer, meld dem gjerne på',
+			discord: 'Discord',
+
+			instructions: 'Veiledning',
+			step1: 'iRacing <b>må</b> kjøre i modusen Windowed Borderless',
+			step2: 'Start iRacing og plasser kameraet der du vil ta skjermbildet',
+			step3: 'Velg ønsket oppløsning (prøv lavere oppløsninger før du går opp til 8K)',
+			step4: 'Bestem om du vil beskjære iRacings vannmerke; i så fall må du først krympe iRacings grensesnitt til minste størrelse med «Control + PageDown»',
+			step5: 'Trykk på skjermbildeknappen eller bruk hurtigtasten «Control + PrintScreen» for å ta bildene',
+			step6: 'Avhengig av valgt oppløsning kan dette ta noen sekunder; når iRacing-vinduet er tilbake i normal størrelse, er det ferdig',
+			step7: 'Skjermbildet lagres i «C:\\Users\\{User}\\Pictures\\Screenshots»',
+		},
+
+		longExposure: {
+			whatItDoes: 'Hva den gjør',
+			whatItDoesBody:
+				'En lang eksponering blander mange bilder fra en reprise til ett bilde, på samme måte som når man lar et kameralukkeren stå åpen: det som står stille forblir skarpt, det som beveger seg trekker striper. Verktøyet styrer reprisen selv, fanger hvert bilde simulatoren viser, og legger dem sammen på GPU-en.',
+
+			shutter: 'Lukkertid',
+			shutterBody:
+				'Hvor lenge eksponeringen varer <i>i reprisetid</i>, fra en brøkdel av ett reprisebilde opp til ti sekunder. Det er denne innstillingen som avgjør hvor lange stripene blir. Lengre lukkertider samler også flere bilder og trenger derfor mindre hjelp fra alt nedenfor; de raskeste trinnene dekker ett enkelt reprisebilde og samler bare en håndfull prøver.',
+
+			playback: 'Avspillingshastighet',
+			playbackBody:
+				'Reprisen spilles av i sakte film mens eksponeringen fanges, slik at simulatoren viser flere bilder per sekund reprisetid og blandingen får flere prøver. 1/16 samler omtrent seksten ganger så mange bilder som sanntid — og tar seksten ganger så lang faktisk tid. Det er den viktigste avveiningen i panelet: tålmodighet mot mykhet.',
+			playbackAutoBody:
+				'«Automatisk (fra måltall for prøver)» velger hastigheten for deg ut fra <b>måltall for prøver</b>: verktøyet finner den raskeste avspillingen som fortsatt når antallet du ba om. Angi heller en fast hastighet hvis du vil begrense ventetiden.',
+
+			weighting: 'Vekting',
+			weightingBody:
+				'Hvor mye hvert fanget bilde bidrar til resultatet. <b>Box</b> vekter dem alle likt og gir en jevn stripe. <b>Lineær</b> stiger mot slutten av vinduet, slik at motivet er skarpest der det sluttet og toner ut langs banen sin. <b>Ease</b> er den samme ideen med skarpere start og lengre hale.',
+
+			interpolation: 'Bildeinterpolering',
+			interpolationBody:
+				'Finner opp ekstra bilder mellom de virkelige ved hjelp av GPU-ens optical flow-motor og fyller igjen hullene langs stripen. Krever et NVIDIA Turing-kort eller nyere og skjules helt på maskinvare som ikke klarer det.',
+			interpolationCostBody:
+				'Det er ikke gratis: det koster GPU-tid på hvert fanget bilde, og budsjettet er ett iRacing-bilde. Klarer den ikke å henge med, begynner den å gå glipp av <i>virkelige</i> bilder for å lage syntetiske, noe som er et netto tap — stripen blir kortere og grovere. Kostnaden skalerer med megapiksler ganger faktoren, så det som er behagelig ved 2560×1440 er ikke gjennomførbart i 8K. For å sjekke det: ta det samme øyeblikket to ganger, med og uten, og sammenlign antallet virkelige prøver; appen advarer deg også i etterkant hvis et bilde kom til kort.',
+
+			passes: 'Gjennomkjøringer',
+			passesBody:
+				'Besøker det samme øyeblikket flere ganger og akkumulerer til ett bilde. Hver gjennomkjøring fanger bilder de andre tilfeldigvis gikk glipp av, så stripen blir jevnere — ikke lysere, fordi resultatet normaliseres etter hvor mye lys som faktisk landet på hver piksel.',
+			passesTradeBody:
+				'Gjennomkjøringer kjøper det samme som interpolering, men i en annen valuta: faktisk tid i stedet for GPU-tid. Åtte gjennomkjøringer tar omtrent åtte ganger så lang tid, men de kan aldri koste deg virkelige bilder. Det gjør dem til riktig grep ved høye oppløsninger, der interpoleringen ikke henger med, og ved korte lukkertider, der én gjennomkjøring samler svært få prøver. Å bruke begge samtidig er som regel det verste av to verdener — de konkurrerer om det samme budsjettet per bilde.',
+
+			bracket: 'Lukkertidsbracketing',
+			bracketBody:
+				'Gir ett bilde per lukkertidstrinn som er likt eller raskere enn det du valgte, fra ett enkelt opptak. Et bilde ved 1/60 gir deg også 1/125, 1/250, 1/500 og 1/1000 — det samme øyeblikket med gradvis kortere striper — slik at du kan velge uttrykket i etterkant i stedet for å gjette og ta på nytt.',
+			bracketCostBody:
+				'Det koster nesten ingen ekstra tid. Hvert trinn slutter på det samme bildet og skiller seg bare i hvor langt tilbake det rekker, så en raskere lukkertid er ganske enkelt halen av bildene som uansett passerer — de fylles alle fra én gjennomkjøring av reprisen.',
+			bracketMemoryBody:
+				'Det som koster, er minne. Hvert trinn trenger sin egen akkumulator i full oppløsning, så elleve trinn trenger elleve ganger så mye grafikkminne som ett, noe som i 8K er mer enn de fleste kort har. Opptaket kontrollerer dette før det starter og avslår heller enn å krasje iRacing; blir en bracketing avslått, senk oppløsningen eller velg en raskere lukkertid — noe som også gir en kortere stige.',
+			bracketNamingBody:
+				'Trinnet du valgte lagres under det vanlige navnet og er det som vises i galleriet; de øvrige ligger ved siden av med sin lukkertid i filnavnet.',
+
+			highlights: 'Gjenoppretting av høylys',
+			highlightsBody:
+				'Løfter høylys nær utbrenning før bildene legges sammen, og fjerner løftet til slutt. iRacing leverer et bilde som allerede er tonemappet, så en frontlykt og en hvit vegg kommer inn med samme verdi; å midle det gjør et sterkt lys som sveiper gjennom deler av eksponeringen til en grå flekk i stedet for et lyst spor. Dette legger ulineariteten tilbake der en ekte sensor har den. Måles i trinn; 0 er av og endrer ingenting i det hele tatt.',
+
+			whatItSaves: 'Hva den lagrer',
+			whatItSavesBody:
+				'Størrelse, beskjæring av vannmerket og filformat følger de samme kontrollene som et vanlig skjermbilde — innstillingene Oppløsning og Beskjær vannmerke ovenfor, samt utdataformatet i innstillingene. Linjen «Utdata» øverst i sidepanelet viser nøyaktig hva du får.',
+			whatItSavesPngBody:
+				'Velger du PNG, skrives en ekte 16-bits master, noe som er verdt det hvis du skal fargekorrigere bildet etterpå, pluss en 8-bits forhåndsvisning til galleriet. Den er også mye tregere å skrive ved høye oppløsninger — en 16-bits PNG på 33 megapiksler tar rundt ti sekunder, mens det samme bildet som JPEG tar under ett.',
+
+			troubleshooting: 'Hvis resultatet ser feil ut',
+			troubleGhosts:
+				'<b>Adskilte spøkelsesbilder i stedet for en jevn stripe</b> — for få prøver. Bruk en langsommere avspillingshastighet, flere gjennomkjøringer eller en lavere oppløsning.',
+			troubleShutter:
+				'<b>Usikker på hvilken lukkertid du ville ha</b> — slå på lukkertidsbracketing og bestem deg etterpå, for den samme ventetiden.',
+			troubleHighlights:
+				'<b>Utbrente eller flate høylys</b> — prøv 3 til 5 trinn med gjenoppretting av høylys.',
+			troubleBlack:
+				'<b>Et svart bilde</b> — iRacing kjører i eksklusiv fullskjerm. Sett Display &gt; Full Screen til OFF.',
+			troubleSidecar:
+				'Hvert bilde registrerer nøyaktig hvilke innstillinger det brukte, antallet prøver og hvor jevnt de landet, som en .json-fil i loggmappen ved siden av app.log. De 20 siste bildene beholdes — en bracketing teller som ett — så bildet du spør om, er fortsatt der mens du spør.',
+		},
+	},
+
+	update: {
+		checking: 'Ser etter oppdateringer…',
+		newVersion: 'En ny versjon',
+		availableBusy:
+			'{version} er tilgjengelig. Et opptak pågår — du kan laste den ned når det er ferdig.',
+		available: '{version} er tilgjengelig. Klikk for å laste den ned.',
+		downloading: 'Laster ned {version}…',
+		downloadingPercent: 'Laster ned {version} — {percent} %',
+		downloadedBusy:
+			'{version} er klar. Et opptak pågår, så den installeres når du lukker appen.',
+		downloaded:
+			'{version} er klar. Klikk for å starte på nytt og installere.',
+		failed: 'Søket etter oppdateringer mislyktes: {error}',
+		unknownError: 'ukjent feil',
+		neverChecked:
+			'Det er ennå ikke søkt etter oppdateringer (du kjører v{version}).',
+		upToDate: 'Du kjører den nyeste versjonen (v{version}).',
+
+		alreadyDownloading: 'Oppdateringen lastes allerede ned.',
+		alreadyDownloaded: 'Oppdateringen er allerede lastet ned.',
+		nothingToDownload: 'Det finnes ingen oppdatering å laste ned.',
+		captureInProgress: 'Et opptak pågår. Prøv igjen når det er ferdig.',
+		nothingToInstall: 'Ingen oppdatering er klar til å installeres.',
+		captureInProgressInstall:
+			'Et opptak pågår. Oppdateringen installerer seg selv når du lukker appen.',
+		devBuildOnly:
+			'Søk etter oppdateringer kjører bare i en installert versjon.',
+
+		installTitle: 'Installer oppdatering',
+		installMessage: 'Installere versjon {version}?',
+		installFallbackVersion: 'oppdatering',
+		installDetail:
+			'Appen lukkes og åpnes igjen når oppdateringen er installert. Velger du «Senere», installeres den av seg selv neste gang du lukker appen.',
+		installConfirm: 'Start på nytt og installer',
+		installLater: 'Senere',
+	},
+
+	filenameFields: {
+		categories: {
+			Track: 'Bane',
+			Driver: 'Fører',
+			Session: 'Økt',
+			Meta: 'Meta',
+		},
+		track: 'Bane',
+		trackFull: 'Bane fullt navn',
+		trackCity: 'By',
+		trackCountry: 'Land',
+		trackType: 'Banetype',
+		driver: 'Fører',
+		driverAbbrev: 'Fører forkortet',
+		driverInitials: 'Initialer',
+		team: 'Lag',
+		carNumber: 'Bilnr.',
+		car: 'Bil',
+		carFull: 'Bil fullt navn',
+		carClass: 'Bilklasse',
+		iRating: 'iRating',
+		sessionType: 'Økttype',
+		sessionName: 'Øktnavn',
+		lap: 'Runde',
+		date: 'Dato',
+		time: 'Klokkeslett',
+		datetime: 'Dato+klokkeslett',
+		counter: 'Teller',
+	},
+
+	iracingConfig: {
+		projections:
+			'Slå av «Render Scene Using 3 Projections» i iRacing (fanen Display > Monitor) for å unngå loddrette bånd i skjermbildene',
+	},
+
+	wgc: {
+		cursorCaveat:
+			'Musepekeren kan vises i opptak på denne versjonen av Windows. Windows 10 versjon 2004 la til innstillingen som skjuler den.',
+		addonUnavailable:
+			'Komponenten for opptak i høy kvalitet kunne ikke lastes inn på dette systemet.',
+		osUnsupported:
+			'Windows.Graphics.Capture er ikke tilgjengelig på denne versjonen av Windows. Den krever Windows 10 versjon 1903 eller nyere.',
+		nativeCaptureOff: 'Opptak i høy kvalitet (WGC) er slått av',
+	},
+
+	capture: {
+		exclusiveFullscreen:
+			'iRacing kjører i eksklusiv fullskjerm, så skjermbildet ville blitt svart. Sett Display > Full Screen til OFF i iRacing (bruk Borderless eller Windowed), og prøv igjen.',
+		exclusiveFullscreenUnattributed:
+			'Et program kjører i eksklusiv fullskjerm, noe som gir et svart opptak. Hvis iRacing kjører i fullskjerm, sett Display > Full Screen til OFF (bruk Borderless eller Windowed), og prøv igjen.',
+		unknownError: 'Ukjent skjermbildefeil',
+		outputTooSmall: 'Opptaket er for lite ({width}x{height})',
+		blackFrame:
+			'Det fangede bildet er svart — opptakskilden kan ha mislyktes (GPU-akselerert innhold lar seg ikke alltid fange på enkelte Windows-oppsett)',
+		noSource: 'Ingen skrivebordsopptakskilde funnet for vinduet {windowId}',
+		metadataTimeout: 'Tidsavbrudd under venting på opptakets videometadata',
+		noVideoFrame: 'Opptaksstrømmen ga ingen videobilder',
+		dimensionTimeout:
+			'Tidsavbrudd under venting på vindusstørrelsen {width}x{height}; fortsetter med {actualWidth}x{actualHeight}',
+	},
+
+	longExposureCapture: {
+		busy: 'Et opptak pågår allerede.',
+		needsNativeCapture:
+			'Lang eksponering krever opptak i høy kvalitet (WGC). Slå det på i innstillingene for å bruke det.',
+		unavailable: 'Lang eksponering er ikke tilgjengelig på denne maskinen.',
+		noTelemetry:
+			'Lang eksponering krever reprisetelemetri fra iRacing. Kontroller at simulatoren kjører og er i en økt.',
+		windowNotFound: 'Fant ikke iRacing-vinduet.',
+		cancelled: 'Opptaket ble avbrutt.',
+		seekTimeout:
+			'Reprisen nådde ikke bilde {frame} i tide. Den laster kanskje fortsatt.',
+		noPasses: 'Et opptak må kjøre minst én gjennomkjøring.',
+		playbackStalled:
+			'Reprisen startet ikke. Kontroller at iRacing ikke er satt på pause av et annet verktøy.',
+		exposureTimeout:
+			'Eksponeringen nådde ikke bilde {frame} innen {seconds} s.',
+		endedEarly: 'Eksponeringen sluttet før det valgte øyeblikket ble nådd.',
+		noFramesPresented: 'iRacing viste ingen bilder å fange.',
+		subFrameNoSamples:
+			'Denne lukkertiden er kortere enn ett reprisebilde, og iRacing gjengav ingen bilder innenfor den. Prøv en langsommere avspillingshastighet, eller den neste lengre lukkertiden.',
+		noSamples:
+			'Ingen bilder ble akkumulert. iRacing kan ha sluttet å gjengi under eksponeringen.',
+		withNativeError: '{reason} ({error})',
+		resolveFailed: 'GPU-en returnerte ingen bilde.',
+		bracketShortfall:
+			'Bracketingen ba om {asked} trinn, men {returned} kom tilbake — resten kunne ikke løses ut, eller denne versjonen av opptakskomponenten er eldre enn bracketing.',
+	},
+
+	validation: {
+		windowBeforeStart:
+			'Eksponeringen trenger {frames} reprisebilder før det valgte øyeblikket, men det ligger bare {anchor} bilder inn i reprisen. Velg et senere øyeblikk eller en raskere lukkertid.',
+		pastEnd: 'Det valgte øyeblikket ligger etter slutten av reprisen.',
+		sessionChanged:
+			'Reprisen har byttet til en annen økt siden dette bildet ble satt opp. Velg øyeblikket på nytt.',
+		singleSampleMultiPass:
+			'Denne lukkertiden er så kort at bare omtrent ett bilde havner innenfor den per gjennomkjøring, så {passes} gjennomkjøringer samler omtrent {passes} prøver. En langsommere avspillingshastighet eller en lengre lukkertid gir langt flere.',
+		singleSample:
+			'Denne lukkertiden er så kort at bare ett bilde havner innenfor den, så resultatet får ingen bevegelsesuskarphet. En langsommere avspillingshastighet eller en lengre lukkertid gir prøver.',
+		bracketVsInterpolation:
+			'Lukkertidsbracketing og {factor}x bildeinterpolering kan ikke kjøre samtidig, så dette bildet tas uten interpolering. Slå av bracketingen hvis mellombildene betyr mer for deg enn de ekstra trinnene.',
+		passesVsInterpolation:
+			'Både flere gjennomkjøringer og {factor}x interpolering er på. De konkurrerer: interpoleringen bremser hver gjennomkjøring så mye at den koster virkelige bilder, slik at den samme ventetiden kjøper færre virkelige prøver enn gjennomkjøringer alene ville gjort. Å slå av interpoleringen gir som regel det beste bildet.',
+		shortOfTarget:
+			'Selv ved hastigheten 1/{divisor} når denne eksponeringen omtrent {samples} prøver, færre enn de {target} som ble bedt om. Bruk en lengre lukkertid for å få flere.',
+		longCaptureEscalate:
+			'Dette opptaket spiller av reprisen med hastigheten 1/{divisor} i omtrent {duration} faktisk tid{passSuffix}, og kan ikke fremskyndes når det først er startet. {advice}',
+		longCaptureWarn:
+			'Dette opptaket tar omtrent {duration} faktisk tid ved avspillingshastigheten 1/{divisor}{passSuffix}.',
+		passSuffix:
+			', fordelt over {passes} gjennomkjøringer av det samme øyeblikket',
+		adviceFewerPasses:
+			'Færre gjennomkjøringer blir ferdige tidligere, med færre prøver.',
+		adviceFasterPlayback:
+			'En raskere avspillingshastighet blir ferdig tidligere, med færre prøver.',
+		pastLogCap:
+			'Dette opptaket forventes å samle omtrent {samples} prøver over {passes} gjennomkjøringer, mer enn de {cap} diagnostikkloggen rommer. Bildet påvirkes ikke — bare tallene for jevnhet og hull vil beskrive den første delen av opptaket.',
+		interpolationLossy:
+			'I denne størrelsen har {factor}x interpolering tidligere kostet denne maskinen virkelige prøver. Vurder en lavere faktor, en lavere oppløsning eller flere gjennomkjøringer i stedet.',
+	},
+
+	duration: {
+		zero: '0 sekunder',
+		seconds: {
+			one: '{count} sekund',
+			other: '{count} sekunder',
+		},
+		minutes: {
+			one: '{count} minutt',
+			other: '{count} minutter',
+		},
+		minutesSeconds: '{minutes} min {seconds} s',
+	},
+};
+
+export default no;

--- a/src/locales/pl.ts
+++ b/src/locales/pl.ts
@@ -1,0 +1,494 @@
+// Polish. Translated from en.ts — see that file's header before editing.
+//
+// NOTE ON PLURALS. Polish has four CLDR categories and this catalogue uses them:
+//   one   n = 1                      → 1 przebieg
+//   few   n % 10 = 2..4, n % 100 ∉ 12..14 → 2 przebiegi
+//   many  everything else integral    → 5 przebiegów
+//   other fractional counts           → same form as `many` here
+// Dropping `few` would render "2 przebiegów", which is simply wrong Polish — the
+// selector uses Intl.PluralRules, so all four forms are actually reachable.
+//
+// Product and technology names stay untranslated: iRacing, ReShade, Discord,
+// Windows.Graphics.Capture, WGC, VRAM, GPU, NVIDIA Turing and the file formats.
+
+import type { Catalog } from './index';
+
+const pl: Catalog = {
+	notice: {
+		danger: 'Problemy',
+		warning: 'Warto wiedzieć',
+		info: 'Uwagi',
+	},
+
+	promo: {
+		greeting: 'Dziękujemy za korzystanie z iRacing Screenshot Tool!',
+		signature: 'Stworzone i rozwijane przez AR Media Solutions.',
+	},
+
+	changelog: {
+		title: 'Lista zmian',
+		untitledRelease: 'Wydanie',
+	},
+
+	gallery: {
+		menu: {
+			openExternally: 'Otwórz w innej aplikacji',
+			openFolder: 'Otwórz folder',
+			copy: 'Kopiuj',
+			delete: 'Usuń',
+		},
+		copiedToClipboard: 'Skopiowano {name} do schowka',
+	},
+
+	sidebar: {
+		resolution: 'Rozdzielczość',
+		width: 'Szerokość',
+		height: 'Wysokość',
+		output: 'Wynik:',
+		cropWatermark: 'Przytnij znak wodny',
+		keepAspectRatio: 'Zachowaj proporcje',
+		screenshot: 'Zrzut ekranu',
+		custom: 'Własna',
+		vramStatus: '{adapter}{free} wolne z {total}',
+		savedSuccessfully: 'Zapisano {name}',
+		screenshotFailed: 'Nie udało się wykonać zrzutu: {message}',
+		errorLogPrefix: 'Dziennik: ',
+		notices: {
+			exclusiveFullscreen:
+				'iRacing działa w wyłącznym trybie pełnoekranowym — zrzuty będą czarne. W iRacing ustaw Display > Full Screen na OFF (Borderless lub Windowed), aby umożliwić przechwytywanie.',
+			vramRisk:
+				'{resolution} wymaga około {needed} więcej pamięci VRAM, a wolne jest tylko {free} — iRacing prawdopodobnie wyczerpie pamięć i się zawiesi.',
+			vramCaution:
+				'{resolution} zostawia niewielki zapas pamięci VRAM ({free} wolne) i może się zawiesić przy wymagających kombinacjach toru i samochodu.',
+			switchResolution: 'Przełącz na {resolution}',
+			vramStatic:
+				'Wysokie rozdzielczości mogą spowodować awarię iRacing, jeśli zabraknie pamięci VRAM. Niektóre kombinacje toru i samochodu wymagają jej więcej.',
+			reshade:
+				'Po naciśnięciu przycisku zrzutu w iRacing Screenshot Tool trzeba jeszcze użyć skrótu klawiszowego zrzutu ekranu z ReShade.',
+			crop: 'Przycięcie znaku wodnego nieznacznie przybliża końcowy obraz. Obszary przy krawędziach ekranu zostaną obcięte.',
+			aspectRatio:
+				'„Zachowaj proporcje” dopasowuje wysokość zrzutu do proporcji Twojego monitora (np. 21:9 ultrapanoramicznego) zamiast domyślnych 16:9. Wybrana rozdzielczość wyznacza szerokość.',
+		},
+	},
+
+	settings: {
+		title: 'Ustawienia',
+		version: 'Wersja - {version}',
+		changelog: 'Lista zmian',
+		openLogsFolder: 'Otwórz folder dzienników',
+		checkForUpdates: 'Sprawdź aktualizacje',
+		updateCheckFailed: 'Sprawdzanie aktualizacji nie powiodło się: {message}',
+
+		language: 'Język',
+		languageDescription:
+			'Język używany w całej aplikacji. Wykrywany z systemu Windows przy pierwszym uruchomieniu.',
+
+		screenshotFolder: 'Folder zrzutów ekranu',
+		selectFolder: 'Wybierz folder',
+		screenshotKeybind: 'Skrót klawiszowy zrzutu',
+		editBind: 'Zmień skrót',
+
+		customFilenameFormat: 'Własny format nazwy pliku',
+		customFilenameFormatDescription:
+			'Użyj własnego wzorca zamiast domyślnego ({track}-{driver}-{counter})',
+		filenameFieldsHint:
+			'Kliknij pola, aby dodać je do formatu. Separatory (-, _ itp.) wpisuj bezpośrednio.',
+		reset: 'Przywróć',
+		preview: 'Podgląd:',
+
+		outputFormat: 'Format wyjściowy',
+		formatJpeg: 'JPEG (najwyższa jakość)',
+		formatPng: 'PNG (bezstratny)',
+		formatWebp: 'WebP (jakość 95%)',
+
+		disableTooltips: 'Ukryj podpowiedzi',
+		disableTooltipsDescription: 'Zostaw mnie w spokoju, wiem, co robię',
+
+		cropTopLeft: 'Preferuj przycięcie znaku wodnego z lewego górnego rogu',
+		cropTopLeftDescription:
+			'Przycina tylko prawy dolny róg (3%). Gdy opcja jest wyłączona, zrzut jest przycinany równomiernie ze wszystkich stron (łącznie 6%), co daje wyśrodkowany rezultat.',
+
+		manualWindowRestore: 'Ręczne przywracanie okna',
+		manualWindowRestoreDescription:
+			'Zastępuje automatyczne przywracanie okna własną pozycją i rozmiarem. Przydatne przy monitorach ultrapanoramicznych lub Nvidia Surround.',
+		left: 'Lewo',
+		top: 'Góra',
+		width: 'Szerokość',
+		height: 'Wysokość',
+		restoreNow: 'Przywróć teraz',
+
+		nativeCapture: 'Przechwytywanie wysokiej jakości (WGC)',
+		nativeCaptureDescription:
+			'Przechwytuje prawdziwy kolor bez podpróbkowania przez Windows.Graphics.Capture zamiast domyślnego potoku (który podpróbkowuje kolor). W razie niepowodzenia automatycznie wraca do metody zapasowej.',
+		nativeCaptureUnavailable:
+			'Niedostępne w tym systemie — przechwytywanie wysokiej jakości nie może tu działać.',
+		nativeCaptureUnverified:
+			'Windows zgłasza obsługę, ale testowe przechwycenie nie powróciło. Jeśli błąd się powtórzy, przechwytywanie automatycznie przejdzie na metodę zapasową.',
+
+		reshade: 'Tryb zgodności z ReShade',
+		reshadeDescription:
+			'Korzystając z ReShade, musisz najpierw użyć skrótu iRacing Screenshot Tool lub nacisnąć przycisk, a następnie — gdy okno iRacing zmieni rozmiar — użyć skrótu zrzutu ekranu z ReShade.',
+		reshadeIni: 'Plik INI ReShade',
+		selectFile: 'Wybierz plik',
+	},
+
+	longExposure: {
+		title: 'Długie naświetlanie',
+		shutter: 'Czas migawki',
+		playbackSpeed: 'Prędkość odtwarzania',
+		playbackAuto: 'Automatycznie (z docelowej liczby próbek)',
+		playbackRealTime: '1x (czas rzeczywisty)',
+		targetSamples: 'Docelowa liczba próbek',
+		advanced: 'Zaawansowane',
+		defaultsSummary: 'wartości domyślne: {count}',
+
+		weighting: 'Ważenie',
+		weightingBox: 'Box (równomierne)',
+		weightingLinear: 'Liniowe (ostre na końcu)',
+		weightingEase: 'Ease (ostrzejszy początek, długi ogon)',
+
+		interpolation: 'Interpolacja klatek',
+		interpolationOff: 'Wyłączona',
+		interpolation2: '2× (jedna klatka pośrednia)',
+		interpolation4: '4× (trzy klatki pośrednie)',
+		interpolation8: '8× (siedem klatek pośrednich)',
+
+		passes: 'Przebiegi',
+		passes1: '1 (pojedynczy przebieg)',
+		passes2: '2× — dwukrotnie dłuższe oczekiwanie',
+		passes4: '4× — czterokrotnie dłuższe oczekiwanie',
+		passes8: '8× — ośmiokrotnie dłuższe oczekiwanie',
+
+		bracket: 'Bracketing czasów migawki',
+		highlightRecovery: 'Odzyskiwanie świateł (EV)',
+
+		cancel: 'Anuluj',
+		saved: 'Zapisano długie naświetlanie — próbek: {count}',
+		failed: 'Długie naświetlanie nie powiodło się',
+
+		modified: {
+			weighting_linear: 'liniowe',
+			weighting_ease: 'ease',
+			interpolation: 'interpolacja {factor}×',
+			passes: {
+				one: '{count} przebieg',
+				few: '{count} przebiegi',
+				many: '{count} przebiegów',
+				other: '{count} przebiegów',
+			},
+			bracketed: 'bracketing',
+			recovery: 'odzyskiwanie {stops} EV',
+		},
+
+		progress: {
+			working: 'Pracuję…',
+			seeking: 'Wyszukiwanie…{pass}',
+			accumulating: 'Naświetlanie… próbek: {count}{pass}',
+			resolving: 'Wywoływanie…',
+			restoring: 'Przywracanie powtórki…',
+			pass: ' (przebieg {current} z {total})',
+		},
+
+		notices: {
+			needsNativeCapture:
+				'Długie naświetlanie wymaga przechwytywania wysokiej jakości (WGC), które jest obecnie wyłączone. Włącz je w ustawieniach, aby korzystać z długiego naświetlania.',
+			unavailableWithReason:
+				'Długie naświetlanie jest niedostępne na tym komputerze: {reason}',
+			unavailable: 'Długie naświetlanie jest niedostępne na tym komputerze.',
+			interpolationCost:
+				'Interpolacja wymyśla klatki pomiędzy prawdziwymi, aby wygładzić smugę. Kosztuje czas GPU na każdą klatkę, więc porównaj liczbę prawdziwych próbek zapisanego ujęcia z tym samym ujęciem bez interpolacji — jeśli ta liczba spada, kupuje ona wymyślone próbki za prawdziwe.',
+			passesAndInterpolation:
+				'Przebiegi i interpolacja rywalizują o ten sam budżet na klatkę. Gdy oba są włączone, każdy przebieg przechwytuje mniej prawdziwych klatek — wyłączenie interpolacji zwykle daje lepsze ujęcie przy tym samym czasie oczekiwania.',
+			passes:
+				'Każdy przebieg odtwarza ten sam moment i wyłapuje klatki pominięte przez pozostałe, dzięki czemu smuga staje się gładsza, a nie jaśniejsza. Najlepiej sprawdza się przy krótkich czasach migawki, gdzie pojedynczy przebieg zbiera zaledwie garść próbek.',
+			interpolationUnsupported:
+				'Interpolacja klatek wymaga karty NVIDIA Turing lub nowszej{adapter}. Cała reszta długiego naświetlania działa normalnie.',
+			interpolationAdapter: ' (to przechwytywanie działa na {adapter})',
+			reshade:
+				'Długie naświetlanie przechwytuje natywnie i nie korzysta z ReShade, więc efekty ReShade nie pojawią się w wyniku.',
+		},
+	},
+
+	help: {
+		title: 'Pomoc',
+		sections: 'Sekcje pomocy',
+		tabGeneral: 'Ogólne',
+		tabLongExposure: 'Długie naświetlanie',
+
+		general: {
+			iracingSettings: 'Ustawienia iRacing',
+			borderless: 'iRacing musi działać w trybie Windowed Borderless',
+			vram: 'Do zrzutów w rozdzielczości 8K i wyższej zalecane jest co najmniej 8 GB pamięci VRAM',
+			newerContent: 'Nowsze tory i samochody wymagają więcej pamięci VRAM',
+			shrinkUi:
+				'Jeśli korzystasz z opcji przycinania znaku wodnego, przed zrzutem zmniejsz interfejs do minimum — skrót „Control+PageDown” go pomniejsza. Jeśli to nie działa, może być konieczne zresetowanie powiększenia interfejsu w ustawieniach iRacing.',
+
+			screenshotFolder: 'Folder zrzutów ekranu',
+			screenshotFolderBody:
+				'Zrzuty są domyślnie zapisywane w „C:\\Users\\user\\Pictures\\Screenshots”; można to zmienić w ustawieniach.',
+
+			screenshotHotkey: 'Skrót klawiszowy zrzutu',
+			screenshotHotkeyBody:
+				'Domyślnie „Control + PrintScreen” wykonuje zrzut z bieżącymi ustawieniami; skrót można zmienić w ustawieniach.',
+
+			issues: 'Problemy',
+			issuesBody: 'W razie problemów zgłoś je na',
+			discord: 'Discordzie',
+
+			instructions: 'Instrukcja',
+			step1: 'iRacing <b>musi</b> działać w trybie Windowed Borderless',
+			step2: 'Uruchom iRacing i ustaw kamerę w pozycji, z której chcesz wykonać zrzut',
+			step3: 'Wybierz żądaną rozdzielczość (wypróbuj niższe rozdzielczości, zanim przejdziesz do 8K)',
+			step4: 'Zdecyduj, czy chcesz przyciąć znak wodny iRacing; jeśli tak, najpierw zmniejsz interfejs iRacing do najmniejszego rozmiaru skrótem „Control + PageDown”',
+			step5: 'Naciśnij przycisk zrzutu lub użyj skrótu „Control + PrintScreen”, aby wykonać zrzuty',
+			step6: 'W zależności od wybranej rozdzielczości może to potrwać kilka sekund; gdy okno iRacing wróci do normalnego rozmiaru, operacja jest zakończona',
+			step7: 'Twój zrzut zostanie zapisany w „C:\\Users\\{User}\\Pictures\\Screenshots”',
+		},
+
+		longExposure: {
+			whatItDoes: 'Co to robi',
+			whatItDoesBody:
+				'Długie naświetlanie łączy wiele klatek powtórki w jeden obraz, tak jak pozostawiona otwarta migawka aparatu: to, co nieruchome, pozostaje ostre, a to, co się porusza, zostawia smugę. Narzędzie samo steruje powtórką, przechwytuje każdą klatkę wyświetlaną przez symulator i sumuje je na GPU.',
+
+			shutter: 'Czas migawki',
+			shutterBody:
+				'Jak długo trwa naświetlanie <i>w czasie powtórki</i>, od ułamka jednej klatki powtórki do dziesięciu sekund. To ustawienie decyduje o długości smug. Dłuższe czasy migawki zbierają też więcej klatek, więc mniej potrzebują wszystkiego poniżej; najkrótsze wartości obejmują pojedynczą klatkę powtórki i zbierają zaledwie garść próbek.',
+
+			playback: 'Prędkość odtwarzania',
+			playbackBody:
+				'Podczas przechwytywania naświetlenia powtórka jest odtwarzana w zwolnionym tempie, dzięki czemu symulator wyświetla więcej klatek na sekundę czasu powtórki, a złożenie otrzymuje więcej próbek. 1/16 zbiera mniej więcej szesnaście razy więcej klatek niż czas rzeczywisty — i trwa szesnaście razy dłużej w czasie rzeczywistym. To główny kompromis w tym panelu: cierpliwość za gładkość.',
+			playbackAutoBody:
+				'„Automatycznie (z docelowej liczby próbek)” dobiera prędkość na podstawie <b>docelowej liczby próbek</b>: narzędzie wyznacza najszybsze odtwarzanie, które nadal osiąga żądaną liczbę. Ustaw konkretną prędkość, jeśli wolisz ograniczyć czas oczekiwania.',
+
+			weighting: 'Ważenie',
+			weightingBody:
+				'Jak bardzo każda przechwycona klatka wpływa na wynik. <b>Box</b> waży wszystkie jednakowo, dając równomierną smugę. <b>Liniowe</b> narasta ku końcowi okna, więc obiekt jest najostrzejszy tam, gdzie zakończył ruch, i zanika wzdłuż swojej drogi. <b>Ease</b> to ta sama idea z ostrzejszym początkiem i dłuższym ogonem.',
+
+			interpolation: 'Interpolacja klatek',
+			interpolationBody:
+				'Wymyśla dodatkowe klatki pomiędzy prawdziwymi, korzystając z układu przepływu optycznego GPU, i wypełnia luki w smudze. Wymaga karty NVIDIA Turing lub nowszej, a na sprzęcie, który tego nie obsługuje, jest całkowicie ukryta.',
+			interpolationCostBody:
+				'Nie jest darmowa: kosztuje czas GPU przy każdej przechwyconej klatce, a budżet to jedna klatka iRacing. Jeśli nie nadąża, zaczyna gubić <i>prawdziwe</i> klatki, by wytworzyć syntetyczne, co jest stratą netto — smuga wychodzi krótsza i bardziej poszarpana. Koszt rośnie z liczbą megapikseli pomnożoną przez współczynnik, więc to, co jest wygodne przy 2560×1440, nie sprawdzi się w 8K. Aby to sprawdzić, wykonaj to samo ujęcie dwa razy, z interpolacją i bez, i porównaj liczbę prawdziwych próbek; aplikacja ostrzeże Cię też po fakcie, jeśli ujęcie okaże się niepełne.',
+
+			passes: 'Przebiegi',
+			passesBody:
+				'Odwiedza ten sam moment wielokrotnie, sumując wszystko w jeden obraz. Każdy przebieg wyłapuje klatki, które inne przypadkiem pominęły, więc smuga staje się gładsza — nie jaśniejsza, ponieważ wynik jest normalizowany według ilości światła, które faktycznie padło na każdy piksel.',
+			passesTradeBody:
+				'Przebiegi kupują to samo co interpolacja, ale inną walutą: czasem rzeczywistym zamiast czasu GPU. Osiem przebiegów trwa mniej więcej osiem razy dłużej, ale nigdy nie może Cię kosztować prawdziwych klatek. To czyni je właściwą dźwignią przy wysokich rozdzielczościach, gdzie interpolacja nie nadąża, oraz przy krótkich czasach migawki, gdzie pojedynczy przebieg zbiera bardzo mało próbek. Używanie obu naraz to zwykle najgorsze z rozwiązań — rywalizują o ten sam budżet na klatkę.',
+
+			bracket: 'Bracketing czasów migawki',
+			bracketBody:
+				'Z jednego przechwycenia tworzy po jednym obrazie dla każdego czasu migawki równego wybranemu lub krótszego. Ujęcie przy 1/60 daje także 1/125, 1/250, 1/500 i 1/1000 — ten sam moment z coraz krótszymi smugami — dzięki czemu wybierasz efekt później, zamiast zgadywać i powtarzać ujęcie.',
+			bracketCostBody:
+				'Nie kosztuje to praktycznie żadnego dodatkowego czasu. Każdy czas kończy się na tej samej klatce i różni się tylko tym, jak daleko sięga wstecz, więc krótsza migawka to po prostu końcówka klatek, które i tak przelatują — wszystkie są wypełniane z jednego przebiegu powtórki.',
+			bracketMemoryBody:
+				'Kosztuje natomiast pamięć. Każdy czas potrzebuje własnego akumulatora w pełnej rozdzielczości, więc jedenaście czasów wymaga jedenastokrotnie więcej pamięci karty niż jeden, co przy 8K przekracza możliwości większości kart. Przechwytywanie sprawdza to przed startem i odmawia, zamiast doprowadzić do awarii iRacing; jeśli bracketing zostanie odrzucony, obniż rozdzielczość albo wybierz krótszy czas migawki — co daje też krótszą drabinkę.',
+			bracketNamingBody:
+				'Wybrany przez Ciebie czas jest zapisywany pod zwykłą nazwą i to on pojawia się w galerii; pozostałe leżą obok, z czasem migawki w nazwie pliku.',
+
+			highlights: 'Odzyskiwanie świateł',
+			highlightsBody:
+				'Wzmacnia światła bliskie przepaleniu, zanim klatki zostaną zsumowane, a na końcu cofa to wzmocnienie. iRacing przekazuje obraz już po mapowaniu tonalnym, więc reflektor i biała ściana docierają z tą samą wartością; uśrednienie tego sprawia, że jasne światło przemieszczające się przez część naświetlenia wygląda jak szara smuga zamiast jasnego śladu. Ta opcja przywraca nieliniowość tam, gdzie ma ją prawdziwa matryca. Mierzone w działkach EV; 0 oznacza wyłączenie i nie zmienia zupełnie nic.',
+
+			whatItSaves: 'Co zapisuje',
+			whatItSavesBody:
+				'Rozmiar, przycinanie znaku wodnego i format pliku podlegają tym samym ustawieniom co zwykły zrzut ekranu — opcjom Rozdzielczość i Przytnij znak wodny powyżej oraz formatowi wyjściowemu w ustawieniach. Wiersz „Wynik” na górze panelu bocznego pokazuje dokładnie to, co otrzymasz.',
+			whatItSavesPngBody:
+				'Wybór PNG zapisuje prawdziwy 16-bitowy master, co ma sens, jeśli zamierzasz później korygować kolory, oraz 8-bitowy podgląd do galerii. Zapis jest też znacznie wolniejszy przy wysokich rozdzielczościach — 16-bitowy PNG o wielkości 33 megapikseli zajmuje około dziesięciu sekund, podczas gdy ta sama klatka w JPEG poniżej sekundy.',
+
+			troubleshooting: 'Jeśli wynik wygląda źle',
+			troubleGhosts:
+				'<b>Osobne duchy zamiast gładkiej smugi</b> — zbyt mało próbek. Użyj wolniejszej prędkości odtwarzania, większej liczby przebiegów albo niższej rozdzielczości.',
+			troubleShutter:
+				'<b>Nie wiesz, jakiego czasu migawki chciałeś</b> — włącz bracketing czasów migawki i zdecyduj później, przy tym samym czasie oczekiwania.',
+			troubleHighlights:
+				'<b>Przepalone lub płaskie światła</b> — spróbuj od 3 do 5 działek odzyskiwania świateł.',
+			troubleBlack:
+				'<b>Czarny obraz</b> — iRacing działa w wyłącznym trybie pełnoekranowym. Ustaw Display &gt; Full Screen na OFF.',
+			troubleSidecar:
+				'Każde ujęcie zapisuje dokładnie użyte ustawienia, liczbę próbek i to, jak równomiernie były rozłożone, w pliku .json w folderze dzienników obok app.log. Przechowywanych jest ostatnich 20 ujęć — bracketing liczy się jako jedno — więc ujęcie, o które pytasz, wciąż tam jest, gdy o nie pytasz.',
+		},
+	},
+
+	update: {
+		checking: 'Sprawdzanie aktualizacji…',
+		newVersion: 'Nowa wersja',
+		availableBusy:
+			'Dostępna jest wersja {version}. Trwa przechwytywanie — będzie można ją pobrać, gdy się zakończy.',
+		available: 'Dostępna jest wersja {version}. Kliknij, aby ją pobrać.',
+		downloading: 'Pobieranie wersji {version}…',
+		downloadingPercent: 'Pobieranie wersji {version} — {percent}%',
+		downloadedBusy:
+			'Wersja {version} jest gotowa. Trwa przechwytywanie, więc zostanie zainstalowana po zamknięciu aplikacji.',
+		downloaded:
+			'Wersja {version} jest gotowa. Kliknij, aby uruchomić ponownie i zainstalować.',
+		failed: 'Sprawdzanie aktualizacji nie powiodło się: {error}',
+		unknownError: 'nieznany błąd',
+		neverChecked:
+			'Nie sprawdzano jeszcze aktualizacji (masz wersję v{version}).',
+		upToDate: 'Masz najnowszą wersję (v{version}).',
+
+		alreadyDownloading: 'Aktualizacja jest już pobierana.',
+		alreadyDownloaded: 'Aktualizacja została już pobrana.',
+		nothingToDownload: 'Nie ma aktualizacji do pobrania.',
+		captureInProgress:
+			'Trwa przechwytywanie. Spróbuj ponownie, gdy się zakończy.',
+		nothingToInstall: 'Żadna aktualizacja nie czeka na instalację.',
+		captureInProgressInstall:
+			'Trwa przechwytywanie. Aktualizacja zainstaluje się sama po zamknięciu aplikacji.',
+		devBuildOnly:
+			'Sprawdzanie aktualizacji działa tylko w zainstalowanej wersji.',
+
+		installTitle: 'Zainstaluj aktualizację',
+		installMessage: 'Zainstalować wersję {version}?',
+		installFallbackVersion: 'aktualizację',
+		installDetail:
+			'Aplikacja zostanie zamknięta i otwarta ponownie po zainstalowaniu aktualizacji. Jeśli wybierzesz „Później”, zainstaluje się sama przy następnym zamknięciu aplikacji.',
+		installConfirm: 'Uruchom ponownie i zainstaluj',
+		installLater: 'Później',
+	},
+
+	filenameFields: {
+		categories: {
+			Track: 'Tor',
+			Driver: 'Kierowca',
+			Session: 'Sesja',
+			Meta: 'Meta',
+		},
+		track: 'Tor',
+		trackFull: 'Tor (pełna nazwa)',
+		trackCity: 'Miasto',
+		trackCountry: 'Kraj',
+		trackType: 'Typ toru',
+		driver: 'Kierowca',
+		driverAbbrev: 'Kierowca (skrót)',
+		driverInitials: 'Inicjały',
+		team: 'Zespół',
+		carNumber: 'Nr auta',
+		car: 'Samochód',
+		carFull: 'Samochód (pełna nazwa)',
+		carClass: 'Klasa samochodu',
+		iRating: 'iRating',
+		sessionType: 'Typ sesji',
+		sessionName: 'Nazwa sesji',
+		lap: 'Okrążenie',
+		date: 'Data',
+		time: 'Godzina',
+		datetime: 'Data+godzina',
+		counter: 'Licznik',
+	},
+
+	iracingConfig: {
+		projections:
+			'Wyłącz „Render Scene Using 3 Projections” w iRacing (karta Display > Monitor), aby uniknąć pionowych pasów na zrzutach',
+	},
+
+	wgc: {
+		cursorCaveat:
+			'W tej wersji systemu Windows kursor myszy może pojawiać się na zrzutach. Windows 10 w wersji 2004 dodał ustawienie, które go ukrywa.',
+		addonUnavailable:
+			'Nie udało się załadować składnika przechwytywania wysokiej jakości w tym systemie.',
+		osUnsupported:
+			'Windows.Graphics.Capture nie jest dostępne w tej wersji systemu Windows. Wymaga Windows 10 w wersji 1903 lub nowszej.',
+		nativeCaptureOff: 'Przechwytywanie wysokiej jakości (WGC) jest wyłączone',
+	},
+
+	capture: {
+		exclusiveFullscreen:
+			'iRacing działa w wyłącznym trybie pełnoekranowym, więc zrzut byłby czarny. W iRacing ustaw Display > Full Screen na OFF (użyj Borderless lub Windowed) i spróbuj ponownie.',
+		exclusiveFullscreenUnattributed:
+			'Jakaś aplikacja działa w wyłącznym trybie pełnoekranowym, co daje czarny zrzut. Jeśli iRacing jest w trybie pełnoekranowym, ustaw Display > Full Screen na OFF (użyj Borderless lub Windowed) i spróbuj ponownie.',
+		unknownError: 'Nieznany błąd zrzutu ekranu',
+		outputTooSmall: 'Przechwycony obraz jest za mały ({width}x{height})',
+		blackFrame:
+			'Przechwycona klatka jest czarna — źródło przechwytywania mogło zawieść (w niektórych konfiguracjach Windows treści akcelerowane przez GPU nie dają się przechwycić)',
+		noSource:
+			'Nie znaleziono źródła przechwytywania pulpitu dla okna {windowId}',
+		metadataTimeout:
+			'Przekroczono czas oczekiwania na metadane wideo przechwytywania',
+		noVideoFrame:
+			'Strumień przechwytywania nie dostarczył żadnej klatki wideo',
+		dimensionTimeout:
+			'Przekroczono czas oczekiwania na wymiary okna {width}x{height}; kontynuowanie z {actualWidth}x{actualHeight}',
+	},
+
+	longExposureCapture: {
+		busy: 'Przechwytywanie jest już w toku.',
+		needsNativeCapture:
+			'Długie naświetlanie wymaga przechwytywania wysokiej jakości (WGC). Włącz je w ustawieniach, aby z niego korzystać.',
+		unavailable: 'Długie naświetlanie jest niedostępne na tym komputerze.',
+		noTelemetry:
+			'Długie naświetlanie wymaga telemetrii powtórki z iRacing. Sprawdź, czy symulator jest uruchomiony i znajduje się w sesji.',
+		windowNotFound: 'Nie znaleziono okna iRacing.',
+		cancelled: 'Przechwytywanie anulowane.',
+		seekTimeout:
+			'Powtórka nie dotarła na czas do klatki {frame}. Może się jeszcze wczytywać.',
+		noPasses: 'Przechwytywanie musi wykonać co najmniej jeden przebieg.',
+		playbackStalled:
+			'Powtórka nie ruszyła. Sprawdź, czy iRacing nie został wstrzymany przez inne narzędzie.',
+		exposureTimeout:
+			'Naświetlanie nie dotarło do klatki {frame} w ciągu {seconds} s.',
+		endedEarly:
+			'Naświetlanie zakończyło się przed osiągnięciem wybranego momentu.',
+		noFramesPresented:
+			'iRacing nie wyświetlił żadnych klatek do przechwycenia.',
+		subFrameNoSamples:
+			'Ten czas migawki jest krótszy niż jedna klatka powtórki, a iRacing nie wyrenderował w nim żadnej klatki. Spróbuj wolniejszej prędkości odtwarzania albo kolejnego dłuższego czasu migawki.',
+		noSamples:
+			'Nie zebrano żadnych klatek. iRacing mógł przestać renderować w trakcie naświetlania.',
+		withNativeError: '{reason} ({error})',
+		resolveFailed: 'GPU nie zwróciło obrazu.',
+		bracketShortfall:
+			'Bracketing zażądał {asked} czasów, ale wróciło {returned} — pozostałych nie udało się rozwiązać albo ta wersja składnika przechwytywania jest starsza niż bracketing.',
+	},
+
+	validation: {
+		windowBeforeStart:
+			'Naświetlanie wymaga {frames} klatek powtórki przed wybranym momentem, a znajduje się on zaledwie {anchor} klatek od początku powtórki. Wybierz późniejszy moment albo krótszy czas migawki.',
+		pastEnd: 'Wybrany moment znajduje się poza końcem powtórki.',
+		sessionChanged:
+			'Od czasu przygotowania tego ujęcia powtórka przeszła do innej sesji. Wybierz moment ponownie.',
+		singleSampleMultiPass:
+			'Ten czas migawki jest tak krótki, że mieści się w nim około jednej klatki na przebieg, więc {passes} przebiegów zbierze mniej więcej {passes} próbek. Wolniejsza prędkość odtwarzania albo dłuższy czas migawki dadzą znacznie więcej.',
+		singleSample:
+			'Ten czas migawki jest tak krótki, że zmieści się w nim tylko jedna klatka, więc wynik nie będzie miał rozmycia ruchu. Wolniejsza prędkość odtwarzania albo dłuższy czas migawki dostarczą próbek.',
+		bracketVsInterpolation:
+			'Bracketing czasów migawki i {factor}x interpolacja klatek nie mogą działać jednocześnie, więc to ujęcie zostanie wykonane bez interpolacji. Wyłącz bracketing, jeśli klatki pośrednie są dla Ciebie ważniejsze niż dodatkowe czasy.',
+		passesVsInterpolation:
+			'Włączone są zarówno wiele przebiegów, jak i {factor}x interpolacja. Rywalizują ze sobą: interpolacja spowalnia każdy przebieg na tyle, że kosztuje go prawdziwe klatki, więc ten sam czas oczekiwania kupuje mniej prawdziwych próbek niż same przebiegi. Wyłączenie interpolacji zwykle daje lepsze ujęcie.',
+		shortOfTarget:
+			'Nawet przy prędkości 1/{divisor} to naświetlanie osiąga około {samples} próbek, mniej niż żądane {target}. Użyj dłuższego czasu migawki, aby uzyskać więcej.',
+		longCaptureEscalate:
+			'To przechwytywanie odtwarza powtórkę z prędkością 1/{divisor} przez około {duration} czasu rzeczywistego{passSuffix} i po rozpoczęciu nie da się go przyspieszyć. {advice}',
+		longCaptureWarn:
+			'To przechwytywanie potrwa około {duration} czasu rzeczywistego przy prędkości odtwarzania 1/{divisor}{passSuffix}.',
+		passSuffix: ', rozłożone na {passes} przebiegów przez ten sam moment',
+		adviceFewerPasses:
+			'Mniej przebiegów kończy się wcześniej, przy mniejszej liczbie próbek.',
+		adviceFasterPlayback:
+			'Wyższa prędkość odtwarzania kończy się wcześniej, przy mniejszej liczbie próbek.',
+		pastLogCap:
+			'Przewiduje się, że to przechwytywanie zbierze około {samples} próbek w {passes} przebiegach, powyżej {cap}, które mieści dziennik diagnostyczny. Nie ma to wpływu na obraz — jedynie wskaźniki równomierności i przerw opiszą pierwszą część przechwytywania.',
+		interpolationLossy:
+			'Przy tym rozmiarze {factor}x interpolacja już wcześniej kosztowała ten komputer prawdziwe próbki. Rozważ niższy współczynnik, niższą rozdzielczość albo zamiast tego więcej przebiegów.',
+	},
+
+	duration: {
+		zero: '0 sekund',
+		seconds: {
+			one: '{count} sekunda',
+			few: '{count} sekundy',
+			many: '{count} sekund',
+			other: '{count} sekund',
+		},
+		minutes: {
+			one: '{count} minuta',
+			few: '{count} minuty',
+			many: '{count} minut',
+			other: '{count} minut',
+		},
+		minutesSeconds: '{minutes} min {seconds} s',
+	},
+};
+
+export default pl;

--- a/src/locales/pt.ts
+++ b/src/locales/pt.ts
@@ -1,0 +1,481 @@
+// Portuguese (European). Translated from en.ts — see that file's header before
+// editing.
+//
+// Product and technology names stay untranslated: iRacing, ReShade, Discord,
+// Windows.Graphics.Capture, WGC, VRAM, GPU, NVIDIA Turing and the file formats.
+
+import type { Catalog } from './index';
+
+const pt: Catalog = {
+	notice: {
+		danger: 'Problemas',
+		warning: 'A ter em conta',
+		info: 'Notas',
+	},
+
+	promo: {
+		greeting: 'Obrigado por usar o iRacing Screenshot Tool!',
+		signature: 'Criado e mantido pela AR Media Solutions.',
+	},
+
+	changelog: {
+		title: 'Registo de alterações',
+		untitledRelease: 'Versão',
+	},
+
+	gallery: {
+		menu: {
+			openExternally: 'Abrir noutra aplicação',
+			openFolder: 'Abrir pasta',
+			copy: 'Copiar',
+			delete: 'Eliminar',
+		},
+		copiedToClipboard: '{name} copiado para a área de transferência',
+	},
+
+	sidebar: {
+		resolution: 'Resolução',
+		width: 'Largura',
+		height: 'Altura',
+		output: 'Saída:',
+		cropWatermark: 'Recortar marca de água',
+		keepAspectRatio: 'Manter proporção',
+		screenshot: 'Captura',
+		custom: 'Personalizada',
+		vramStatus: '{adapter}{free} livres de {total}',
+		savedSuccessfully: '{name} guardado com sucesso',
+		screenshotFailed: 'A captura falhou: {message}',
+		errorLogPrefix: 'Registo: ',
+		notices: {
+			exclusiveFullscreen:
+				'O iRacing está em ecrã inteiro exclusivo — as capturas ficarão pretas. No iRacing, coloca Display > Full Screen em OFF (Borderless ou Windowed) para permitir a captura.',
+			vramRisk:
+				'{resolution} precisa de cerca de {needed} de VRAM adicional, mas só {free} estão livres — o iRacing irá provavelmente ficar sem memória e fechar.',
+			vramCaution:
+				'{resolution} deixa pouca margem de VRAM ({free} livres) e pode falhar em combinações exigentes de pista e carro.',
+			switchResolution: 'Mudar para {resolution}',
+			vramStatic:
+				'Resoluções elevadas podem fazer o iRacing falhar se ficares sem VRAM. Certas combinações de pista e carro exigem mais VRAM.',
+			reshade:
+				'Depois de premires o botão de captura no iRacing Screenshot Tool, terás de premir o atalho de captura do ReShade.',
+			crop: 'Recortar a marca de água aproxima ligeiramente a imagem final. As zonas junto às margens do ecrã ficarão cortadas.',
+			aspectRatio:
+				'«Manter proporção» ajusta a altura da captura à proporção do teu monitor (por exemplo 21:9 ultrapanorâmico) em vez do 16:9 predefinido. A resolução escolhida define a largura.',
+		},
+	},
+
+	settings: {
+		title: 'Definições',
+		version: 'Versão - {version}',
+		changelog: 'Registo de alterações',
+		openLogsFolder: 'Abrir pasta de registos',
+		checkForUpdates: 'Procurar atualizações',
+		updateCheckFailed: 'A procura de atualizações falhou: {message}',
+
+		language: 'Idioma',
+		languageDescription:
+			'O idioma usado em toda a aplicação. Detetado a partir do Windows no primeiro arranque.',
+
+		screenshotFolder: 'Pasta das capturas',
+		selectFolder: 'Escolher pasta',
+		screenshotKeybind: 'Atalho de captura',
+		editBind: 'Editar atalho',
+
+		customFilenameFormat: 'Formato de nome de ficheiro personalizado',
+		customFilenameFormatDescription:
+			'Usar um padrão próprio em vez do predefinido ({track}-{driver}-{counter})',
+		filenameFieldsHint:
+			'Clica nos campos para os adicionar ao formato. Escreve os separadores (-, _, etc.) diretamente.',
+		reset: 'Repor',
+		preview: 'Pré-visualização:',
+
+		outputFormat: 'Formato de saída',
+		formatJpeg: 'JPEG (qualidade máxima)',
+		formatPng: 'PNG (sem perdas)',
+		formatWebp: 'WebP (qualidade 95%)',
+
+		disableTooltips: 'Ocultar sugestões',
+		disableTooltipsDescription: 'Deixa-me em paz, eu sei o que estou a fazer',
+
+		cropTopLeft:
+			'Preferir recorte da marca de água no canto superior esquerdo',
+		cropTopLeftDescription:
+			'Recorta apenas o canto inferior direito (3%). Quando desativado, a captura é recortada por igual em todos os lados (6% no total), dando um resultado centrado.',
+
+		manualWindowRestore: 'Restauro manual da janela',
+		manualWindowRestoreDescription:
+			'Substitui o restauro automático da janela por uma posição e um tamanho próprios. Útil para quem usa ultrapanorâmico ou Nvidia Surround.',
+		left: 'Esquerda',
+		top: 'Topo',
+		width: 'Largura',
+		height: 'Altura',
+		restoreNow: 'Restaurar agora',
+
+		nativeCapture: 'Captura de alta fidelidade (WGC)',
+		nativeCaptureDescription:
+			'Captura cor real sem subamostragem através do Windows.Graphics.Capture em vez do pipeline predefinido (que subamostra a cor). Recorre automaticamente à alternativa se uma captura falhar.',
+		nativeCaptureUnavailable:
+			'Indisponível neste sistema — a captura de alta fidelidade não pode funcionar aqui.',
+		nativeCaptureUnverified:
+			'O Windows indica que é suportada, mas uma captura de teste não chegou a devolver resultado. As capturas recorrerão automaticamente à alternativa se continuar a falhar.',
+
+		reshade: 'Modo de compatibilidade com ReShade',
+		reshadeDescription:
+			'Ao usar o ReShade terás de usar primeiro o atalho do iRacing Screenshot Tool ou premir o botão e, depois de a janela do iRacing ser redimensionada, usar o teu atalho de captura do ReShade.',
+		reshadeIni: 'INI do ReShade',
+		selectFile: 'Escolher ficheiro',
+	},
+
+	longExposure: {
+		title: 'Longa exposição',
+		shutter: 'Obturador',
+		playbackSpeed: 'Velocidade de reprodução',
+		playbackAuto: 'Automática (a partir do objetivo de amostras)',
+		playbackRealTime: '1x (tempo real)',
+		targetSamples: 'Objetivo de amostras',
+		advanced: 'Avançado',
+		defaultsSummary: '{count} valores predefinidos',
+
+		weighting: 'Ponderação',
+		weightingBox: 'Box (uniforme)',
+		weightingLinear: 'Linear (nítida no fim)',
+		weightingEase: 'Ease (cabeça mais nítida, cauda longa)',
+
+		interpolation: 'Interpolação de fotogramas',
+		interpolationOff: 'Desativada',
+		interpolation2: '2× (um fotograma intermédio)',
+		interpolation4: '4× (três fotogramas intermédios)',
+		interpolation8: '8× (sete fotogramas intermédios)',
+
+		passes: 'Passagens',
+		passes1: '1 (passagem única)',
+		passes2: '2× — o dobro da espera',
+		passes4: '4× — quatro vezes a espera',
+		passes8: '8× — oito vezes a espera',
+
+		bracket: 'Bracketing de obturador',
+		highlightRecovery: 'Recuperação de altas luzes (stops)',
+
+		cancel: 'Cancelar',
+		saved: 'Longa exposição guardada — {count} amostras',
+		failed: 'A longa exposição falhou',
+
+		modified: {
+			weighting_linear: 'linear',
+			weighting_ease: 'ease',
+			interpolation: 'interpolação {factor}×',
+			passes: {
+				one: '{count} passagem',
+				other: '{count} passagens',
+			},
+			bracketed: 'bracketing',
+			recovery: 'recuperação de {stops} stops',
+		},
+
+		progress: {
+			working: 'A processar…',
+			seeking: 'A procurar…{pass}',
+			accumulating: 'A expor… {count} amostras{pass}',
+			resolving: 'A revelar…',
+			restoring: 'A restaurar a repetição…',
+			pass: ' (passagem {current} de {total})',
+		},
+
+		notices: {
+			needsNativeCapture:
+				'A longa exposição precisa da captura de alta fidelidade (WGC), que está desativada. Ativa-a nas definições para poderes usá-la.',
+			unavailableWithReason:
+				'A longa exposição está indisponível nesta máquina: {reason}',
+			unavailable: 'A longa exposição está indisponível nesta máquina.',
+			interpolationCost:
+				'A interpolação inventa fotogramas entre os reais para suavizar o rasto. Custa tempo de GPU por fotograma, por isso compara o número de amostras reais da captura guardada com a mesma captura sem interpolação: se esse número descer, está a comprar amostras inventadas com amostras reais.',
+			passesAndInterpolation:
+				'As passagens e a interpolação competem pelo mesmo orçamento por fotograma. Com ambas ativas, cada passagem capta menos fotogramas reais — desativar a interpolação costuma dar uma captura melhor com a mesma espera.',
+			passes:
+				'Cada passagem repete o mesmo instante e apanha fotogramas que as outras falharam, pelo que o rasto fica mais uniforme e não mais claro. Ideal em obturadores rápidos, onde uma única passagem recolhe pouquíssimas amostras.',
+			interpolationUnsupported:
+				'A interpolação de fotogramas exige uma GPU NVIDIA Turing ou mais recente{adapter}. Tudo o resto na longa exposição funciona normalmente.',
+			interpolationAdapter: ' (esta captura corre em {adapter})',
+			reshade:
+				'A longa exposição capta de forma nativa e não usa o ReShade, pelo que os efeitos do ReShade não aparecerão no resultado.',
+		},
+	},
+
+	help: {
+		title: 'Ajuda',
+		sections: 'Secções de ajuda',
+		tabGeneral: 'Geral',
+		tabLongExposure: 'Longa exposição',
+
+		general: {
+			iracingSettings: 'Definições do iRacing',
+			borderless: 'O iRacing tem de estar em Windowed Borderless',
+			vram: 'São recomendados pelo menos 8 GB de VRAM para capturas em 8K ou superior',
+			newerContent: 'Pistas e carros mais recentes exigem mais VRAM',
+			shrinkUi:
+				'Reduz a interface ao mínimo antes de captar se usares a opção de recortar a marca de água; «Control+PageDown» reduz-la. Se não resultar, poderás ter de repor o zoom da interface nas definições do iRacing.',
+
+			screenshotFolder: 'Pasta das capturas',
+			screenshotFolderBody:
+				'Por predefinição, as capturas são guardadas em «C:\\Users\\user\\Pictures\\Screenshots»; isto pode ser alterado nas definições.',
+
+			screenshotHotkey: 'Atalho de captura',
+			screenshotHotkeyBody:
+				'Por predefinição, «Control + PrintScreen» faz uma captura com as definições atuais; isto pode ser alterado nas definições.',
+
+			issues: 'Problemas',
+			issuesBody: 'Se tiveres algum problema, comunica-o no',
+			discord: 'Discord',
+
+			instructions: 'Instruções',
+			step1: 'O iRacing <b>tem</b> de estar em modo Windowed Borderless',
+			step2: 'Inicia o iRacing e coloca a câmara na posição a partir da qual queres captar',
+			step3: 'Escolhe a resolução pretendida (experimenta resoluções mais baixas antes de passares a 8K)',
+			step4: 'Decide se queres recortar a marca de água do iRacing; se sim, terás primeiro de reduzir a interface do iRacing ao tamanho mínimo com «Control + PageDown»',
+			step5: 'Prime o botão de captura ou usa o atalho «Control + PrintScreen» para captar',
+			step6: 'Consoante a resolução escolhida, isto pode demorar alguns segundos; quando a janela do iRacing voltar ao tamanho normal, está concluído',
+			step7: 'A tua captura será guardada em «C:\\Users\\{User}\\Pictures\\Screenshots»',
+		},
+
+		longExposure: {
+			whatItDoes: 'O que faz',
+			whatItDoesBody:
+				'Uma longa exposição funde muitos fotogramas de uma repetição numa só imagem, tal como deixar o obturador de uma câmara aberto: o que está parado fica nítido, o que se move deixa rasto. A ferramenta comanda a própria repetição, capta cada fotograma apresentado pelo simulador e soma-os na GPU.',
+
+			shutter: 'Obturador',
+			shutterBody:
+				'Quanto tempo dura a exposição <i>em tempo de repetição</i>, de uma fração de um fotograma de repetição até dez segundos. É esta definição que determina o comprimento dos rastos. Obturadores mais lentos recolhem também mais fotogramas, pelo que precisam menos de tudo o que se segue; os passos mais rápidos abrangem um único fotograma de repetição e recolhem apenas um punhado de amostras.',
+
+			playback: 'Velocidade de reprodução',
+			playbackBody:
+				'A repetição é reproduzida em câmara lenta enquanto a exposição é captada, pelo que o simulador apresenta mais fotogramas por segundo de tempo de repetição e a mistura obtém mais amostras. 1/16 recolhe cerca de dezasseis vezes mais fotogramas do que o tempo real — e demora dezasseis vezes mais em tempo real. É o compromisso principal deste painel: paciência em troca de suavidade.',
+			playbackAutoBody:
+				'«Automática (a partir do objetivo de amostras)» escolhe a velocidade por ti a partir do <b>objetivo de amostras</b>: a ferramenta calcula a reprodução mais rápida que ainda atinge o número pedido. Define antes uma velocidade explícita se preferires limitar a espera.',
+
+			weighting: 'Ponderação',
+			weightingBody:
+				'Quanto cada fotograma captado contribui para o resultado. <b>Box</b> pondera-os todos por igual, dando um rasto uniforme. <b>Linear</b> aumenta em direção ao fim da janela, pelo que o motivo fica mais nítido onde terminou e se esbate ao longo do seu percurso. <b>Ease</b> é a mesma ideia com uma cabeça mais nítida e uma cauda mais longa.',
+
+			interpolation: 'Interpolação de fotogramas',
+			interpolationBody:
+				'Inventa fotogramas adicionais entre os reais usando o motor de fluxo ótico da GPU, preenchendo as falhas ao longo do rasto. Exige uma placa NVIDIA Turing ou mais recente e fica totalmente oculta em hardware que não o consegue fazer.',
+			interpolationCostBody:
+				'Não é gratuita: custa tempo de GPU em cada fotograma captado, e o orçamento é um fotograma do iRacing. Se não acompanhar, começa a falhar fotogramas <i>reais</i> para fabricar sintéticos, o que é uma perda líquida — o rasto sai mais curto e mais grosseiro. O custo escala com os megapíxeis vezes o fator, pelo que o que é confortável a 2560×1440 não é viável em 8K. Para verificar, capta o mesmo instante duas vezes, com e sem, e compara o número de amostras reais; a aplicação também te avisa depois se uma captura ficou aquém.',
+
+			passes: 'Passagens',
+			passesBody:
+				'Visita o mesmo instante várias vezes, acumulando numa só imagem. Cada passagem apanha fotogramas que as outras falharam, pelo que o rasto fica mais uniforme — não mais claro, porque o resultado é normalizado pela luz que efetivamente chegou a cada píxel.',
+			passesTradeBody:
+				'As passagens compram o mesmo que a interpolação, mas noutra moeda: tempo real em vez de tempo de GPU. Oito passagens demoram cerca de oito vezes mais, mas nunca te podem custar fotogramas reais. Isso faz delas a alavanca certa em resoluções altas, onde a interpolação não acompanha, e em obturadores rápidos, onde uma única passagem recolhe muito poucas amostras. Usar as duas ao mesmo tempo é normalmente o pior dos dois mundos — competem pelo mesmo orçamento por fotograma.',
+
+			bracket: 'Bracketing de obturador',
+			bracketBody:
+				'Produz uma imagem por cada passo de obturador igual ou mais rápido do que o escolhido, a partir de uma única captura. Uma captura a 1/60 dá-te também 1/125, 1/250, 1/500 e 1/1000 — o mesmo instante com rastos progressivamente mais curtos — para que possas escolher o resultado depois, em vez de adivinhar e repetir.',
+			bracketCostBody:
+				'Não custa praticamente tempo adicional. Todos os passos terminam no mesmo fotograma e diferem apenas em quão atrás alcançam, pelo que um obturador mais rápido é simplesmente a cauda dos fotogramas que já estão a passar — são todos preenchidos numa só passagem da repetição.',
+			bracketMemoryBody:
+				'O que custa mesmo é memória. Cada passo precisa do seu próprio acumulador em resolução completa, pelo que onze passos precisam de onze vezes a memória de vídeo de um só, o que em 8K é mais do que a maioria das placas tem. A captura verifica isto antes de começar e recusa em vez de fazer o iRacing falhar; se um bracketing for recusado, baixa a resolução ou escolhe um obturador mais rápido — o que também encurta a escada.',
+			bracketNamingBody:
+				'O passo que escolheste é guardado com o nome habitual e é o que aparece na galeria; os restantes ficam ao lado, com o respetivo obturador no nome do ficheiro.',
+
+			highlights: 'Recuperação de altas luzes',
+			highlightsBody:
+				'Realça as altas luzes próximas do corte antes de os fotogramas serem somados e desfaz o realce no fim. O iRacing entrega uma imagem à qual já foi aplicado mapeamento tonal, pelo que um farol e uma parede branca chegam com o mesmo valor; fazer a média disso transforma uma luz intensa que atravessa parte da exposição numa mancha cinzenta em vez de um rasto luminoso. Isto devolve a não linearidade ao sítio onde um sensor real a tem. Medida em stops; 0 desativa-a e não altera absolutamente nada.',
+
+			whatItSaves: 'O que guarda',
+			whatItSavesBody:
+				'Tamanho, recorte da marca de água e formato de ficheiro seguem os mesmos controlos de uma captura normal — as definições Resolução e Recortar marca de água acima e o formato de saída nas definições. A linha «Saída» no topo da barra lateral mostra exatamente o que vais obter.',
+			whatItSavesPngBody:
+				'Escolher PNG escreve um verdadeiro master de 16 bits, o que compensa se pretenderes fazer correção de cor depois, mais uma pré-visualização de 8 bits para a galeria. É também muito mais lento de escrever em resoluções altas — um PNG de 16 bits com 33 megapíxeis demora cerca de dez segundos, ao passo que o mesmo fotograma em JPEG demora menos de um.',
+
+			troubleshooting: 'Se o resultado parecer errado',
+			troubleGhosts:
+				'<b>Fantasmas separados em vez de um rasto suave</b> — amostras a menos. Usa uma velocidade de reprodução mais lenta, mais passagens ou uma resolução mais baixa.',
+			troubleShutter:
+				'<b>Não sabes que obturador querias</b> — ativa o bracketing de obturador e decide depois, com a mesma espera.',
+			troubleHighlights:
+				'<b>Altas luzes queimadas ou sem contraste</b> — experimenta 3 a 5 stops de recuperação de altas luzes.',
+			troubleBlack:
+				'<b>Uma imagem preta</b> — o iRacing está em ecrã inteiro exclusivo. Coloca Display &gt; Full Screen em OFF.',
+			troubleSidecar:
+				'Cada captura regista as definições exatas que usou, o número de amostras e a uniformidade com que caíram, num ficheiro .json na pasta de registos, junto ao app.log. São mantidas as últimas 20 capturas — um bracketing conta como uma — pelo que a captura sobre a qual estás a perguntar ainda lá está enquanto perguntas.',
+		},
+	},
+
+	update: {
+		checking: 'A procurar atualizações…',
+		newVersion: 'Uma nova versão',
+		availableBusy:
+			'{version} está disponível. Está uma captura em curso — poderás transferi-la assim que terminar.',
+		available: '{version} está disponível. Clica para a transferir.',
+		downloading: 'A transferir {version}…',
+		downloadingPercent: 'A transferir {version} — {percent}%',
+		downloadedBusy:
+			'{version} está pronta. Está uma captura em curso, por isso será instalada quando fechares a aplicação.',
+		downloaded: '{version} está pronta. Clica para reiniciar e instalar.',
+		failed: 'A procura de atualizações falhou: {error}',
+		unknownError: 'erro desconhecido',
+		neverChecked:
+			'Ainda não foram procuradas atualizações (estás na v{version}).',
+		upToDate: 'Estás na versão mais recente (v{version}).',
+
+		alreadyDownloading: 'A atualização já está a ser transferida.',
+		alreadyDownloaded: 'A atualização já foi transferida.',
+		nothingToDownload: 'Não há nenhuma atualização para transferir.',
+		captureInProgress:
+			'Está uma captura em curso. Tenta novamente assim que terminar.',
+		nothingToInstall: 'Não há nenhuma atualização pronta a instalar.',
+		captureInProgressInstall:
+			'Está uma captura em curso. A atualização instalar-se-á sozinha quando fechares a aplicação.',
+		devBuildOnly:
+			'A procura de atualizações só funciona numa versão instalada.',
+
+		installTitle: 'Instalar atualização',
+		installMessage: 'Instalar a versão {version}?',
+		installFallbackVersion: 'atualização',
+		installDetail:
+			'A aplicação irá fechar e reabrir assim que a atualização estiver instalada. Se escolheres «Mais tarde», ela instalar-se-á sozinha da próxima vez que fechares a aplicação.',
+		installConfirm: 'Reiniciar e instalar',
+		installLater: 'Mais tarde',
+	},
+
+	filenameFields: {
+		categories: {
+			Track: 'Pista',
+			Driver: 'Piloto',
+			Session: 'Sessão',
+			Meta: 'Meta',
+		},
+		track: 'Pista',
+		trackFull: 'Pista completa',
+		trackCity: 'Cidade',
+		trackCountry: 'País',
+		trackType: 'Tipo de pista',
+		driver: 'Piloto',
+		driverAbbrev: 'Piloto abreviado',
+		driverInitials: 'Iniciais',
+		team: 'Equipa',
+		carNumber: 'N.º do carro',
+		car: 'Carro',
+		carFull: 'Carro completo',
+		carClass: 'Classe do carro',
+		iRating: 'iRating',
+		sessionType: 'Tipo de sessão',
+		sessionName: 'Nome da sessão',
+		lap: 'Volta',
+		date: 'Data',
+		time: 'Hora',
+		datetime: 'Data+hora',
+		counter: 'Contador',
+	},
+
+	iracingConfig: {
+		projections:
+			'Desativa «Render Scene Using 3 Projections» no iRacing (separador Display > Monitor) para evitar bandas verticais nas capturas',
+	},
+
+	wgc: {
+		cursorCaveat:
+			'O cursor do rato pode aparecer nas capturas nesta versão do Windows. O Windows 10 versão 2004 acrescentou o controlo que o oculta.',
+		addonUnavailable:
+			'Não foi possível carregar o componente de captura de alta fidelidade neste sistema.',
+		osUnsupported:
+			'O Windows.Graphics.Capture não está disponível nesta versão do Windows. Requer o Windows 10 versão 1903 ou mais recente.',
+		nativeCaptureOff: 'A captura de alta fidelidade (WGC) está desativada',
+	},
+
+	capture: {
+		exclusiveFullscreen:
+			'O iRacing está em ecrã inteiro exclusivo, pelo que a captura ficaria preta. No iRacing, coloca Display > Full Screen em OFF (usa Borderless ou Windowed) e tenta novamente.',
+		exclusiveFullscreenUnattributed:
+			'Há uma aplicação em ecrã inteiro exclusivo, o que produz uma captura preta. Se o iRacing estiver em ecrã inteiro, coloca Display > Full Screen em OFF (usa Borderless ou Windowed) e tenta novamente.',
+		unknownError: 'Erro de captura desconhecido',
+		outputTooSmall: 'A captura é demasiado pequena ({width}x{height})',
+		blackFrame:
+			'O fotograma captado está preto — a fonte de captura pode ter falhado (em algumas configurações do Windows, o conteúdo acelerado por GPU não se deixa captar)',
+		noSource:
+			'Não foi encontrada nenhuma fonte de captura do ambiente de trabalho para a janela {windowId}',
+		metadataTimeout:
+			'Tempo esgotado à espera dos metadados de vídeo da captura',
+		noVideoFrame: 'O fluxo de captura não produziu nenhum fotograma de vídeo',
+		dimensionTimeout:
+			'Tempo esgotado à espera das dimensões de janela {width}x{height}; a prosseguir com {actualWidth}x{actualHeight}',
+	},
+
+	longExposureCapture: {
+		busy: 'Já está uma captura em curso.',
+		needsNativeCapture:
+			'A longa exposição precisa da captura de alta fidelidade (WGC). Ativa-a nas definições para a usares.',
+		unavailable: 'A longa exposição não está disponível nesta máquina.',
+		noTelemetry:
+			'A longa exposição precisa da telemetria de repetição do iRacing. Verifica se o simulador está a correr e dentro de uma sessão.',
+		windowNotFound: 'Janela do iRacing não encontrada.',
+		cancelled: 'Captura cancelada.',
+		seekTimeout:
+			'A repetição não chegou ao fotograma {frame} a tempo. Pode ainda estar a carregar.',
+		noPasses: 'Uma captura tem de executar pelo menos uma passagem.',
+		playbackStalled:
+			'A repetição não começou a reproduzir. Verifica se o iRacing não foi colocado em pausa por outra ferramenta.',
+		exposureTimeout:
+			'A exposição não chegou ao fotograma {frame} em {seconds} s.',
+		endedEarly:
+			'A exposição terminou antes de alcançar o instante selecionado.',
+		noFramesPresented:
+			'O iRacing não apresentou nenhum fotograma para captar.',
+		subFrameNoSamples:
+			'Este obturador é mais curto do que um fotograma de repetição, e o iRacing não desenhou nenhum dentro dele. Experimenta uma velocidade de reprodução mais lenta, ou o passo de obturador imediatamente mais lento.',
+		noSamples:
+			'Não foi acumulado nenhum fotograma. O iRacing pode ter deixado de desenhar durante a exposição.',
+		withNativeError: '{reason} ({error})',
+		resolveFailed: 'A GPU não devolveu nenhuma imagem.',
+		bracketShortfall:
+			'O bracketing pediu {asked} passos mas voltaram {returned} — os restantes não se resolveram, ou esta versão do componente de captura é anterior ao bracketing.',
+	},
+
+	validation: {
+		windowBeforeStart:
+			'A exposição precisa de {frames} fotogramas de repetição antes do instante selecionado, mas este está apenas a {anchor} fotogramas do início. Escolhe um instante posterior ou um obturador mais rápido.',
+		pastEnd: 'O instante selecionado está para além do fim da repetição.',
+		sessionChanged:
+			'A repetição mudou para outra sessão desde que esta captura foi preparada. Volta a selecionar o instante.',
+		singleSampleMultiPass:
+			'Este obturador é tão curto que só cai nele cerca de um fotograma por passagem, pelo que {passes} passagens recolhem aproximadamente {passes} amostras. Uma velocidade de reprodução ou um obturador mais lentos rendem muito mais.',
+		singleSample:
+			'Este obturador é tão curto que só um fotograma cairá dentro dele, pelo que o resultado não terá desfoque de movimento. Uma velocidade de reprodução ou um obturador mais lentos rendem amostras.',
+		bracketVsInterpolation:
+			'O bracketing de obturador e a interpolação de fotogramas {factor}x não podem funcionar em conjunto, pelo que esta captura será feita sem interpolação. Desativa o bracketing se os fotogramas intermédios te importarem mais do que os passos adicionais.',
+		passesVsInterpolation:
+			'Estão ativas tanto as passagens múltiplas como a interpolação {factor}x. Competem entre si: a interpolação abranda cada passagem o suficiente para lhe custar fotogramas reais, pelo que a mesma espera compra menos amostras reais do que as passagens sozinhas. Desativar a interpolação costuma dar uma captura melhor.',
+		shortOfTarget:
+			'Mesmo à velocidade 1/{divisor}, esta exposição chega a cerca de {samples} amostras, aquém das {target} pedidas. Usa um obturador mais lento para obteres mais.',
+		longCaptureEscalate:
+			'Esta captura reproduz a repetição à velocidade 1/{divisor} durante cerca de {duration} de tempo real{passSuffix}, e não pode ser acelerada depois de iniciada. {advice}',
+		longCaptureWarn:
+			'Esta captura demorará cerca de {duration} de tempo real à velocidade de reprodução 1/{divisor}{passSuffix}.',
+		passSuffix:
+			', distribuídas por {passes} passagens sobre o mesmo instante',
+		adviceFewerPasses:
+			'Menos passagens terminam mais cedo, com menos amostras.',
+		adviceFasterPlayback:
+			'Uma velocidade de reprodução mais alta termina mais cedo, com menos amostras.',
+		pastLogCap:
+			'Prevê-se que esta captura recolha cerca de {samples} amostras ao longo de {passes} passagens, acima das {cap} que o registo de diagnóstico comporta. A imagem não é afetada — apenas os valores de uniformidade e de intervalo descreverão a primeira parte da captura.',
+		interpolationLossy:
+			'Neste tamanho, a interpolação {factor}x já custou amostras reais a esta máquina. Considera um fator mais baixo, uma resolução mais baixa ou, em alternativa, mais passagens.',
+	},
+
+	duration: {
+		zero: '0 segundos',
+		seconds: {
+			one: '{count} segundo',
+			other: '{count} segundos',
+		},
+		minutes: {
+			one: '{count} minuto',
+			other: '{count} minutos',
+		},
+		minutesSeconds: '{minutes} min {seconds} s',
+	},
+};
+
+export default pt;

--- a/src/locales/sv.ts
+++ b/src/locales/sv.ts
@@ -1,0 +1,474 @@
+// Swedish. Translated from en.ts — see that file's header before editing.
+//
+// Product and technology names stay untranslated: iRacing, ReShade, Discord,
+// Windows.Graphics.Capture, WGC, VRAM, GPU, NVIDIA Turing and the file formats.
+
+import type { Catalog } from './index';
+
+const sv: Catalog = {
+	notice: {
+		danger: 'Problem',
+		warning: 'Värt att veta',
+		info: 'Noteringar',
+	},
+
+	promo: {
+		greeting: 'Tack för att du använder iRacing Screenshot Tool!',
+		signature: 'Byggt och underhållet av AR Media Solutions.',
+	},
+
+	changelog: {
+		title: 'Ändringslogg',
+		untitledRelease: 'Version',
+	},
+
+	gallery: {
+		menu: {
+			openExternally: 'Öppna i annat program',
+			openFolder: 'Öppna mapp',
+			copy: 'Kopiera',
+			delete: 'Ta bort',
+		},
+		copiedToClipboard: '{name} kopierad till urklipp',
+	},
+
+	sidebar: {
+		resolution: 'Upplösning',
+		width: 'Bredd',
+		height: 'Höjd',
+		output: 'Utdata:',
+		cropWatermark: 'Beskär vattenstämpel',
+		keepAspectRatio: 'Behåll bildförhållande',
+		screenshot: 'Skärmbild',
+		custom: 'Anpassad',
+		vramStatus: '{adapter}{free} ledigt av {total}',
+		savedSuccessfully: '{name} sparades',
+		screenshotFailed: 'Skärmbilden misslyckades: {message}',
+		errorLogPrefix: 'Logg: ',
+		notices: {
+			exclusiveFullscreen:
+				'iRacing körs i exklusivt helskärmsläge — skärmbilderna blir svarta. Ställ Display > Full Screen på OFF i iRacing (Borderless eller Windowed) för att göra inspelning möjlig.',
+			vramRisk:
+				'{resolution} behöver ungefär {needed} mer VRAM, men bara {free} är ledigt — iRacing kommer sannolikt att få slut på minne och krascha.',
+			vramCaution:
+				'{resolution} lämnar liten VRAM-marginal ({free} ledigt) och kan krascha vid krävande bana/bil-kombinationer.',
+			switchResolution: 'Byt till {resolution}',
+			vramStatic:
+				'Höga upplösningar kan få iRacing att krascha om VRAM tar slut. Vissa bana/bil-kombinationer kräver mer VRAM.',
+			reshade:
+				'När du har tryckt på skärmbildsknappen i iRacing Screenshot Tool måste du även trycka på ReShades kortkommando för skärmbilder.',
+			crop: 'Beskärning av vattenstämpeln zoomar in den färdiga bilden något. Områden nära skärmkanterna klipps bort.',
+			aspectRatio:
+				'”Behåll bildförhållande” anpassar skärmbildens höjd till din skärms bildförhållande (till exempel 21:9 ultrabred) i stället för standardvärdet 16:9. Den valda upplösningen bestämmer bredden.',
+		},
+	},
+
+	settings: {
+		title: 'Inställningar',
+		version: 'Version - {version}',
+		changelog: 'Ändringslogg',
+		openLogsFolder: 'Öppna loggmappen',
+		checkForUpdates: 'Sök efter uppdateringar',
+		updateCheckFailed: 'Uppdateringskontrollen misslyckades: {message}',
+
+		language: 'Språk',
+		languageDescription:
+			'Språket som används i hela appen. Hämtas från Windows första gången appen körs.',
+
+		screenshotFolder: 'Mapp för skärmbilder',
+		selectFolder: 'Välj mapp',
+		screenshotKeybind: 'Kortkommando för skärmbild',
+		editBind: 'Ändra kortkommando',
+
+		customFilenameFormat: 'Eget filnamnsformat',
+		customFilenameFormatDescription:
+			'Använd ett eget mönster i stället för standardformatet ({track}-{driver}-{counter})',
+		filenameFieldsHint:
+			'Klicka på fälten för att lägga till dem i formatet. Skriv avgränsare (-, _ osv.) direkt.',
+		reset: 'Återställ',
+		preview: 'Förhandsgranskning:',
+
+		outputFormat: 'Utdataformat',
+		formatJpeg: 'JPEG (högsta kvalitet)',
+		formatPng: 'PNG (förlustfri)',
+		formatWebp: 'WebP (kvalitet 95 %)',
+
+		disableTooltips: 'Dölj tips',
+		disableTooltipsDescription: 'Låt mig vara, jag vet vad jag gör',
+
+		cropTopLeft: 'Föredra beskärning av vattenstämpeln uppe till vänster',
+		cropTopLeftDescription:
+			'Beskär bara det nedre högra hörnet (3 %). När det är avstängt beskärs skärmbilden lika mycket från alla sidor (6 % totalt), vilket ger ett centrerat resultat.',
+
+		manualWindowRestore: 'Manuell fönsteråterställning',
+		manualWindowRestoreDescription:
+			'Ersätter den automatiska fönsteråterställningen med egen position och storlek. Användbart för ultrabreda skärmar eller Nvidia Surround.',
+		left: 'Vänster',
+		top: 'Överkant',
+		width: 'Bredd',
+		height: 'Höjd',
+		restoreNow: 'Återställ nu',
+
+		nativeCapture: 'Högkvalitativ inspelning (WGC)',
+		nativeCaptureDescription:
+			'Fångar äkta färg utan delsampling via Windows.Graphics.Capture i stället för standardvägen (som delsamplar färgen). Faller automatiskt tillbaka om en inspelning misslyckas.',
+		nativeCaptureUnavailable:
+			'Inte tillgängligt på det här systemet — högkvalitativ inspelning kan inte köras här.',
+		nativeCaptureUnverified:
+			'Windows uppger att det stöds, men en testinspelning kom aldrig tillbaka. Inspelningar faller automatiskt tillbaka om det fortsätter att misslyckas.',
+
+		reshade: 'ReShade-kompatibilitetsläge',
+		reshadeDescription:
+			'Med ReShade måste du först använda kortkommandot för iRacing Screenshot Tool eller trycka på knappen, och sedan använda ditt ReShade-kortkommando för skärmbilder när iRacing-fönstret har ändrat storlek.',
+		reshadeIni: 'ReShade-INI',
+		selectFile: 'Välj fil',
+	},
+
+	longExposure: {
+		title: 'Långtidsexponering',
+		shutter: 'Slutartid',
+		playbackSpeed: 'Uppspelningshastighet',
+		playbackAuto: 'Automatiskt (utifrån målantal sampel)',
+		playbackRealTime: '1x (realtid)',
+		targetSamples: 'Målantal sampel',
+		advanced: 'Avancerat',
+		defaultsSummary: '{count} standardvärden',
+
+		weighting: 'Viktning',
+		weightingBox: 'Box (jämn)',
+		weightingLinear: 'Linjär (skarp i slutet)',
+		weightingEase: 'Ease (skarpare början, lång svans)',
+
+		interpolation: 'Bildinterpolering',
+		interpolationOff: 'Av',
+		interpolation2: '2× (en mellanbild)',
+		interpolation4: '4× (tre mellanbilder)',
+		interpolation8: '8× (sju mellanbilder)',
+
+		passes: 'Pass',
+		passes1: '1 (ett enda pass)',
+		passes2: '2× — dubbelt så lång väntan',
+		passes4: '4× — fyra gånger så lång väntan',
+		passes8: '8× — åtta gånger så lång väntan',
+
+		bracket: 'Slutartidsgaffling',
+		highlightRecovery: 'Högdageråterhämtning (steg)',
+
+		cancel: 'Avbryt',
+		saved: 'Långtidsexponering sparad — {count} sampel',
+		failed: 'Långtidsexponeringen misslyckades',
+
+		modified: {
+			weighting_linear: 'linjär',
+			weighting_ease: 'ease',
+			interpolation: '{factor}× interpolering',
+			passes: {
+				one: '{count} pass',
+				other: '{count} pass',
+			},
+			bracketed: 'gafflad',
+			recovery: '{stops} stegs återhämtning',
+		},
+
+		progress: {
+			working: 'Arbetar…',
+			seeking: 'Söker…{pass}',
+			accumulating: 'Exponerar… {count} sampel{pass}',
+			resolving: 'Framkallar…',
+			restoring: 'Återställer replayen…',
+			pass: ' (pass {current} av {total})',
+		},
+
+		notices: {
+			needsNativeCapture:
+				'Långtidsexponering kräver högkvalitativ inspelning (WGC), som just nu är avstängd. Slå på den i inställningarna för att kunna använda långtidsexponering.',
+			unavailableWithReason:
+				'Långtidsexponering är inte tillgänglig på den här datorn: {reason}',
+			unavailable:
+				'Långtidsexponering är inte tillgänglig på den här datorn.',
+			interpolationCost:
+				'Interpolering hittar på bildrutor mellan de verkliga för att jämna ut strecket. Det kostar GPU-tid per bildruta, så jämför antalet verkliga sampel i den sparade bilden med samma bild utan interpolering — om siffran sjunker köper den påhittade sampel med verkliga.',
+			passesAndInterpolation:
+				'Pass och interpolering konkurrerar om samma budget per bildruta. Med båda på fångar varje pass färre verkliga bildrutor — att stänga av interpoleringen ger oftast en bättre bild för samma väntan.',
+			passes:
+				'Varje pass spelar upp samma ögonblick igen och fångar bildrutor som de andra missade, så strecket blir jämnare snarare än ljusare. Fungerar bäst vid korta slutartider, där ett enda pass bara samlar en handfull sampel.',
+			interpolationUnsupported:
+				'Bildinterpolering kräver en NVIDIA Turing-GPU eller nyare{adapter}. Allt annat i långtidsexponeringen fungerar som vanligt.',
+			interpolationAdapter: ' (den här inspelningen körs på {adapter})',
+			reshade:
+				'Långtidsexponering spelar in nativt och använder inte ReShade, så ReShade-effekter syns inte i resultatet.',
+		},
+	},
+
+	help: {
+		title: 'Hjälp',
+		sections: 'Hjälpavsnitt',
+		tabGeneral: 'Allmänt',
+		tabLongExposure: 'Långtidsexponering',
+
+		general: {
+			iracingSettings: 'iRacing-inställningar',
+			borderless: 'iRacing måste köras i Windowed Borderless',
+			vram: 'Minst 8 GB VRAM rekommenderas för skärmbilder i 8K eller högre',
+			newerContent: 'Nyare banor och bilar kräver mer VRAM',
+			shrinkUi:
+				'Krymp gränssnittet så mycket det går innan du tar en skärmbild om du använder beskärning av vattenstämpeln; ”Control+PageDown” krymper det. Fungerar det inte kan du behöva återställa gränssnittets zoom i iRacings inställningar.',
+
+			screenshotFolder: 'Mapp för skärmbilder',
+			screenshotFolderBody:
+				'Skärmbilder sparas som standard i ”C:\\Users\\user\\Pictures\\Screenshots”; detta kan ändras i inställningarna.',
+
+			screenshotHotkey: 'Kortkommando för skärmbild',
+			screenshotHotkeyBody:
+				'Som standard tar ”Control + PrintScreen” en skärmbild med aktuella inställningar; detta kan ändras i inställningarna.',
+
+			issues: 'Problem',
+			issuesBody: 'Har du problem, rapportera dem gärna på',
+			discord: 'Discord',
+
+			instructions: 'Instruktioner',
+			step1: 'iRacing <b>måste</b> köras i läget Windowed Borderless',
+			step2: 'Starta iRacing och placera kameran där du vill ta skärmbilden',
+			step3: 'Välj önskad upplösning (prova lägre upplösningar innan du går upp till 8K)',
+			step4: 'Bestäm om du vill beskära iRacings vattenstämpel; i så fall måste du först krympa iRacings gränssnitt till minsta storlek med ”Control + PageDown”',
+			step5: 'Tryck på skärmbildsknappen eller använd kortkommandot ”Control + PrintScreen” för att ta bilderna',
+			step6: 'Beroende på vald upplösning kan detta ta några sekunder; när iRacing-fönstret återfår sin normala storlek är det klart',
+			step7: 'Din skärmbild sparas i ”C:\\Users\\{User}\\Pictures\\Screenshots”',
+		},
+
+		longExposure: {
+			whatItDoes: 'Vad den gör',
+			whatItDoesBody:
+				'En långtidsexponering blandar många bildrutor från en replay till en enda bild, precis som när man låter en kameraslutare stå öppen: det som står stilla förblir skarpt, det som rör sig drar streck. Verktyget styr replayen själv, fångar varje bildruta som simulatorn visar och summerar dem på GPU:n.',
+
+			shutter: 'Slutartid',
+			shutterBody:
+				'Hur länge exponeringen varar <i>i replaytid</i>, från en bråkdel av en replaybildruta upp till tio sekunder. Det är den här inställningen som avgör hur långa strecken blir. Längre slutartider samlar också fler bildrutor och behöver därför mindre hjälp av allt nedanför; de kortaste stegen täcker en enda replaybildruta och samlar bara en handfull sampel.',
+
+			playback: 'Uppspelningshastighet',
+			playbackBody:
+				'Replayen spelas upp i slow motion medan exponeringen fångas, så att simulatorn visar fler bildrutor per sekund replaytid och blandningen får fler sampel. 1/16 samlar ungefär sexton gånger så många bildrutor som realtid — och tar sexton gånger så lång verklig tid. Det är den huvudsakliga avvägningen i panelen: tålamod mot mjukhet.',
+			playbackAutoBody:
+				'”Automatiskt (utifrån målantal sampel)” väljer hastigheten åt dig utifrån <b>målantal sampel</b>: verktyget räknar ut den snabbaste uppspelning som fortfarande når det antal du bett om. Ange en uttrycklig hastighet i stället om du hellre begränsar väntetiden.',
+
+			weighting: 'Viktning',
+			weightingBody:
+				'Hur mycket varje fångad bildruta bidrar till resultatet. <b>Box</b> viktar dem alla lika och ger ett jämnt streck. <b>Linjär</b> ökar mot slutet av fönstret, så motivet är skarpast där det slutade och tonar bort längs sin bana. <b>Ease</b> är samma idé med skarpare början och längre svans.',
+
+			interpolation: 'Bildinterpolering',
+			interpolationBody:
+				'Hittar på extra bildrutor mellan de verkliga med hjälp av GPU:ns optical flow-motor och fyller igen luckorna längs strecket. Kräver ett NVIDIA Turing-kort eller nyare och döljs helt på hårdvara som inte klarar det.',
+			interpolationCostBody:
+				'Det är inte gratis: det kostar GPU-tid på varje fångad bildruta, och budgeten är en iRacing-bildruta. Om den inte hinner med börjar den missa <i>verkliga</i> bildrutor för att tillverka syntetiska, vilket är en nettoförlust — strecket blir kortare och grövre. Kostnaden skalar med megapixlar gånger faktorn, så det som är bekvämt vid 2560×1440 är inte gångbart i 8K. För att kontrollera det: fotografera samma ögonblick två gånger, med och utan, och jämför antalet verkliga sampel; appen varnar dig också i efterhand om en bild blev för snål.',
+
+			passes: 'Pass',
+			passesBody:
+				'Besöker samma ögonblick flera gånger och ackumulerar allt till en bild. Varje pass fångar bildrutor som de andra råkade missa, så strecket blir jämnare — inte ljusare, eftersom resultatet normaliseras efter hur mycket ljus som faktiskt landade på varje bildpunkt.',
+			passesTradeBody:
+				'Pass köper samma sak som interpolering, fast i en annan valuta: verklig tid i stället för GPU-tid. Åtta pass tar ungefär åtta gånger så lång tid, men de kan aldrig kosta dig verkliga bildrutor. Det gör dem till rätt verktyg vid höga upplösningar, där interpoleringen inte hinner med, och vid korta slutartider, där ett enda pass samlar väldigt få sampel. Att använda båda samtidigt är oftast det sämsta av två världar — de konkurrerar om samma budget per bildruta.',
+
+			bracket: 'Slutartidsgaffling',
+			bracketBody:
+				'Ger en bild per slutartidssteg som är lika med eller kortare än det du valt, från en enda inspelning. En bild vid 1/60 ger dig även 1/125, 1/250, 1/500 och 1/1000 — samma ögonblick med successivt kortare streck — så att du kan välja uttryck i efterhand i stället för att gissa och ta om.',
+			bracketCostBody:
+				'Det kostar nästan ingen extra tid. Varje steg slutar på samma bildruta och skiljer sig bara i hur långt bakåt det når, så en kortare slutartid är helt enkelt slutet på de bildrutor som ändå passerar — de fylls alla från ett enda pass av replayen.',
+			bracketMemoryBody:
+				'Det som kostar är minne. Varje steg behöver en egen ackumulator i full upplösning, så elva steg behöver elva gånger så mycket grafikminne som ett, vilket i 8K är mer än de flesta kort har. Inspelningen kontrollerar detta innan den startar och avstår hellre än att krascha iRacing; om en gaffling nekas, sänk upplösningen eller välj en kortare slutartid — vilket också ger en kortare stege.',
+			bracketNamingBody:
+				'Steget du valde sparas under det vanliga namnet och är det som visas i galleriet; de övriga ligger bredvid med sin slutartid i filnamnet.',
+
+			highlights: 'Högdageråterhämtning',
+			highlightsBody:
+				'Förstärker nästan urblåsta högdagrar innan bildrutorna summeras och tar sedan bort förstärkningen på slutet. iRacing lämnar ifrån sig en bild som redan tonmappats, så en strålkastare och en vit vägg kommer in med samma värde; att medelvärdesbilda det gör att ett starkt ljus som sveper genom en del av exponeringen läses som en grå fläck i stället för ett ljust spår. Detta lägger tillbaka olineariteten där en riktig sensor har den. Mäts i steg; 0 är av och ändrar ingenting alls.',
+
+			whatItSaves: 'Vad den sparar',
+			whatItSavesBody:
+				'Storlek, beskärning av vattenstämpeln och filformat följer samma reglage som en vanlig skärmbild — inställningarna Upplösning och Beskär vattenstämpel ovan, samt utdataformatet i inställningarna. Raden ”Utdata” högst upp i sidopanelen visar exakt vad du får.',
+			whatItSavesPngBody:
+				'Väljer du PNG skrivs en äkta 16-bitars master, vilket är värt det om du tänker färgsätta bilden efteråt, plus en 8-bitars förhandsvisning till galleriet. Den är också mycket långsammare att skriva vid höga upplösningar — en 16-bitars PNG på 33 megapixel tar omkring tio sekunder, medan samma bildruta som JPEG tar under en sekund.',
+
+			troubleshooting: 'Om resultatet ser fel ut',
+			troubleGhosts:
+				'<b>Enskilda spökbilder i stället för ett mjukt streck</b> — för få sampel. Använd en långsammare uppspelningshastighet, fler pass eller en lägre upplösning.',
+			troubleShutter:
+				'<b>Osäker på vilken slutartid du ville ha</b> — slå på slutartidsgaffling och bestäm i efterhand, för samma väntan.',
+			troubleHighlights:
+				'<b>Urblåsta eller platta högdagrar</b> — prova 3 till 5 steg av högdageråterhämtning.',
+			troubleBlack:
+				'<b>En svart bild</b> — iRacing körs i exklusivt helskärmsläge. Ställ Display &gt; Full Screen på OFF.',
+			troubleSidecar:
+				'Varje bild registrerar exakt vilka inställningar som användes, antalet sampel och hur jämnt de landade, som en .json-fil i loggmappen bredvid app.log. De 20 senaste bilderna sparas — en gaffling räknas som en — så den bild du frågar om finns kvar medan du frågar om den.',
+		},
+	},
+
+	update: {
+		checking: 'Söker efter uppdateringar…',
+		newVersion: 'En ny version',
+		availableBusy:
+			'{version} finns tillgänglig. En inspelning pågår — du kan hämta den när den är klar.',
+		available: '{version} finns tillgänglig. Klicka för att hämta den.',
+		downloading: 'Hämtar {version}…',
+		downloadingPercent: 'Hämtar {version} — {percent} %',
+		downloadedBusy:
+			'{version} är klar. En inspelning pågår, så den installeras när du stänger appen.',
+		downloaded: '{version} är klar. Klicka för att starta om och installera.',
+		failed: 'Uppdateringskontrollen misslyckades: {error}',
+		unknownError: 'okänt fel',
+		neverChecked: 'Inga uppdateringar har sökts ännu (du kör v{version}).',
+		upToDate: 'Du kör den senaste versionen (v{version}).',
+
+		alreadyDownloading: 'Uppdateringen hämtas redan.',
+		alreadyDownloaded: 'Uppdateringen är redan hämtad.',
+		nothingToDownload: 'Det finns ingen uppdatering att hämta.',
+		captureInProgress: 'En inspelning pågår. Försök igen när den är klar.',
+		nothingToInstall: 'Ingen uppdatering är redo att installeras.',
+		captureInProgressInstall:
+			'En inspelning pågår. Uppdateringen installeras av sig själv när du stänger appen.',
+		devBuildOnly:
+			'Uppdateringskontroller körs bara i en installerad version.',
+
+		installTitle: 'Installera uppdatering',
+		installMessage: 'Installera version {version}?',
+		installFallbackVersion: 'uppdatering',
+		installDetail:
+			'Appen stängs och öppnas igen när uppdateringen har installerats. Väljer du ”Senare” installeras den av sig själv nästa gång du stänger appen.',
+		installConfirm: 'Starta om och installera',
+		installLater: 'Senare',
+	},
+
+	filenameFields: {
+		categories: {
+			Track: 'Bana',
+			Driver: 'Förare',
+			Session: 'Session',
+			Meta: 'Meta',
+		},
+		track: 'Bana',
+		trackFull: 'Bana fullständigt',
+		trackCity: 'Stad',
+		trackCountry: 'Land',
+		trackType: 'Bantyp',
+		driver: 'Förare',
+		driverAbbrev: 'Förare förkortat',
+		driverInitials: 'Initialer',
+		team: 'Stall',
+		carNumber: 'Bilnr',
+		car: 'Bil',
+		carFull: 'Bil fullständigt',
+		carClass: 'Bilklass',
+		iRating: 'iRating',
+		sessionType: 'Sessionstyp',
+		sessionName: 'Sessionsnamn',
+		lap: 'Varv',
+		date: 'Datum',
+		time: 'Tid',
+		datetime: 'Datum+tid',
+		counter: 'Räknare',
+	},
+
+	iracingConfig: {
+		projections:
+			'Stäng av ”Render Scene Using 3 Projections” i iRacing (fliken Display > Monitor) för att undvika lodräta band i skärmbilderna',
+	},
+
+	wgc: {
+		cursorCaveat:
+			'Muspekaren kan synas i inspelningar på den här versionen av Windows. Windows 10 version 2004 lade till inställningen som döljer den.',
+		addonUnavailable:
+			'Komponenten för högkvalitativ inspelning kunde inte läsas in på det här systemet.',
+		osUnsupported:
+			'Windows.Graphics.Capture är inte tillgängligt på den här versionen av Windows. Det kräver Windows 10 version 1903 eller nyare.',
+		nativeCaptureOff: 'Högkvalitativ inspelning (WGC) är avstängd',
+	},
+
+	capture: {
+		exclusiveFullscreen:
+			'iRacing körs i exklusivt helskärmsläge, så skärmbilden skulle bli svart. Ställ Display > Full Screen på OFF i iRacing (använd Borderless eller Windowed) och försök igen.',
+		exclusiveFullscreenUnattributed:
+			'Ett program körs i exklusivt helskärmsläge, vilket ger en svart inspelning. Om iRacing körs i helskärm, ställ Display > Full Screen på OFF (använd Borderless eller Windowed) och försök igen.',
+		unknownError: 'Okänt skärmbildsfel',
+		outputTooSmall: 'Inspelningen är för liten ({width}x{height})',
+		blackFrame:
+			'Den fångade bildrutan är svart — inspelningskällan kan ha misslyckats (GPU-accelererat innehåll går inte alltid att fånga på vissa Windows-uppsättningar)',
+		noSource:
+			'Ingen skrivbordsinspelningskälla hittades för fönster {windowId}',
+		metadataTimeout:
+			'Tidsgränsen nåddes i väntan på inspelningens videometadata',
+		noVideoFrame: 'Inspelningsströmmen gav ingen videobildruta',
+		dimensionTimeout:
+			'Tidsgränsen nåddes i väntan på fönsterstorleken {width}x{height}; fortsätter med {actualWidth}x{actualHeight}',
+	},
+
+	longExposureCapture: {
+		busy: 'En inspelning pågår redan.',
+		needsNativeCapture:
+			'Långtidsexponering kräver högkvalitativ inspelning (WGC). Slå på den i inställningarna för att använda den.',
+		unavailable: 'Långtidsexponering är inte tillgänglig på den här datorn.',
+		noTelemetry:
+			'Långtidsexponering kräver replaytelemetri från iRacing. Kontrollera att simulatorn körs och befinner sig i en session.',
+		windowNotFound: 'iRacing-fönstret hittades inte.',
+		cancelled: 'Inspelningen avbröts.',
+		seekTimeout:
+			'Replayen nådde inte bildruta {frame} i tid. Den kanske fortfarande läses in.',
+		noPasses: 'En inspelning måste köra minst ett pass.',
+		playbackStalled:
+			'Replayen började inte spelas. Kontrollera att iRacing inte har pausats av ett annat verktyg.',
+		exposureTimeout:
+			'Exponeringen nådde inte bildruta {frame} inom {seconds} s.',
+		endedEarly: 'Exponeringen tog slut innan det valda ögonblicket nåddes.',
+		noFramesPresented: 'iRacing visade inga bildrutor att fånga.',
+		subFrameNoSamples:
+			'Den här slutartiden är kortare än en replaybildruta, och iRacing renderade ingen bildruta inom den. Prova en långsammare uppspelningshastighet, eller nästa längre slutartid.',
+		noSamples:
+			'Inga bildrutor ackumulerades. iRacing kan ha slutat rendera under exponeringen.',
+		withNativeError: '{reason} ({error})',
+		resolveFailed: 'GPU:n returnerade ingen bild.',
+		bracketShortfall:
+			'Gafflingen begärde {asked} steg men {returned} kom tillbaka — resten kunde inte lösas ut, eller så är den här versionen av inspelningskomponenten äldre än gafflingen.',
+	},
+
+	validation: {
+		windowBeforeStart:
+			'Exponeringen behöver {frames} replaybildrutor före det valda ögonblicket, men det ligger bara {anchor} bildrutor in i replayen. Välj ett senare ögonblick eller en kortare slutartid.',
+		pastEnd: 'Det valda ögonblicket ligger efter replayens slut.',
+		sessionChanged:
+			'Replayen har bytt till en annan session sedan den här bilden ställdes in. Välj ögonblicket på nytt.',
+		singleSampleMultiPass:
+			'Den här slutartiden är så kort att bara ungefär en bildruta hamnar inom den per pass, så {passes} pass samlar ungefär {passes} sampel. En långsammare uppspelningshastighet eller en längre slutartid ger betydligt fler.',
+		singleSample:
+			'Den här slutartiden är så kort att bara en bildruta hamnar inom den, så resultatet får ingen rörelseoskärpa. En långsammare uppspelningshastighet eller en längre slutartid ger sampel.',
+		bracketVsInterpolation:
+			'Slutartidsgaffling och {factor}x bildinterpolering kan inte köras samtidigt, så den här bilden tas utan interpolering. Stäng av gafflingen om mellanbilderna betyder mer för dig än de extra stegen.',
+		passesVsInterpolation:
+			'Både flera pass och {factor}x interpolering är på. De konkurrerar: interpoleringen bromsar varje pass så mycket att det kostar verkliga bildrutor, så samma väntan köper färre verkliga sampel än enbart pass skulle göra. Att stänga av interpoleringen ger oftast den bättre bilden.',
+		shortOfTarget:
+			'Även vid hastigheten 1/{divisor} når den här exponeringen omkring {samples} sampel, färre än de {target} som begärdes. Använd en längre slutartid för fler.',
+		longCaptureEscalate:
+			'Den här inspelningen spelar upp replayen i hastigheten 1/{divisor} under ungefär {duration} verklig tid{passSuffix}, och går inte att skynda på när den väl startat. {advice}',
+		longCaptureWarn:
+			'Den här inspelningen tar ungefär {duration} verklig tid vid uppspelningshastigheten 1/{divisor}{passSuffix}.',
+		passSuffix: ', fördelat över {passes} pass över samma ögonblick',
+		adviceFewerPasses: 'Färre pass blir klara tidigare, med färre sampel.',
+		adviceFasterPlayback:
+			'En snabbare uppspelningshastighet blir klar tidigare, med färre sampel.',
+		pastLogCap:
+			'Den här inspelningen beräknas samla omkring {samples} sampel över {passes} pass, mer än de {cap} som diagnostikloggen rymmer. Bilden påverkas inte — bara jämnhets- och gluggsiffrorna kommer att beskriva inspelningens första del.',
+		interpolationLossy:
+			'I den här storleken har {factor}x interpolering tidigare kostat den här datorn verkliga sampel. Överväg en lägre faktor, en lägre upplösning eller fler pass i stället.',
+	},
+
+	duration: {
+		zero: '0 sekunder',
+		seconds: {
+			one: '{count} sekund',
+			other: '{count} sekunder',
+		},
+		minutes: {
+			one: '{count} minut',
+			other: '{count} minuter',
+		},
+		minutesSeconds: '{minutes} min {seconds} s',
+	},
+};
+
+export default sv;

--- a/src/main/capture-decisions.test.ts
+++ b/src/main/capture-decisions.test.ts
@@ -72,7 +72,7 @@ describe('decideWgcSupport', () => {
 			capabilities: { ...ALL_CAPABLE, cursorConfigSupported: false },
 		});
 		expect(result.supported).toBe(true);
-		expect(result.caveat).toBe(WGC_CURSOR_CAVEAT);
+		expect(result.caveat).toBe(WGC_CURSOR_CAVEAT());
 		// A caveat is not a refusal, so nothing that blocks the feature is set.
 		expect(result.reason).toBeNull();
 		expect(result.message).toBeNull();
@@ -141,7 +141,7 @@ describe('decideLongExposureAvailability', () => {
 			})
 		).toEqual({
 			available: false,
-			reason: NATIVE_CAPTURE_REQUIRED_REASON,
+			reason: NATIVE_CAPTURE_REQUIRED_REASON(),
 			needsNativeCapture: true,
 		});
 	});

--- a/src/main/capture-decisions.ts
+++ b/src/main/capture-decisions.ts
@@ -4,6 +4,8 @@
 // functions: no I/O, no module state, no electron. index.ts calls them where it
 // used to inline the same expressions; capture-decisions.test.ts locks the logic.
 
+import { t } from '../utilities/i18n';
+
 // Which capture backend a request uses.
 export type CaptureBackend = 'reshade' | 'wgc' | 'getUserMedia';
 
@@ -62,8 +64,11 @@ export interface WgcSupportInputs {
 
 // Shown when the cursor cannot be suppressed. The ONLY capability degradation a
 // user can see in the image, so it is the only one that gets a caveat.
-export const WGC_CURSOR_CAVEAT =
-	'The mouse cursor may appear in captures on this version of Windows. Windows 10 version 2004 added the control that hides it.';
+//
+// A function rather than a const because it is user-facing text: a module-scope
+// const is evaluated at import time, which is before the process has resolved the
+// user's language, and would freeze English into every caller.
+export const WGC_CURSOR_CAVEAT = (): string => t('wgc.cursorCaveat');
 
 export interface WgcSupport {
 	supported: boolean;
@@ -105,8 +110,7 @@ export function decideWgcSupport({
 		return {
 			supported: false,
 			reason: loaderReason,
-			message:
-				'The high-fidelity capture component could not be loaded on this system.',
+			message: t('wgc.addonUnavailable'),
 			caveat: null,
 		};
 	}
@@ -114,8 +118,7 @@ export function decideWgcSupport({
 		return {
 			supported: false,
 			reason: 'OS unsupported (needs Win10 1903+)',
-			message:
-				'Windows.Graphics.Capture is not available on this version of Windows. It needs Windows 10 version 1903 or newer.',
+			message: t('wgc.osUnsupported'),
 			caveat: null,
 		};
 	}
@@ -128,14 +131,14 @@ export function decideWgcSupport({
 		supported: true,
 		reason: null,
 		message: null,
-		caveat: capabilities.cursorConfigSupported ? null : WGC_CURSOR_CAVEAT,
+		caveat: capabilities.cursorConfigSupported ? null : WGC_CURSOR_CAVEAT(),
 	};
 }
 
 // Reason string for the one long-exposure refusal the user can fix with a switch.
 // Kept here beside the decision that produces it so the UI and main cannot drift.
-export const NATIVE_CAPTURE_REQUIRED_REASON =
-	'High-Fidelity Capture (WGC) is turned off';
+export const NATIVE_CAPTURE_REQUIRED_REASON = (): string =>
+	t('wgc.nativeCaptureOff');
 
 export interface LongExposureGateInputs {
 	// config.get('nativeCapture') — the WGC native path is enabled.
@@ -184,7 +187,7 @@ export function decideLongExposureAvailability({
 	if (!nativeCapture) {
 		return {
 			available: false,
-			reason: NATIVE_CAPTURE_REQUIRED_REASON,
+			reason: NATIVE_CAPTURE_REQUIRED_REASON(),
 			needsNativeCapture: true,
 		};
 	}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -106,6 +106,30 @@ import {
 	type UpdateEvent,
 	type UpdateState,
 } from '../utilities/update-decisions';
+import { detectLocale, setLocale, t } from '../utilities/i18n';
+
+// Language, resolved once at startup and re-applied whenever the setting changes.
+//
+// Main has to hold this itself rather than leaving it to the renderer: the
+// long-exposure validation warnings, the capture refusals and the WGC support
+// sentence are all phrased HERE and sent over IPC as finished text.
+//
+// app.getPreferredSystemLanguages() is the ordered list Windows itself would use,
+// so a user whose display language is Portuguese but whose second preference is
+// Spanish gets Spanish rather than English if we ever drop pt.
+function initLocale(): void {
+	const stored = configModule.get('locale');
+	const resolved = setLocale(
+		stored || detectLocale(app.getPreferredSystemLanguages())
+	);
+	// Write the RESOLVED code back on first run, so 'pt-BR' settles to 'pt' once
+	// instead of being re-resolved on every launch — and so the Settings dropdown
+	// has a value to show as selected.
+	if (stored !== resolved) {
+		configModule.set('locale', resolved);
+	}
+	log.info('Locale resolved', { stored: stored || null, locale: resolved });
+}
 
 let width: number;
 let height: number;
@@ -536,16 +560,19 @@ function writeScreenshotErrorLog(payload: {
 // #10: shown by the pre-capture early-exit, where we KNOW (state 3 + attributed)
 // iRacing is the exclusive-fullscreen app — the one deterministic, actionable
 // cause of a black capture.
-const EXCLUSIVE_FULLSCREEN_MESSAGE =
-	'iRacing is in exclusive fullscreen, so the screenshot would be black. In iRacing, set Display > Full Screen to OFF (use Borderless or Windowed) and try again.';
+// Functions, not constants. A module-scope const is evaluated at import time,
+// which is before `app.on('ready')` has resolved the locale — it would freeze
+// English into every one of these before the language was even known.
+const EXCLUSIVE_FULLSCREEN_MESSAGE = (): string =>
+	t('capture.exclusiveFullscreen');
 
 // Softer variant for the black-frame backstop. Enrichment below only runs when
 // the pre-flight saw state 3 but could NOT attribute it to iRacing (an
 // attributed hit would have early-exited), and SHQueryUserNotificationState is
 // session-global — so some OTHER app could be the fullscreen one. Word it as a
 // likely cause, not a fact.
-const EXCLUSIVE_FULLSCREEN_MESSAGE_UNATTRIBUTED =
-	'An application is running in exclusive fullscreen, which produces a black capture. If iRacing is in Full Screen, set Display > Full Screen to OFF (use Borderless or Windowed) and try again.';
+const EXCLUSIVE_FULLSCREEN_MESSAGE_UNATTRIBUTED = (): string =>
+	t('capture.exclusiveFullscreenUnattributed');
 
 // If a worker error is the generic "captured frame is black" AND the last
 // pre-flight saw exclusive fullscreen (state 3), rewrite it to the actionable
@@ -562,7 +589,7 @@ function enrichBlackFrameError(data: unknown): unknown {
 	if (typeof message === 'string' && message.toLowerCase().includes('black')) {
 		return {
 			...(data as object),
-			message: EXCLUSIVE_FULLSCREEN_MESSAGE_UNATTRIBUTED,
+			message: EXCLUSIVE_FULLSCREEN_MESSAGE_UNATTRIBUTED(),
 		};
 	}
 	return data;
@@ -817,6 +844,13 @@ ipcMain.on('config:set', (event, payload: { key: string; value: unknown }) => {
 
 	if (oldValue !== payload.value) {
 		log.debug('Config changed', { key: payload.key });
+		// Main phrases user-facing text of its own, so it has to re-language
+		// itself — not just tell the windows to. Done before the broadcast so a
+		// renderer that reacts by immediately asking main for something already
+		// gets the new language.
+		if (payload.key === 'locale') {
+			setLocale(payload.value);
+		}
 		broadcastToWindows(
 			`config:changed:${payload.key}`,
 			payload.value,
@@ -1071,7 +1105,7 @@ ipcMain.handle('long-exposure:capture', async (event, rawRecipe: unknown) => {
 		return {
 			ok: false,
 			failure: 'busy',
-			message: 'A capture is already in progress.',
+			message: t('longExposureCapture.busy'),
 			warnings: [],
 		};
 	}
@@ -1089,8 +1123,8 @@ ipcMain.handle('long-exposure:capture', async (event, rawRecipe: unknown) => {
 			ok: false,
 			failure: 'backend-unavailable',
 			message: gate.needsNativeCapture
-				? 'Long exposure needs High-Fidelity Capture (WGC). Turn it on in Settings to use it.'
-				: gate.reason || 'Long exposure is not available on this machine.',
+				? t('longExposureCapture.needsNativeCapture')
+				: gate.reason || t('longExposureCapture.unavailable'),
 			warnings: [],
 		};
 	}
@@ -1102,8 +1136,7 @@ ipcMain.handle('long-exposure:capture', async (event, rawRecipe: unknown) => {
 		return {
 			ok: false,
 			failure: 'invalid-recipe',
-			message:
-				'Long exposure needs replay telemetry from iRacing. Check that the sim is running and in a session.',
+			message: t('longExposureCapture.noTelemetry'),
 			warnings: [],
 		};
 	}
@@ -1123,7 +1156,7 @@ ipcMain.handle('long-exposure:capture', async (event, rawRecipe: unknown) => {
 		return {
 			ok: false,
 			failure: 'exclusive-fullscreen',
-			message: EXCLUSIVE_FULLSCREEN_MESSAGE,
+			message: EXCLUSIVE_FULLSCREEN_MESSAGE(),
 			warnings: [],
 		};
 	}
@@ -1173,7 +1206,7 @@ ipcMain.handle('long-exposure:capture', async (event, rawRecipe: unknown) => {
 				const raised = getIracingExclusiveFullscreenState();
 				lastCaptureFullscreenState = raised ? raised.state : null;
 				return raised && raised.exclusiveFullscreen
-					? EXCLUSIVE_FULLSCREEN_MESSAGE
+					? EXCLUSIVE_FULLSCREEN_MESSAGE()
 					: null;
 			},
 			vramInfo: () => getVramInfo(),
@@ -1557,6 +1590,9 @@ app.on('ready', async () => {
 	}
 
 	loadConfig();
+	// Before createWindow, so the renderer reads a settled `locale` from config
+	// and paints its first frame in the right language.
+	initLocale();
 	createWindow();
 
 	width = config.get('defaultScreenWidth');
@@ -1733,7 +1769,7 @@ app.on('ready', async () => {
 				log.info('Screenshot rejected', {
 					reason: 'exclusive-fullscreen',
 				});
-				reportScreenshotError(EXCLUSIVE_FULLSCREEN_MESSAGE, {
+				reportScreenshotError(EXCLUSIVE_FULLSCREEN_MESSAGE(), {
 					context: 'resize-screenshot:exclusive-fullscreen',
 					meta: { request: data },
 				});
@@ -2263,7 +2299,7 @@ ipcMain.handle('update:check', () => {
 	if (!app.isPackaged) {
 		return {
 			started: false,
-			reason: 'Update checks only run in an installed build.',
+			reason: t('update.devBuildOnly'),
 			state: updateStatePayload(),
 		};
 	}
@@ -2316,13 +2352,14 @@ ipcMain.handle('update:install', async () => {
 	// this covers everything else the user might be part-way through.
 	const { response } = await dialog.showMessageBox(mainWindow ?? undefined, {
 		type: 'question',
-		buttons: ['Restart and install', 'Later'],
+		buttons: [t('update.installConfirm'), t('update.installLater')],
 		defaultId: 0,
 		cancelId: 1,
-		title: 'Install update',
-		message: `Install version ${updateState.version ?? 'update'}?`,
-		detail:
-			'The app will close and reopen once the update is installed. If you choose Later, it will install by itself the next time you close the app.',
+		title: t('update.installTitle'),
+		message: t('update.installMessage', {
+			version: updateState.version ?? t('update.installFallbackVersion'),
+		}),
+		detail: t('update.installDetail'),
 	});
 
 	if (response !== 0) {

--- a/src/main/long-exposure/capture-session.ts
+++ b/src/main/long-exposure/capture-session.ts
@@ -43,6 +43,7 @@ import {
 import { assessLongExposureVram } from '../../utilities/long-exposure/vram-budget';
 import type { Dimensions, VramInfo } from '../../utilities/vram-prediction';
 import type { PlaybackSnapshot, ReplayState } from './replay-control';
+import { t } from '../../utilities/i18n';
 import {
 	ReplayController,
 	capturePlaybackSnapshot,
@@ -780,11 +781,15 @@ async function runCapture(args: RunCaptureArgs): Promise<LongExposureOutcome> {
 		return {
 			...base(),
 			failure: 'window-unavailable',
-			message: 'iRacing window not found.',
+			message: t('longExposureCapture.windowNotFound'),
 		};
 	}
 	if (aborted()) {
-		return { ...base(), failure: 'aborted', message: 'Capture cancelled.' };
+		return {
+			...base(),
+			failure: 'aborted',
+			message: t('longExposureCapture.cancelled'),
+		};
 	}
 
 	// #10 AGAIN — and this is the sample that can actually fire.
@@ -870,7 +875,9 @@ async function runCapture(args: RunCaptureArgs): Promise<LongExposureOutcome> {
 			return {
 				...base(),
 				failure: 'seek-failed',
-				message: `The replay did not reach frame ${sink.startFrame} in time. It may still be loading.`,
+				message: t('longExposureCapture.seekTimeout', {
+					frame: sink.startFrame,
+				}),
 			};
 		}
 
@@ -959,7 +966,7 @@ async function runCapture(args: RunCaptureArgs): Promise<LongExposureOutcome> {
 		return {
 			...base(),
 			failure: 'invalid-recipe',
-			message: 'A capture must run at least one pass.',
+			message: t('longExposureCapture.noPasses'),
 		};
 	}
 
@@ -1185,8 +1192,7 @@ async function accumulateWindow(
 			return {
 				...base(),
 				failure: 'playback-stalled',
-				message:
-					'The replay did not start playing. Check that iRacing is not paused by another tool.',
+				message: t('longExposureCapture.playbackStalled'),
 			};
 		}
 		if (elapsed > timeoutMs) {
@@ -1194,7 +1200,10 @@ async function accumulateWindow(
 			return {
 				...base(),
 				failure: 'playback-stalled',
-				message: `The exposure did not reach frame ${sink.endFrame} within ${Math.round(timeoutMs / 1000)}s.`,
+				message: t('longExposureCapture.exposureTimeout', {
+					frame: sink.endFrame,
+					seconds: Math.round(timeoutMs / 1000),
+				}),
 			};
 		}
 
@@ -1227,7 +1236,7 @@ async function accumulateWindow(
 		return {
 			...base(),
 			failure: 'playback-stalled',
-			message: 'The exposure ended before reaching the selected moment.',
+			message: t('longExposureCapture.endedEarly'),
 		};
 	}
 	return null;
@@ -1305,10 +1314,10 @@ async function resolveCapture(
 		// malfunction. Blaming iRacing for that would send the user hunting a
 		// fault that isn't there.
 		const reason = !preResolve.sawFrame
-			? 'iRacing did not present any frames to capture.'
+			? t('longExposureCapture.noFramesPresented')
 			: plan.isSubFrameWindow
-				? `This shutter is shorter than one replay frame, and iRacing did not render a frame inside it. Try a slower playback speed, or the next slower shutter.`
-				: 'No frames were accumulated. iRacing may have stopped rendering during the exposure.';
+				? t('longExposureCapture.subFrameNoSamples')
+				: t('longExposureCapture.noSamples');
 		// Append the native cause when there is one. It is a short, concrete string
 		// aimed at us rather than at the user, but a user who can paste it into a bug
 		// report turns an unfalsifiable "it doesn't work" into a named failure — which
@@ -1319,7 +1328,12 @@ async function resolveCapture(
 		return {
 			...base(),
 			failure: 'no-samples',
-			message: nativeError ? `${reason} (${nativeError})` : reason,
+			message: nativeError
+				? t('longExposureCapture.withNativeError', {
+						reason,
+						error: nativeError,
+					})
+				: reason,
 		};
 	}
 
@@ -1389,7 +1403,7 @@ async function resolveCapture(
 		return {
 			...base(),
 			failure: 'resolve-failed',
-			message: result.error || 'The GPU did not return an image.',
+			message: result.error || t('longExposureCapture.resolveFailed'),
 			stats,
 			backend: result.backend || deps.backendName,
 			interpolation,
@@ -1480,8 +1494,10 @@ async function resolveCapture(
 	}
 	if (sinks.length > 1 && resolvedImages.length < sinks.length) {
 		warnings.push(
-			`Bracketing asked for ${sinks.length} stops but ${resolvedImages.length} came back — ` +
-				'the rest failed to resolve, or this build of the capture addon predates bracketing.'
+			t('longExposureCapture.bracketShortfall', {
+				asked: sinks.length,
+				returned: resolvedImages.length,
+			})
 		);
 	}
 

--- a/src/renderer/components/ChangelogModal.vue
+++ b/src/renderer/components/ChangelogModal.vue
@@ -11,7 +11,7 @@
 				class="modal-card-title"
 				style="color: white; font-weight: 700; margin-bottom: 0rem"
 			>
-				Changelog
+				{{ $t('changelog.title') }}
 			</p>
 			<button type="button" class="delete" @click="$emit('close')" />
 		</header>
@@ -53,7 +53,10 @@ export default {
 
 			releases.forEach((release) => {
 				const releaseVersion = release.tag_name || release.name || '';
-				const releaseTitle = release.name || release.tag_name || 'Release';
+				const releaseTitle =
+					release.name ||
+					release.tag_name ||
+					this.$t('changelog.untitledRelease');
 				const compare = compareVer(version, releaseVersion);
 				if (compare === 0 || compare === 1) {
 					this.changelog += `## ${releaseTitle}\n ${release.body || ''}\n\n ___ \n`;

--- a/src/renderer/components/HelpModal.vue
+++ b/src/renderer/components/HelpModal.vue
@@ -11,7 +11,7 @@
 				class="modal-card-title"
 				style="color: white; font-weight: 700; margin-bottom: 0rem"
 			>
-				Help
+				{{ $t('help.title') }}
 			</p>
 			<button type="button" class="delete" @click="$emit('close')" />
 		</header>
@@ -22,7 +22,11 @@
 			     the build — a runtime-only failure this modal would wear. Two tabs of
 			     real buttons cost less than that risk and style cleanly on the dark
 			     card. -->
-			<div class="help-tabs" role="tablist" aria-label="Help sections">
+			<div
+				class="help-tabs"
+				role="tablist"
+				:aria-label="$t('help.sections')"
+			>
 				<button
 					v-for="(tab, index) in tabs"
 					:id="'help-tab-' + tab.id"
@@ -44,6 +48,20 @@
 				</button>
 			</div>
 
+			<!-- v-html on the prose paragraphs that carry inline <b>/<i> emphasis.
+			     The emphasis is not decoration here — "<b>Box</b> weights them all
+			     equally" is naming a control — and splitting each sentence into three
+			     keys around it would hand translators fragments they cannot reorder,
+			     which is exactly the word order most of these languages need to change.
+
+			     The XSS rule is disabled DELIBERATELY and only here. Its premise is
+			     that the string might be attacker-influenced; every string below comes
+			     from $t, which reads a compile-time catalogue in this repo. No user
+			     input, no file content and no network response can reach these keys —
+			     the only way to get markup in is to commit it. If that ever stops being
+			     true (a downloaded or user-supplied translation, say), this block has to
+			     go back to interpolation. -->
+			<!-- eslint-disable vue/no-v-html -->
 			<div class="help-panels">
 				<div
 					v-show="active === 'general'"
@@ -52,68 +70,39 @@
 					aria-labelledby="help-tab-general"
 					tabindex="0"
 				>
-					<span class="heading">iRacing Settings</span>
+					<span class="heading">{{
+						$t('help.general.iracingSettings')
+					}}</span>
 					<ul>
-						<li>iRacing must be running in Windowed Borderless</li>
-						<li>
-							At least 8GB of VRAM is recommended for screenshots of 8k
-							resolution or higher
-						</li>
-						<li>Newer tracks and cars will require more VRAM</li>
-						<li>
-							Shrink the UI to the smallest it can go before taking a
-							screenshot if using the Crop Watermark option,
-							"Control+PageDown" will shrink it, if this doesnt work you
-							may need to reset your UI Zoom in the iRacing settings
-						</li>
+						<li>{{ $t('help.general.borderless') }}</li>
+						<li>{{ $t('help.general.vram') }}</li>
+						<li>{{ $t('help.general.newerContent') }}</li>
+						<li>{{ $t('help.general.shrinkUi') }}</li>
 					</ul>
-					<span class="heading">Screenshot Folder</span>
+					<span class="heading">{{
+						$t('help.general.screenshotFolder')
+					}}</span>
+					<p>{{ $t('help.general.screenshotFolderBody') }}</p>
+					<span class="heading">{{
+						$t('help.general.screenshotHotkey')
+					}}</span>
+					<p>{{ $t('help.general.screenshotHotkeyBody') }}</p>
+					<span class="heading">{{ $t('help.general.issues') }}</span>
 					<p>
-						Screenshots will be saved by default to
-						"C:\Users\user\Pictures\Screenshots" this can be changed in
-						the settings
+						{{ $t('help.general.issuesBody') }}
+						<a @click="openDiscord">{{ $t('help.general.discord') }}</a>
 					</p>
-					<span class="heading">Screenshot Hotkey</span>
-					<p>
-						By default "Control + PrintScreen" will take a screenshot with
-						the current settings, this can be changed in the settings.
-					</p>
-					<span class="heading">Issues</span>
-					<p>
-						If you have any issues please report them on the
-						<a @click="openDiscord">Discord</a>
-					</p>
-					<span class="heading">Instructions</span>
+					<span class="heading">{{
+						$t('help.general.instructions')
+					}}</span>
 					<ol>
-						<li>
-							iRacing <b>must</b> be running in Windowed Borderless Mode
-						</li>
-						<li>
-							Run iRacing and setup the camera in the position you want
-							to take the screenshot
-						</li>
-						<li>
-							Select your desired resolution (Try lower resolutions
-							before going to 8K)
-						</li>
-						<li>
-							Select if you want to crop the iRacing watermark or not, if
-							you want to crop it you will need to resize the iRacing UI
-							with 'Control + PageDown' to the smallest size first
-						</li>
-						<li>
-							Press the screenshot button or use the Hotkey 'Control +
-							PrintScreen' to take the screenshots
-						</li>
-						<li>
-							Depending on the resolution selected this may take a few
-							seconds, once your iRacing screen resizes to its normal
-							size it is finished
-						</li>
-						<li>
-							Your screenshot will be saved to
-							'C:\Users\{User}\Pictures\Screenshots'
-						</li>
+						<li v-html="$t('help.general.step1')"></li>
+						<li>{{ $t('help.general.step2') }}</li>
+						<li>{{ $t('help.general.step3') }}</li>
+						<li>{{ $t('help.general.step4') }}</li>
+						<li>{{ $t('help.general.step5') }}</li>
+						<li>{{ $t('help.general.step6') }}</li>
+						<li>{{ $t('help.general.step7') }}</li>
 					</ol>
 				</div>
 
@@ -124,170 +113,65 @@
 					aria-labelledby="help-tab-long-exposure"
 					tabindex="0"
 				>
-					<span class="heading">What it does</span>
-					<p>
-						A long exposure blends many frames of a replay into one image,
-						the way leaving a camera shutter open does: stationary things
-						stay sharp, moving things streak. The tool drives the replay
-						itself, captures every frame the sim presents, and adds them
-						up on the GPU.
-					</p>
-					<span class="heading">Shutter</span>
-					<p>
-						How long the exposure lasts <i>in replay time</i>, from a
-						fraction of one replay frame up to ten seconds. This is the
-						setting that decides how long the streaks are. Longer shutters
-						also collect more frames, so they need less help from
-						everything below; the fastest stops span a single replay frame
-						and collect only a handful of samples.
-					</p>
+					<span class="heading">{{
+						$t('help.longExposure.whatItDoes')
+					}}</span>
+					<p>{{ $t('help.longExposure.whatItDoesBody') }}</p>
 
-					<span class="heading">Playback speed</span>
-					<p>
-						The replay is played in slow motion while the exposure is
-						captured, so the sim presents more frames per second of replay
-						time and the blend gets more samples. 1/16 collects roughly
-						sixteen times as many frames as real time — and takes sixteen
-						times as long in wall clock. This is the main trade in the
-						panel: patience for smoothness.
-					</p>
-					<p>
-						"Auto (from sample target)" picks the speed for you from
-						<b>Target samples</b>: the tool solves for the fastest
-						playback that still reaches the number you asked for. Set an
-						explicit speed instead if you would rather cap the wait.
-					</p>
+					<span class="heading">{{
+						$t('help.longExposure.shutter')
+					}}</span>
+					<p v-html="$t('help.longExposure.shutterBody')"></p>
 
-					<span class="heading">Weighting</span>
-					<p>
-						How much each captured frame contributes to the result.
-						<b>Box</b> weights them all equally, giving an even streak.
-						<b>Linear</b> ramps toward the end of the window, so the
-						subject is sharpest where it finished and fades back along its
-						path. <b>Ease</b> is the same idea with a sharper head and a
-						longer tail.
-					</p>
+					<span class="heading">{{
+						$t('help.longExposure.playback')
+					}}</span>
+					<p>{{ $t('help.longExposure.playbackBody') }}</p>
+					<p v-html="$t('help.longExposure.playbackAutoBody')"></p>
 
-					<span class="heading">Frame interpolation</span>
-					<p>
-						Invents extra frames between the real ones using the GPU's
-						optical-flow engine, filling in the gaps along the streak.
-						Requires an NVIDIA Turing or newer card and is hidden entirely
-						on hardware that cannot do it.
-					</p>
-					<p>
-						It is not free: it costs GPU time on every captured frame, and
-						the budget is one iRacing frame. If it cannot keep up it
-						starts missing <i>real</i> frames in order to manufacture
-						synthetic ones, which is a net loss — the streak comes out
-						shorter and coarser. The cost scales with megapixels times the
-						factor, so what is comfortable at 2560×1440 is not viable at
-						8K. To check it, shoot the same moment twice with it on and
-						off and compare the real sample counts; the app also warns you
-						afterwards if a shot fell short.
-					</p>
+					<span class="heading">{{
+						$t('help.longExposure.weighting')
+					}}</span>
+					<p v-html="$t('help.longExposure.weightingBody')"></p>
 
-					<span class="heading">Passes</span>
-					<p>
-						Visits the same moment several times, accumulating into one
-						image. Each pass catches frames the others happened to miss,
-						so the streak gets smoother — not brighter, because the result
-						is normalised by how much light actually landed on each pixel.
-					</p>
-					<p>
-						Passes buy the same thing interpolation does, with a different
-						currency: wall clock instead of GPU time. Eight passes take
-						roughly eight times as long, but they can never cost you real
-						frames. That makes them the right lever at high resolutions,
-						where interpolation cannot keep up, and on fast shutters,
-						where a single pass collects very few samples. Using both at
-						once is usually the worst of the trade — they compete for the
-						same per-frame budget.
-					</p>
+					<span class="heading">{{
+						$t('help.longExposure.interpolation')
+					}}</span>
+					<p>{{ $t('help.longExposure.interpolationBody') }}</p>
+					<p v-html="$t('help.longExposure.interpolationCostBody')"></p>
 
-					<span class="heading">Bracket shutters</span>
-					<p>
-						Emits one image per shutter stop at or faster than the one you
-						chose, from a single capture. A shot at 1/60 also gives you
-						1/125, 1/250, 1/500 and 1/1000 — the same moment with
-						progressively shorter streaks — so you can pick the look
-						afterwards instead of guessing and re-shooting.
-					</p>
-					<p>
-						It costs almost no extra time. Every stop ends on the same
-						frame and differs only in how far back it reaches, so a faster
-						shutter is simply the tail of the frames already going past —
-						they are all filled from one pass of the replay.
-					</p>
-					<p>
-						What it does cost is memory. Each stop needs its own
-						full-resolution accumulator, so eleven stops need eleven times
-						the video memory of one, which at 8K is more than most cards
-						have. The capture checks this before it starts and refuses
-						rather than crashing iRacing, so if a bracket is declined,
-						lower the resolution or pick a faster shutter — which is also
-						a shorter ladder.
-					</p>
-					<p>
-						The stop you chose is saved under the usual name and is the
-						one that appears in the gallery; the others sit beside it with
-						their shutter in the filename.
-					</p>
+					<span class="heading">{{ $t('help.longExposure.passes') }}</span>
+					<p>{{ $t('help.longExposure.passesBody') }}</p>
+					<p>{{ $t('help.longExposure.passesTradeBody') }}</p>
 
-					<span class="heading">Highlight recovery</span>
-					<p>
-						Boosts near-clipped highlights before the frames are added up,
-						then undoes the boost at the end. iRacing hands over an image
-						that has already been tonemapped, so a headlight and a white
-						wall arrive at the same value; averaging that makes a bright
-						light sweeping through part of the exposure read as a grey
-						smudge rather than a bright trail. This puts the non-linearity
-						back where a real sensor has it. Measured in stops; 0 is off
-						and changes nothing at all.
-					</p>
+					<span class="heading">{{
+						$t('help.longExposure.bracket')
+					}}</span>
+					<p>{{ $t('help.longExposure.bracketBody') }}</p>
+					<p>{{ $t('help.longExposure.bracketCostBody') }}</p>
+					<p>{{ $t('help.longExposure.bracketMemoryBody') }}</p>
+					<p>{{ $t('help.longExposure.bracketNamingBody') }}</p>
 
-					<span class="heading">What it saves</span>
-					<p>
-						Size, watermark cropping and file format all follow the same
-						controls a normal screenshot uses — the Resolution and Crop
-						Watermark settings above, and the output format in Settings.
-						The Output line at the top of the sidebar shows exactly what
-						you will get.
-					</p>
-					<p>
-						Choosing PNG writes a true 16-bit master, which is worth it if
-						you intend to grade the shot afterwards, plus an 8-bit preview
-						for the gallery. It is also much slower to write at high
-						resolutions — a 33-megapixel 16-bit PNG takes around ten
-						seconds where the same frame as JPEG takes under one.
-					</p>
+					<span class="heading">{{
+						$t('help.longExposure.highlights')
+					}}</span>
+					<p>{{ $t('help.longExposure.highlightsBody') }}</p>
 
-					<span class="heading">If the result looks wrong</span>
+					<span class="heading">{{
+						$t('help.longExposure.whatItSaves')
+					}}</span>
+					<p>{{ $t('help.longExposure.whatItSavesBody') }}</p>
+					<p>{{ $t('help.longExposure.whatItSavesPngBody') }}</p>
+
+					<span class="heading">{{
+						$t('help.longExposure.troubleshooting')
+					}}</span>
 					<ul>
-						<li>
-							<b>Discrete ghosts instead of a smooth streak</b> — too few
-							samples. Use a slower playback speed, more passes, or a
-							lower resolution.
-						</li>
-						<li>
-							<b>Not sure which shutter you wanted</b> — turn on Bracket
-							shutters and decide afterwards, for the same wait.
-						</li>
-						<li>
-							<b>Blown-out or flat highlights</b> — try 3 to 5 stops of
-							highlight recovery.
-						</li>
-						<li>
-							<b>A black image</b> — iRacing is in exclusive fullscreen.
-							Set Display &gt; Full Screen to OFF.
-						</li>
-						<li>
-							Every shot records the exact settings it used, the sample
-							count and how evenly the samples landed, as a .json file in
-							the log folder alongside app.log. The last 20 shots are
-							kept — a bracket counts as one — so the shot you are asking
-							about is still there while you are asking about it.
-						</li>
+						<li v-html="$t('help.longExposure.troubleGhosts')"></li>
+						<li v-html="$t('help.longExposure.troubleShutter')"></li>
+						<li v-html="$t('help.longExposure.troubleHighlights')"></li>
+						<li v-html="$t('help.longExposure.troubleBlack')"></li>
+						<li>{{ $t('help.longExposure.troubleSidecar') }}</li>
 					</ul>
 				</div>
 			</div>
@@ -302,11 +186,20 @@ export default {
 	data() {
 		return {
 			active: 'general',
-			tabs: [
-				{ id: 'general', label: 'General' },
-				{ id: 'long-exposure', label: 'Long Exposure' },
-			],
 		};
+	},
+	computed: {
+		// A computed, not data: the labels have to re-read when the language
+		// changes, and data() runs once.
+		tabs(): { id: string; label: string }[] {
+			return [
+				{ id: 'general', label: this.$t('help.tabGeneral') },
+				{
+					id: 'long-exposure',
+					label: this.$t('help.tabLongExposure'),
+				},
+			];
+		},
 	},
 	methods: {
 		openDiscord() {

--- a/src/renderer/components/LongExposurePanel.vue
+++ b/src/renderer/components/LongExposurePanel.vue
@@ -19,7 +19,9 @@
 			>
 				<font-awesome-icon icon="chevron-right" />
 			</span>
-			<span class="label" style="margin-bottom: 0">Long Exposure</span>
+			<span class="label" style="margin-bottom: 0">{{
+				$t('longExposure.title')
+			}}</span>
 			<!-- No status text on the right. It carried the compute backend when
 			     open ("d3d11-compute") and the panel state when folded ("needs a
 			     replay"), neither of which is something to read every time the
@@ -30,7 +32,7 @@
 
 		<div v-show="!collapsed" id="long-exposure-body">
 			<template v-if="available">
-				<o-field label="Shutter">
+				<o-field :label="$t('longExposure.shutter')">
 					<o-select v-model="shutter" expanded :disabled="busy">
 						<option
 							v-for="stop in shutterOptions"
@@ -42,16 +44,23 @@
 					</o-select>
 				</o-field>
 
-				<o-field label="Playback speed">
+				<o-field :label="$t('longExposure.playbackSpeed')">
 					<o-select v-model="playbackSpeed" expanded :disabled="busy">
-						<option :value="0">Auto (from sample target)</option>
+						<option :value="0">
+							{{ $t('longExposure.playbackAuto') }}
+						</option>
 						<option v-for="d in playbackDivisors" :key="d" :value="d">
-							{{ d === 1 ? '1x (real time)' : '1/' + d }}
+							{{
+								d === 1 ? $t('longExposure.playbackRealTime') : '1/' + d
+							}}
 						</option>
 					</o-select>
 				</o-field>
 
-				<o-field v-if="playbackSpeed === 0" label="Target samples">
+				<o-field
+					v-if="playbackSpeed === 0"
+					:label="$t('longExposure.targetSamples')"
+				>
 					<o-input
 						v-model="targetSamples"
 						type="number"
@@ -81,7 +90,7 @@
 					>
 						<font-awesome-icon icon="chevron-right" />
 					</span>
-					<span>Advanced</span>
+					<span>{{ $t('longExposure.advanced') }}</span>
 					<span
 						class="long-exposure__summary"
 						:class="{ 'is-modified': advancedModified.length > 0 }"
@@ -91,12 +100,16 @@
 				</button>
 
 				<div v-show="advancedOpen" id="long-exposure-advanced">
-					<o-field label="Weighting">
+					<o-field :label="$t('longExposure.weighting')">
 						<o-select v-model="weighting" expanded :disabled="busy">
-							<option value="box">Box (even)</option>
-							<option value="linear">Linear (sharp at the end)</option>
+							<option value="box">
+								{{ $t('longExposure.weightingBox') }}
+							</option>
+							<option value="linear">
+								{{ $t('longExposure.weightingLinear') }}
+							</option>
 							<option value="ease">
-								Ease (sharper head, long tail)
+								{{ $t('longExposure.weightingEase') }}
 							</option>
 						</o-select>
 					</o-field>
@@ -116,13 +129,21 @@
 			     this. -->
 					<o-field
 						v-if="interpolationSupported"
-						label="Frame interpolation"
+						:label="$t('longExposure.interpolation')"
 					>
 						<o-select v-model="interpolation" expanded :disabled="busy">
-							<option :value="1">Off</option>
-							<option :value="2">2× (one in-between)</option>
-							<option :value="4">4× (three in-betweens)</option>
-							<option :value="8">8× (seven in-betweens)</option>
+							<option :value="1">
+								{{ $t('longExposure.interpolationOff') }}
+							</option>
+							<option :value="2">
+								{{ $t('longExposure.interpolation2') }}
+							</option>
+							<option :value="4">
+								{{ $t('longExposure.interpolation4') }}
+							</option>
+							<option :value="8">
+								{{ $t('longExposure.interpolation8') }}
+							</option>
 						</o-select>
 					</o-field>
 
@@ -130,12 +151,20 @@
 			     not companions: both buy sample density, one with GPU time we may
 			     not have and one with wall clock we always do. Needs no particular
 			     hardware, so unlike interpolation it is always offered. -->
-					<o-field label="Passes">
+					<o-field :label="$t('longExposure.passes')">
 						<o-select v-model="passes" expanded :disabled="busy">
-							<option :value="1">1 (single pass)</option>
-							<option :value="2">2× — twice the wait</option>
-							<option :value="4">4× — four times the wait</option>
-							<option :value="8">8× — eight times the wait</option>
+							<option :value="1">
+								{{ $t('longExposure.passes1') }}
+							</option>
+							<option :value="2">
+								{{ $t('longExposure.passes2') }}
+							</option>
+							<option :value="4">
+								{{ $t('longExposure.passes4') }}
+							</option>
+							<option :value="8">
+								{{ $t('longExposure.passes8') }}
+							</option>
 						</o-select>
 					</o-field>
 
@@ -156,9 +185,9 @@
 							for="long-exposure-bracket-switch"
 							class="settings-toggle-row__text"
 						>
-							<span class="label" style="margin-bottom: 0px"
-								>Bracket shutters</span
-							>
+							<span class="label" style="margin-bottom: 0px">{{
+								$t('longExposure.bracket')
+							}}</span>
 						</label>
 					</o-field>
 
@@ -170,7 +199,7 @@
 			     was 0 — i.e. permanently, since 0 is the default. A tip that fires on
 			     the default state is a nag, not guidance. The default stays 0, where
 			     it is exactly identity. -->
-					<o-field label="Highlight recovery (stops)">
+					<o-field :label="$t('longExposure.highlightRecovery')">
 						<o-input
 							v-model="highlightRecovery"
 							type="number"
@@ -210,7 +239,7 @@
 				style="margin-top: 0.5rem"
 				@click="capture"
 			>
-				{{ busy ? progressLabel : 'Long Exposure' }}
+				{{ busy ? progressLabel : $t('longExposure.title') }}
 			</o-button>
 
 			<o-button
@@ -221,7 +250,7 @@
 				style="margin-top: 0.35rem"
 				@click="abort"
 			>
-				Cancel
+				{{ $t('longExposure.cancel') }}
 			</o-button>
 
 			<!-- No shot summary here any more. The panel used to forecast samples,
@@ -375,22 +404,34 @@ export default defineComponent({
 		advancedModified(): string[] {
 			const active: string[] = [];
 			if (this.weighting !== 'box') {
-				active.push(this.weighting);
+				active.push(
+					this.$t(`longExposure.modified.weighting_${this.weighting}`)
+				);
 			}
 			if (this.interpolationSupported && Number(this.interpolation) > 1) {
-				active.push(`${this.interpolation}× interpolation`);
+				active.push(
+					this.$t('longExposure.modified.interpolation', {
+						factor: this.interpolation,
+					})
+				);
 			}
 			// Named rather than counted, and for the sharpest version of the reason
 			// this disclosure names anything: a forgotten 8 here is an eightfold wait.
 			if (Number(this.passes) > 1) {
-				active.push(`${this.passes} passes`);
+				active.push(
+					this.$t('longExposure.modified.passes', {
+						count: Number(this.passes),
+					})
+				);
 			}
 			if (this.bracket) {
-				active.push('bracketed');
+				active.push(this.$t('longExposure.modified.bracketed'));
 			}
 			const recovery = parseFloat(this.highlightRecovery);
 			if (Number.isFinite(recovery) && recovery !== 0) {
-				active.push(`${recovery} stop recovery`);
+				active.push(
+					this.$t('longExposure.modified.recovery', { stops: recovery })
+				);
 			}
 			return active;
 		},
@@ -429,7 +470,7 @@ export default defineComponent({
 			if (this.needsNativeCapture) {
 				notices.push({
 					level: 'warning',
-					text: 'Long exposure needs High-Fidelity Capture (WGC), which is currently off. Turn it on in Settings to enable long exposure.',
+					text: this.$t('longExposure.notices.needsNativeCapture'),
 				});
 				return notices;
 			}
@@ -439,9 +480,11 @@ export default defineComponent({
 			if (!this.available) {
 				notices.push({
 					level: 'warning',
-					text: `Long exposure is unavailable on this machine${
-						this.unavailableReason ? ': ' + this.unavailableReason : '.'
-					}`,
+					text: this.unavailableReason
+						? this.$t('longExposure.notices.unavailableWithReason', {
+								reason: this.unavailableReason,
+							})
+						: this.$t('longExposure.notices.unavailable'),
 				});
 				// Nothing below applies when the feature cannot run at all.
 				return notices;
@@ -465,7 +508,7 @@ export default defineComponent({
 			if (this.lastResult && !this.lastResult.ok) {
 				notices.push({
 					level: 'danger',
-					text: this.lastResult.message || 'Long exposure failed',
+					text: this.lastResult.message || this.$t('longExposure.failed'),
 				});
 			}
 			if (this.lastResult) {
@@ -491,11 +534,7 @@ export default defineComponent({
 			if (this.interpolationWillRun) {
 				notices.push({
 					level: 'warning',
-					text:
-						'Interpolation invents frames between the real ones to smooth the ' +
-						"streak. It costs GPU time per frame, so check the saved shot's " +
-						'real sample count against the same shot with it off — if that ' +
-						'number drops, it is buying invented samples with real ones.',
+					text: this.$t('longExposure.notices.interpolationCost'),
 				});
 			}
 
@@ -504,20 +543,14 @@ export default defineComponent({
 			if (Number(this.passes) > 1 && this.interpolationWillRun) {
 				notices.push({
 					level: 'warning',
-					text:
-						'Passes and interpolation compete for the same per-frame budget. ' +
-						'With both on, each pass captures fewer real frames — turning ' +
-						'interpolation off usually makes the better shot for the same wait.',
+					text: this.$t('longExposure.notices.passesAndInterpolation'),
 				});
 			}
 
 			if (Number(this.passes) > 1) {
 				notices.push({
 					level: 'info',
-					text:
-						'Each pass replays the same moment and catches frames the others ' +
-						'missed, so the streak gets smoother rather than brighter. Best on ' +
-						'fast shutters, where a single pass collects only a handful of samples.',
+					text: this.$t('longExposure.notices.passes'),
 				});
 			}
 
@@ -526,10 +559,13 @@ export default defineComponent({
 			if (!this.interpolationSupported && this.interpolationReason) {
 				notices.push({
 					level: 'info',
-					text:
-						'Frame interpolation needs an NVIDIA Turing or newer GPU' +
-						`${this.adapter ? ` (this capture runs on ${this.adapter})` : ''}. ` +
-						'Everything else about long exposure works as normal.',
+					text: this.$t('longExposure.notices.interpolationUnsupported', {
+						adapter: this.adapter
+							? this.$t('longExposure.notices.interpolationAdapter', {
+									adapter: this.adapter,
+								})
+							: '',
+					}),
 				});
 			}
 
@@ -539,9 +575,7 @@ export default defineComponent({
 			if (this.reshade) {
 				notices.push({
 					level: 'info',
-					text:
-						'Long exposure captures natively and does not use ReShade, so ' +
-						'ReShade effects will not appear in the result.',
+					text: this.$t('longExposure.notices.reshade'),
 				});
 			}
 
@@ -553,7 +587,9 @@ export default defineComponent({
 			}
 			return this.advancedModified.length > 0
 				? this.advancedModified.join(', ')
-				: `${this.advancedCount} defaults`;
+				: this.$t('longExposure.defaultsSummary', {
+						count: this.advancedCount,
+					});
 		},
 		// Multi-pass re-seeks between passes, so without the pass number the progress
 		// line would appear to restart part-way through and read as a fault.
@@ -561,23 +597,31 @@ export default defineComponent({
 			const total = this.progress?.passes ?? 0;
 			const current = this.progress?.pass;
 			if (total > 1 && typeof current === 'number') {
-				return ` (pass ${current + 1} of ${total})`;
+				return this.$t('longExposure.progress.pass', {
+					current: current + 1,
+					total,
+				});
 			}
 			return '';
 		},
 		progressLabel(): string {
-			if (!this.progress) return 'Working…';
+			if (!this.progress) return this.$t('longExposure.progress.working');
 			switch (this.progress.phase) {
 				case 'seeking':
-					return `Seeking…${this.passLabel}`;
+					return this.$t('longExposure.progress.seeking', {
+						pass: this.passLabel,
+					});
 				case 'accumulating':
-					return `Exposing… ${this.progress.accepted ?? 0} samples${this.passLabel}`;
+					return this.$t('longExposure.progress.accumulating', {
+						count: this.progress.accepted ?? 0,
+						pass: this.passLabel,
+					});
 				case 'resolving':
-					return 'Developing…';
+					return this.$t('longExposure.progress.resolving');
 				case 'restoring':
-					return 'Restoring replay…';
+					return this.$t('longExposure.progress.restoring');
 				default:
-					return 'Working…';
+					return this.$t('longExposure.progress.working');
 			}
 		},
 		// Everything the main process needs to execute the shot. Building this in
@@ -781,12 +825,14 @@ export default defineComponent({
 				this.lastResult = result;
 				if (result.ok) {
 					useOruga().notification.open({
-						message: `Long exposure saved — ${result.stats.accepted} samples`,
+						message: this.$t('longExposure.saved', {
+							count: result.stats.accepted,
+						}),
 						variant: 'success',
 					});
 				} else {
 					useOruga().notification.open({
-						message: result.message || 'Long exposure failed',
+						message: result.message || this.$t('longExposure.failed'),
 						variant: 'danger',
 					});
 				}

--- a/src/renderer/components/NoticeCard.vue
+++ b/src/renderer/components/NoticeCard.vue
@@ -97,10 +97,12 @@ const ICONS: Record<NoticeLevel, string> = {
 	info: 'circle-info',
 };
 
-const TITLES: Record<NoticeLevel, string> = {
-	danger: 'Problems',
-	warning: 'Worth knowing',
-	info: 'Notes',
+// Translation keys rather than text: this is module scope, evaluated at import
+// time, and the heading has to follow the language for the life of the window.
+const TITLE_KEYS: Record<NoticeLevel, string> = {
+	danger: 'notice.danger',
+	warning: 'notice.warning',
+	info: 'notice.info',
 };
 
 // ONE card for every notice a panel wants to raise, replacing the stacks of
@@ -142,7 +144,7 @@ export default defineComponent({
 			return this.ordered.length > 0 ? this.ordered[0].level : 'info';
 		},
 		resolvedTitle(): string {
-			return this.title || TITLES[this.level];
+			return this.title || this.$t(TITLE_KEYS[this.level]);
 		},
 	},
 	methods: {

--- a/src/renderer/components/PromoCard.vue
+++ b/src/renderer/components/PromoCard.vue
@@ -1,11 +1,7 @@
 <template>
 	<section class="maintainer-note">
-		<p class="maintainer-note__greeting">
-			Thanks for using iRacing Screenshot Tool!
-		</p>
-		<p class="maintainer-note__signature">
-			Built and maintained by AR Media Solutions.
-		</p>
+		<p class="maintainer-note__greeting">{{ $t('promo.greeting') }}</p>
+		<p class="maintainer-note__signature">{{ $t('promo.signature') }}</p>
 		<a class="maintainer-note__link" href="#" @click.prevent="openSite">
 			<span>armediasolutions.net</span>
 			<font-awesome-icon :icon="['fas', 'up-right-from-square']" />

--- a/src/renderer/components/SettingsModal.vue
+++ b/src/renderer/components/SettingsModal.vue
@@ -1,23 +1,33 @@
 <template>
 	<div class="modal-card">
 		<header class="modal-card-head">
-			<p class="modal-card-title settings-title">Settings</p>
+			<p class="modal-card-title settings-title">
+				{{ $t('settings.title') }}
+			</p>
 		</header>
 		<section class="modal-card-body settings-body">
 			<div class="settings-layout">
 				<aside class="settings-meta">
-					<span class="heading">Version - {{ toolVersion }}</span>
+					<span class="heading">{{
+						$t('settings.version', { version: toolVersion })
+					}}</span>
 					<span class="heading"
-						><a @click="$emit('changelog')">Changelog</a></span
+						><a @click="$emit('changelog')">{{
+							$t('settings.changelog')
+						}}</a></span
 					>
 					<span class="heading"
-						><a @click="openLogsFolder">Open Logs Folder</a></span
+						><a @click="openLogsFolder">{{
+							$t('settings.openLogsFolder')
+						}}</a></span
 					>
 					<!-- Somewhere to ASK. The updater is otherwise entirely passive,
 					     so a user who wanted to know whether they were current had no
 					     way to find out short of opening GitHub. -->
 					<span class="heading"
-						><a @click="checkForUpdates">Check for Updates</a></span
+						><a @click="checkForUpdates">{{
+							$t('settings.checkForUpdates')
+						}}</a></span
 					>
 					<span class="heading settings-meta__update">{{
 						updateStatus
@@ -25,7 +35,25 @@
 				</aside>
 
 				<div class="settings-form">
-					<o-field label="Screenshot Folder" />
+					<o-field :label="$t('settings.language')">
+						<o-select v-model="locale" expanded>
+							<!-- Each language named in ITSELF. Someone looking for their
+							     language in a list they cannot otherwise read still
+							     recognises its endonym; "Czech" helps nobody who needs it. -->
+							<option
+								v-for="option in localeOptions"
+								:key="option.code"
+								:value="option.code"
+							>
+								{{ option.name }}
+							</option>
+						</o-select>
+					</o-field>
+					<span class="description">{{
+						$t('settings.languageDescription')
+					}}</span>
+					<hr />
+					<o-field :label="$t('settings.screenshotFolder')" />
 
 					<o-field addons class="settings-inline-field">
 						<o-input
@@ -39,12 +67,12 @@
 								class="button is-primary settings-action"
 								@click="openFolderDialog"
 							>
-								Select Folder
+								{{ $t('settings.selectFolder') }}
 							</o-button>
 						</p>
 					</o-field>
 					<hr />
-					<o-field label="Screenshot Keybind" />
+					<o-field :label="$t('settings.screenshotKeybind')" />
 					<o-field addons class="settings-inline-field">
 						<o-input
 							expanded
@@ -58,7 +86,7 @@
 								:loading="bindingKey"
 								@click="bindScreenshotKeybind"
 							>
-								Edit Bind
+								{{ $t('settings.editBind') }}
 							</o-button>
 						</p>
 					</o-field>
@@ -74,21 +102,19 @@
 							for="settings-custom-filename-format-switch"
 							class="settings-toggle-row__text"
 						>
-							<span class="label" style="margin-bottom: 0px"
-								>Custom Filename Format</span
-							>
-							<span class="description"
-								>Use a custom pattern instead of the default
-								({track}-{driver}-{counter})</span
-							>
+							<span class="label" style="margin-bottom: 0px">{{
+								$t('settings.customFilenameFormat')
+							}}</span>
+							<span class="description">{{
+								$t('settings.customFilenameFormatDescription')
+							}}</span>
 						</label>
 					</o-field>
 					<div v-if="customFilenameFormat">
 						<o-field>
-							<span class="description"
-								>Click fields to add them to the format. Type separators
-								(-, _, etc.) directly.</span
-							>
+							<span class="description">{{
+								$t('settings.filenameFieldsHint')
+							}}</span>
 						</o-field>
 
 						<o-field>
@@ -104,14 +130,14 @@
 									style="width: 80px"
 									@click="filenameFormat = defaultFormat"
 								>
-									Reset
+									{{ $t('settings.reset') }}
 								</o-button>
 							</p>
 						</o-field>
 
 						<o-field>
 							<span class="description"
-								>Preview:
+								>{{ $t('settings.preview') }}
 								<strong style="color: #fff">{{
 									filenamePreview
 								}}</strong></span
@@ -119,18 +145,18 @@
 						</o-field>
 
 						<div
-							v-for="(fields, category) in fieldsByCategory"
-							:key="category"
+							v-for="group in fieldGroups"
+							:key="group.key"
 							style="margin-bottom: 0.5rem"
 						>
 							<span
 								class="description"
 								style="display: block; margin-bottom: 0.25rem"
-								>{{ category }}</span
+								>{{ group.name }}</span
 							>
 							<div class="field is-grouped is-grouped-multiline">
 								<div
-									v-for="field in fields"
+									v-for="field in group.fields"
 									:key="field.token"
 									class="control"
 								>
@@ -139,7 +165,7 @@
 										style="cursor: pointer"
 										@click="insertField(field.token)"
 									>
-										{{ field.label }}
+										{{ $t(field.labelKey) }}
 									</o-tag>
 								</div>
 							</div>
@@ -147,11 +173,17 @@
 					</div>
 
 					<hr />
-					<o-field label="Output Format">
+					<o-field :label="$t('settings.outputFormat')">
 						<o-select v-model="outputFormat">
-							<option value="jpeg">JPEG (max quality)</option>
-							<option value="png">PNG (lossless)</option>
-							<option value="webp">WebP (quality 95%)</option>
+							<option value="jpeg">
+								{{ $t('settings.formatJpeg') }}
+							</option>
+							<option value="png">
+								{{ $t('settings.formatPng') }}
+							</option>
+							<option value="webp">
+								{{ $t('settings.formatWebp') }}
+							</option>
 						</o-select>
 					</o-field>
 					<hr />
@@ -166,12 +198,12 @@
 							for="settings-disable-tooltips-switch"
 							class="settings-toggle-row__text"
 						>
-							<span class="label" style="margin-bottom: 0px"
-								>Disable Tooltips</span
-							>
-							<span class="description"
-								>Leave me alone, I know what I'm doing</span
-							>
+							<span class="label" style="margin-bottom: 0px">{{
+								$t('settings.disableTooltips')
+							}}</span>
+							<span class="description">{{
+								$t('settings.disableTooltipsDescription')
+							}}</span>
 						</label>
 					</o-field>
 					<hr />
@@ -186,14 +218,12 @@
 							for="settings-crop-top-left-switch"
 							class="settings-toggle-row__text"
 						>
-							<span class="label" style="margin-bottom: 0px"
-								>Prefer top-left watermark crop</span
-							>
-							<span class="description"
-								>Crops only the bottom-right corner (3%). When off, the
-								screenshot is cropped (6% total) equally from all sides
-								for a centered result.</span
-							>
+							<span class="label" style="margin-bottom: 0px">{{
+								$t('settings.cropTopLeft')
+							}}</span>
+							<span class="description">{{
+								$t('settings.cropTopLeftDescription')
+							}}</span>
 						</label>
 					</o-field>
 					<hr />
@@ -208,32 +238,30 @@
 							for="settings-manual-window-restore-switch"
 							class="settings-toggle-row__text"
 						>
-							<span class="label" style="margin-bottom: 0px"
-								>Manual Window Restore</span
-							>
-							<span class="description"
-								>Override the automatic window restore with custom
-								position and size. Useful for people using an Ultrawide
-								or Nvidia Surround</span
-							>
+							<span class="label" style="margin-bottom: 0px">{{
+								$t('settings.manualWindowRestore')
+							}}</span>
+							<span class="description">{{
+								$t('settings.manualWindowRestoreDescription')
+							}}</span>
 						</label>
 					</o-field>
 					<div v-if="manualWindowRestore">
 						<div class="columns settings-grid">
 							<div class="column">
-								<o-field label="Left">
+								<o-field :label="$t('settings.left')">
 									<o-input v-model="screenLeft" type="number" />
 								</o-field>
 							</div>
 							<div class="column">
-								<o-field label="Top">
+								<o-field :label="$t('settings.top')">
 									<o-input v-model="screenTop" type="number" />
 								</o-field>
 							</div>
 						</div>
 						<div class="columns settings-grid">
 							<div class="column">
-								<o-field label="Width">
+								<o-field :label="$t('settings.width')">
 									<o-input
 										v-model="screenWidth"
 										type="number"
@@ -243,7 +271,7 @@
 								</o-field>
 							</div>
 							<div class="column">
-								<o-field label="Height">
+								<o-field :label="$t('settings.height')">
 									<o-input
 										v-model="screenHeight"
 										type="number"
@@ -261,7 +289,7 @@
 							style="margin-top: 0.5rem"
 							@click="restoreNow"
 						>
-							Restore Now
+							{{ $t('settings.restoreNow') }}
 						</o-button>
 					</div>
 					<hr />
@@ -277,9 +305,9 @@
 							for="settings-native-capture-switch"
 							class="settings-toggle-row__text"
 						>
-							<span class="label" style="margin-bottom: 0px"
-								>High-Fidelity Capture (WGC)</span
-							>
+							<span class="label" style="margin-bottom: 0px">{{
+								$t('settings.nativeCapture')
+							}}</span>
 							<span
 								class="description"
 								:class="{
@@ -302,17 +330,15 @@
 							for="settings-reshade-switch"
 							class="settings-toggle-row__text"
 						>
-							<span class="label" style="margin-bottom: 0px"
-								>Reshade Compatibility Mode</span
-							>
+							<span class="label" style="margin-bottom: 0px">{{
+								$t('settings.reshade')
+							}}</span>
 						</label>
 					</o-field>
 					<span class="description">
-						When using reshade you will have to first use your hotkey for
-						the iRacing Screenshot Tool or press the button, then use your
-						reshade screenshot hotkey once the iRacing window has resized
+						{{ $t('settings.reshadeDescription') }}
 					</span>
-					<o-field label="Reshade INI" />
+					<o-field :label="$t('settings.reshadeIni')" />
 
 					<o-field addons class="settings-inline-field">
 						<o-input
@@ -327,7 +353,7 @@
 								class="button is-primary settings-action"
 								@click="openReshadeDialog"
 							>
-								Select File
+								{{ $t('settings.selectFile') }}
 							</o-button>
 						</p>
 					</o-field>
@@ -343,7 +369,10 @@ import { version } from '../../../package.json';
 import {
 	FILENAME_FIELDS,
 	DEFAULT_FORMAT,
+	type FilenameField,
 } from '../../utilities/filenameFormat';
+import { getLocale, SUPPORTED_LOCALES } from '../../utilities/i18n';
+import { applyLocale } from '../i18n';
 import {
 	describeUpdate,
 	initialUpdateState,
@@ -354,6 +383,12 @@ const path = require('path');
 export default {
 	data() {
 		return {
+			// `|| getLocale()` so the dropdown always has a selected row. Main
+			// resolves and persists `locale` before the window is created, so the
+			// config read normally wins — but an empty string would render a picker
+			// with nothing highlighted, which reads as "no language set".
+			locale: config.get('locale') || getLocale(),
+			localeOptions: SUPPORTED_LOCALES,
 			screenshotFolder: config.get('screenshotFolder'),
 			screenshotKeybind: config.get('screenshotKeybind'),
 			bindingKey: false,
@@ -437,16 +472,38 @@ export default {
 			const extMap = { jpeg: '.jpg', png: '.png', webp: '.webp' };
 			return preview + (extMap[this.outputFormat] || '.jpg');
 		},
-		fieldsByCategory() {
-			return this.filenameFields.reduce((acc, field) => {
-				if (!acc[field.category]) acc[field.category] = [];
-				acc[field.category].push(field);
-				return acc;
-			}, {});
+		// Grouped for display, with the group heading translated. Keyed by the
+		// UNtranslated category key so the v-for key is stable across a language
+		// change (and so two languages that happen to translate two categories the
+		// same way cannot collide).
+		fieldGroups(): {
+			key: string;
+			name: string;
+			fields: FilenameField[];
+		}[] {
+			const order: string[] = [];
+			const grouped: Record<string, FilenameField[]> = {};
+			for (const field of this.filenameFields as FilenameField[]) {
+				if (!grouped[field.categoryKey]) {
+					grouped[field.categoryKey] = [];
+					order.push(field.categoryKey);
+				}
+				grouped[field.categoryKey].push(field);
+			}
+			return order.map((key) => ({
+				key,
+				name: this.$t(key),
+				fields: grouped[key],
+			}));
 		},
 		// The same sentence the title-bar tooltip uses, from the same helper, so the
 		// two places that talk about updates cannot drift apart.
 		updateStatus() {
+			// describeUpdate phrases through the core's module-level `t`, which Vue
+			// cannot observe. Touching $locale is what re-runs this computed when
+			// the language changes — otherwise the line would keep the wording it
+			// had when it was last invalidated for some other reason.
+			void this.$locale;
 			return (
 				this.updateNotice ??
 				describeUpdate(
@@ -470,14 +527,13 @@ export default {
 			if (!this.nativeCaptureSupported) {
 				return (
 					this.nativeCaptureReason ||
-					'Unavailable on this system — high-fidelity capture cannot run here.'
+					this.$t('settings.nativeCaptureUnavailable')
 				);
 			}
 			if (this.nativeCaptureWarning) {
 				return this.nativeCaptureWarning;
 			}
-			const base =
-				'Capture true un-subsampled color via Windows.Graphics.Capture instead of the default pipeline (which subsamples color). Falls back automatically if a capture fails.';
+			const base = this.$t('settings.nativeCaptureDescription');
 			// A caveat means it works but gives something up, so it reads as an
 			// addition to the description rather than replacing it.
 			return this.nativeCaptureCaveat
@@ -486,6 +542,16 @@ export default {
 		},
 	},
 	watch: {
+		// Adopt the language in THIS window immediately, then persist. The write
+		// makes main re-language itself and broadcasts to every window, including
+		// this one — applyLocale is idempotent, so the echo is harmless, and doing
+		// it here as well means the picker never lags its own selection.
+		locale(value) {
+			const resolved = applyLocale(value);
+			if (config.get('locale') !== resolved) {
+				config.set('locale', resolved);
+			}
+		},
 		outputFormat() {
 			config.set('outputFormat', this.outputFormat);
 		},
@@ -558,7 +624,7 @@ export default {
 			this.nativeCaptureCaveat = check?.caveat ?? null;
 			this.nativeCaptureWarning =
 				check && check.verified === false
-					? 'Windows reports this is supported, but a test capture did not come back. Captures will fall back automatically if it keeps failing.'
+					? this.$t('settings.nativeCaptureUnverified')
 					: null;
 			config.set('nativeCapture', true);
 		},
@@ -658,9 +724,9 @@ export default {
 					this.updateNotice = result.reason;
 				}
 			} catch (error) {
-				this.updateNotice = `Update check failed: ${
-					(error as Error)?.message || String(error)
-				}`;
+				this.updateNotice = this.$t('settings.updateCheckFailed', {
+					message: (error as Error)?.message || String(error),
+				});
 			}
 		},
 		restoreNow() {

--- a/src/renderer/components/SideBar.vue
+++ b/src/renderer/components/SideBar.vue
@@ -1,14 +1,22 @@
 <template>
 	<div style="padding: 1rem; padding-top: 0.5rem">
-		<o-field label="Resolution">
-			<o-select v-model="resolution" expanded placeholder="Resolution">
+		<o-field :label="$t('sidebar.resolution')">
+			<o-select
+				v-model="resolution"
+				expanded
+				:placeholder="$t('sidebar.resolution')"
+			>
+				<!-- The VALUE stays the untranslated key ('Custom', '4k', ...) because
+				     it is what lands in config.json and what every comparison below
+				     tests. Only the visible label is translated, and only for 'Custom'
+				     — the resolution names are not words. -->
 				<option
 					v-for="option in items"
 					:key="option"
 					:value="option"
 					:style="optionStyle(option)"
 				>
-					{{ option }}
+					{{ resolutionLabel(option) }}
 				</option>
 			</o-select>
 		</o-field>
@@ -21,11 +29,11 @@
 			{{ vramStatusText }}
 		</p>
 
-		<o-field v-if="resolution === 'Custom'" label="Width">
+		<o-field v-if="resolution === 'Custom'" :label="$t('sidebar.width')">
 			<o-input v-model="customWidth" type="number" min="0" max="10000" />
 		</o-field>
 
-		<o-field v-if="resolution === 'Custom'" label="Height">
+		<o-field v-if="resolution === 'Custom'" :label="$t('sidebar.height')">
 			<o-input v-model="customHeight" type="number" min="0" max="10000" />
 		</o-field>
 
@@ -35,7 +43,7 @@
 		     the long-exposure panel used to carry one and it read as a second,
 		     competing answer to a question already answered here. -->
 		<p v-if="outputDimensions" class="sidebar-target-hint">
-			Output:
+			{{ $t('sidebar.output') }}
 			<span class="sidebar-target-hint__value"
 				>{{ outputDimensions.width }}×{{ outputDimensions.height }}
 				<template v-if="outputFormatLabel"
@@ -61,7 +69,9 @@
 				for="sidebar-crop-watermark-switch"
 				class="settings-toggle-row__text"
 			>
-				<span class="label" style="margin-bottom: 0px">Crop Watermark</span>
+				<span class="label" style="margin-bottom: 0px">{{
+					$t('sidebar.cropWatermark')
+				}}</span>
 			</label>
 		</o-field>
 
@@ -76,9 +86,9 @@
 				for="sidebar-keep-aspect-ratio-switch"
 				class="settings-toggle-row__text"
 			>
-				<span class="label" style="margin-bottom: 0px"
-					>Keep Aspect Ratio</span
-				>
+				<span class="label" style="margin-bottom: 0px">{{
+					$t('sidebar.keepAspectRatio')
+				}}</span>
 			</label>
 		</o-field>
 
@@ -99,7 +109,7 @@
 			style="margin-top: 0.5rem"
 			@click="takeScreenshot"
 		>
-			Screenshot
+			{{ $t('sidebar.screenshot') }}
 		</o-button>
 
 		<!-- Long exposure. Self-contained: it owns its own parameters, its own
@@ -132,6 +142,9 @@ import { resolveCropTarget } from '../../utilities/screenshot-output';
 import { useOruga } from '@oruga-ui/oruga-next';
 import LongExposurePanel from './LongExposurePanel.vue';
 import NoticeCard from './NoticeCard.vue';
+// Module-level `t` for the toast content component below, which is defined at
+// module scope and so has no `this.$t`.
+import { t } from '../../utilities/i18n';
 const { ipcRenderer } = require('electron');
 const fs = require('fs');
 
@@ -173,7 +186,10 @@ const ScreenshotErrorContent = defineComponent({
 							{
 								class: 'screenshot-error-log',
 							},
-							['Log: ', h('code', null, props.logFile)]
+							[
+								t('sidebar.errorLogPrefix'),
+								h('code', null, props.logFile),
+							]
 						)
 					: null,
 			]);
@@ -333,10 +349,11 @@ export default {
 			) {
 				return '';
 			}
-			const name = info.adapterName ? `${info.adapterName}: ` : '';
-			return `${name}${formatVramGiB(
-				this.vramAssessment.freeBytes
-			)} free of ${formatVramGiB(info.totalBytes)}`;
+			return this.$t('sidebar.vramStatus', {
+				adapter: info.adapterName ? `${info.adapterName}: ` : '',
+				free: formatVramGiB(this.vramAssessment.freeBytes),
+				total: formatVramGiB(info.totalBytes),
+			});
 		},
 		// Dynamic VRAM warning replaces the static one whenever we can predict.
 		showDynamicVramWarning() {
@@ -375,10 +392,7 @@ export default {
 			if (this.exclusiveFullscreen && !this.reshade) {
 				notices.push({
 					level: 'danger',
-					text:
-						'iRacing is in exclusive fullscreen — screenshots will capture ' +
-						'black. In iRacing set Display > Full Screen to OFF ' +
-						'(Borderless or Windowed) to enable capture.',
+					text: this.$t('sidebar.notices.exclusiveFullscreen'),
 				});
 			}
 
@@ -387,20 +401,25 @@ export default {
 				notices.push({
 					level: risk ? 'danger' : 'warning',
 					text: risk
-						? `${this.resolution} needs about ${this.formatVram(
-								this.vramAssessment.deltaBytes
-							)} more VRAM but only ${this.formatVram(
-								this.vramAssessment.freeBytes
-							)} is free — iRacing will likely run out of memory and crash.`
-						: `${this.resolution} leaves little VRAM headroom (${this.formatVram(
-								this.vramAssessment.freeBytes
-							)} free) and may crash on heavy track/car combinations.`,
+						? this.$t('sidebar.notices.vramRisk', {
+								resolution: this.resolutionLabel(this.resolution),
+								needed: this.formatVram(this.vramAssessment.deltaBytes),
+								free: this.formatVram(this.vramAssessment.freeBytes),
+							})
+						: this.$t('sidebar.notices.vramCaution', {
+								resolution: this.resolutionLabel(this.resolution),
+								free: this.formatVram(this.vramAssessment.freeBytes),
+							}),
 					// The one-click fix travels with the sentence that motivates it.
 					action:
 						this.safeResolutionLabel &&
 						this.safeResolutionLabel !== this.resolution
 							? {
-									label: `Switch to ${this.safeResolutionLabel}`,
+									label: this.$t('sidebar.notices.switchResolution', {
+										resolution: this.resolutionLabel(
+											this.safeResolutionLabel
+										),
+									}),
 									run: () => this.applySafeResolution(),
 								}
 							: undefined,
@@ -410,12 +429,16 @@ export default {
 			if (this.showStaticVramWarning) {
 				notices.push({
 					level: 'warning',
-					text:
-						'High resolutions may crash iRacing if you run out of VRAM. ' +
-						'Certain track/car combinations will require more VRAM.',
+					text: this.$t('sidebar.notices.vramStatic'),
 				});
 			}
 
+			// checkIracingConfig phrases its warning through the core's module-level
+			// `t`, which Vue cannot see. Touching $locale is what makes this computed
+			// re-run — and re-read the warning in the new language — when the setting
+			// changes. Without it the banner would stay in the old language until
+			// something else happened to invalidate this computed.
+			void this.$locale;
 			this.configWarnings.forEach((warning) => {
 				notices.push({ level: 'warning', text: warning });
 			});
@@ -423,29 +446,21 @@ export default {
 			if (this.reshade && !this.disableTooltips) {
 				notices.push({
 					level: 'warning',
-					text:
-						'After pressing the screenshot button in the iRacing ' +
-						'Screenshot Tool, you will need to press the keybind for ' +
-						'taking a screenshot for ReShade.',
+					text: this.$t('sidebar.notices.reshade'),
 				});
 			}
 
 			if (this.crop && !this.disableTooltips) {
 				notices.push({
 					level: 'info',
-					text:
-						'Crop Watermark zooms the final picture in slightly. Regions ' +
-						'near the borders of the screen will be cut off.',
+					text: this.$t('sidebar.notices.crop'),
 				});
 			}
 
 			if (this.keepAspectRatio && !this.disableTooltips) {
 				notices.push({
 					level: 'info',
-					text:
-						"Keep Aspect Ratio adjusts the screenshot height to match your monitor's " +
-						'aspect ratio (e.g. 21:9 ultrawide) instead of the default 16:9. ' +
-						'The selected resolution sets the width.',
+					text: this.$t('sidebar.notices.aspectRatio'),
 				});
 			}
 
@@ -552,7 +567,7 @@ export default {
 				// not directly on the Oruga instance. useOruga() returns the
 				// _programmatic map, so useOruga().notification === $oruga._programmatic.notification.
 				useOruga().notification.open({
-					message: file + ' saved successfully',
+					message: this.$t('sidebar.savedSuccessfully', { name: file }),
 					variant: 'success',
 				});
 			}
@@ -565,7 +580,9 @@ export default {
 			useOruga().notification.open({
 				component: ScreenshotErrorContent,
 				props: {
-					message: `Screenshot failed: ${error.message}`,
+					message: this.$t('sidebar.screenshotFailed', {
+						message: error.message,
+					}),
 					logFile: error.logFile,
 				},
 				variant: 'danger',
@@ -647,13 +664,13 @@ export default {
 				!Array.isArray(payload)
 			) {
 				return {
-					message: payload.message || 'Unknown screenshot error',
+					message: payload.message || this.$t('capture.unknownError'),
 					logFile: payload.logFile || '',
 				};
 			}
 
 			return {
-				message: String(payload || 'Unknown screenshot error'),
+				message: String(payload || this.$t('capture.unknownError')),
 				logFile: '',
 			};
 		},
@@ -775,6 +792,12 @@ export default {
 		// Template helper (imported fns aren't accessible in the template scope).
 		formatVram(bytes) {
 			return formatVramGiB(bytes);
+		},
+		// Display name for a resolution option. Only 'Custom' is a word; the rest
+		// ('1080p', '4k', ...) are the same in every language and are also the
+		// values stored in config, so they are passed through untouched.
+		resolutionLabel(option) {
+			return option === 'Custom' ? this.$t('sidebar.custom') : option;
 		},
 		takeScreenshot() {
 			// targetDimensions already accounts for Keep Aspect Ratio when on,

--- a/src/renderer/i18n.test.ts
+++ b/src/renderer/i18n.test.ts
@@ -1,0 +1,112 @@
+// @vitest-environment happy-dom
+import { mount } from '@vue/test-utils';
+import { defineComponent, nextTick } from 'vue';
+import { applyLocale, detectRendererLocale, i18n } from './i18n';
+import { FALLBACK_LOCALE, setLocale } from '../utilities/i18n';
+
+// The renderer's i18n binding is a Vue PLUGIN, and this project has already been
+// bitten once by a registration that compiles, builds and silently does nothing
+// (passing raw Oruga components to oruga.use(), which no-ops because they have no
+// install method — see main.ts). `electron-vite build` cannot see that class of
+// fault; only mounting something can. So these tests mount.
+//
+// They also cover the reason the plugin exists at all rather than components just
+// importing the core's `t`: the core keeps the locale in a module variable, which
+// Vue cannot observe, so a language change would leave every already-rendered
+// string in the old language.
+
+const Probe = defineComponent({
+	name: 'I18nProbe',
+	template: '<span class="probe">{{ $t("settings.title") }}</span>',
+});
+
+const ParamProbe = defineComponent({
+	name: 'I18nParamProbe',
+	data() {
+		return { file: 'shot-01' };
+	},
+	template:
+		'<span class="probe">{{ $t("gallery.copiedToClipboard", { name: file }) }}</span>',
+});
+
+const LocaleProbe = defineComponent({
+	name: 'I18nLocaleProbe',
+	template: '<span class="probe">{{ $locale }}</span>',
+});
+
+afterEach(() => {
+	applyLocale(FALLBACK_LOCALE);
+	setLocale(FALLBACK_LOCALE);
+});
+
+describe('renderer i18n plugin', () => {
+	test('installs $t and resolves a message', () => {
+		applyLocale('en');
+		const wrapper = mount(Probe, { global: { plugins: [i18n] } });
+		expect(wrapper.text()).toBe('Settings');
+	});
+
+	test('interpolates parameters from the template', () => {
+		applyLocale('en');
+		const wrapper = mount(ParamProbe, { global: { plugins: [i18n] } });
+		expect(wrapper.text()).toBe('shot-01 copied to clipboard');
+	});
+
+	// THE point of the ref indirection. Without it this assertion fails while
+	// everything still compiles and builds — the string would stay 'Settings'.
+	test('re-renders an already-mounted component when the language changes', async () => {
+		applyLocale('en');
+		const wrapper = mount(Probe, { global: { plugins: [i18n] } });
+		expect(wrapper.text()).toBe('Settings');
+
+		applyLocale('de');
+		await nextTick();
+		expect(wrapper.text()).toBe('Einstellungen');
+
+		applyLocale('fr');
+		await nextTick();
+		expect(wrapper.text()).toBe('Paramètres');
+	});
+
+	// $locale is what the handful of computeds phrasing through SHARED helpers
+	// (describeUpdate, checkIracingConfig) touch to re-establish the dependency
+	// those module-level calls lose.
+	test('exposes a reactive $locale', async () => {
+		applyLocale('en');
+		const wrapper = mount(LocaleProbe, { global: { plugins: [i18n] } });
+		expect(wrapper.text()).toBe('en');
+
+		applyLocale('sv');
+		await nextTick();
+		expect(wrapper.text()).toBe('sv');
+	});
+
+	test('applyLocale resolves and returns the adopted locale', () => {
+		expect(applyLocale('de-DE')).toBe('de');
+		// Unsupported falls back rather than being adopted verbatim.
+		expect(applyLocale('ja-JP')).toBe('en');
+	});
+
+	test('applyLocale also moves the shared core, so main-authored text follows', () => {
+		applyLocale('it');
+		// The core's ambient locale is what update-decisions and shot-recipe read.
+		expect(setLocale('it')).toBe('it');
+	});
+});
+
+describe('detectRendererLocale', () => {
+	test('picks the first supported language the browser reports', () => {
+		const original = Object.getOwnPropertyDescriptor(
+			window.navigator,
+			'languages'
+		);
+		Object.defineProperty(window.navigator, 'languages', {
+			value: ['ja-JP', 'pl-PL', 'de-DE'],
+			configurable: true,
+		});
+		expect(detectRendererLocale()).toBe('pl');
+		if (original) {
+			Object.defineProperty(window.navigator, 'languages', original);
+		}
+	});
+});

--- a/src/renderer/i18n.ts
+++ b/src/renderer/i18n.ts
@@ -1,0 +1,72 @@
+// The renderer's binding to the shared translation core.
+//
+// The core keeps the current locale in a module variable, which is right for the
+// main process and useless to Vue: nothing would re-render when it changed. This
+// mirrors it into a ref, so `$t` establishes a reactive dependency on the language
+// every time it is called and every template and computed that translates
+// re-evaluates the moment the setting changes. No window reload, no restart
+// prompt.
+
+import { ref, type App } from 'vue';
+import {
+	detectLocale,
+	getLocale,
+	setLocale,
+	t,
+	type TranslateParams,
+} from '../utilities/i18n';
+
+// Seeded from whatever the core already resolved (main sets it before the window
+// is created, but the renderer reads config for itself too — see main.ts).
+const localeRef = ref(getLocale());
+
+// Adopt a language. Returns the locale actually adopted, which the caller
+// persists — see setLocale's note on not letting an unsupported tag linger.
+export function applyLocale(locale: unknown): string {
+	const resolved = setLocale(locale);
+	localeRef.value = resolved;
+	return resolved;
+}
+
+// The renderer's own view of the user's language preferences, for first run.
+// Main has app.getPreferredSystemLanguages(); here Chromium reports the same
+// thing through navigator.
+export function detectRendererLocale(): string {
+	const languages =
+		typeof navigator !== 'undefined' && Array.isArray(navigator.languages)
+			? navigator.languages
+			: [];
+	return detectLocale(
+		languages.length > 0 ? languages : [navigator?.language]
+	);
+}
+
+export const i18n = {
+	install(app: App): void {
+		app.config.globalProperties.$t = (
+			key: string,
+			params?: TranslateParams
+		): string => {
+			// Touching the ref is the whole point of this indirection: it is what
+			// makes a language change invalidate every render that translated.
+			void localeRef.value;
+			return t(key, params);
+		};
+
+		// For the handful of computed properties that phrase things through a
+		// SHARED helper rather than through $t — describeUpdate, checkIracingConfig,
+		// FILENAME_FIELDS. Those call the core's `t` directly and so cannot be seen
+		// by Vue; referencing `this.$locale` in the computed re-establishes the
+		// dependency the plain module call loses.
+		Object.defineProperty(app.config.globalProperties, '$locale', {
+			get: () => localeRef.value,
+		});
+	},
+};
+
+declare module 'vue' {
+	interface ComponentCustomProperties {
+		$t: (key: string, params?: TranslateParams) => string;
+		$locale: string;
+	}
+}

--- a/src/renderer/main.ts
+++ b/src/renderer/main.ts
@@ -1,6 +1,8 @@
 import { createApp } from 'vue';
 import App from './App.vue';
 import router from './router';
+import config from '../utilities/config';
+import { applyLocale, detectRendererLocale, i18n } from './i18n';
 import './assets/style/animations.scss';
 import './assets/style/main.scss';
 import VueLazyload from 'vue-lazyload';
@@ -61,8 +63,21 @@ library.add(
 	faDiscord
 );
 
+// Adopt the language BEFORE the app mounts, so the first paint is already in the
+// right one rather than flashing English. Main resolves and persists this from
+// the Windows UI language on first run; detectRendererLocale is only a safety net
+// for a window that somehow opens before that write lands.
+applyLocale(config.get('locale') || detectRendererLocale());
+// Follows the setting for the lifetime of the window. Main broadcasts
+// `config:changed:locale` to EVERY window, so the worker window re-languages
+// itself from the same event that re-languages this one.
+config.onDidChange?.('locale', (newValue) => {
+	applyLocale(newValue);
+});
+
 const app = createApp(App);
 app.use(router);
+app.use(i18n);
 app.use(VueLazyload);
 const oruga = createOruga();
 // Register Oruga component plugins (not raw components). Each plugin's

--- a/src/renderer/views/Home.vue
+++ b/src/renderer/views/Home.vue
@@ -313,24 +313,6 @@ export default {
 			selected: 0,
 			galleryLoadId: 0,
 			generatingThumbs: new Set<string>(),
-			options: [
-				{
-					name: 'Open Externally',
-					slug: 'external',
-				},
-				{
-					name: 'Open Folder',
-					slug: 'folder',
-				},
-				{
-					name: 'Copy',
-					slug: 'copy',
-				},
-				{
-					name: 'Delete',
-					slug: 'delete',
-				},
-			],
 			// Held so beforeUnmount can tear them down — otherwise an HMR reload (or
 			// any future remount) stacks duplicate 'screenshot-response' handlers
 			// (N gallery unshifts per capture) and leaks the config subscription
@@ -343,6 +325,17 @@ export default {
 		};
 	},
 	computed: {
+		// A computed rather than a data field so the context menu re-labels itself
+		// when the language changes — data() runs once per instance and this
+		// component is never remounted.
+		options(): { name: string; slug: string }[] {
+			return [
+				{ name: this.$t('gallery.menu.openExternally'), slug: 'external' },
+				{ name: this.$t('gallery.menu.openFolder'), slug: 'folder' },
+				{ name: this.$t('gallery.menu.copy'), slug: 'copy' },
+				{ name: this.$t('gallery.menu.delete'), slug: 'delete' },
+			];
+		},
 		activeItem(): any | null {
 			return this.items[this.selected] || null;
 		},
@@ -469,7 +462,9 @@ export default {
 			// Oruga 0.13: programmatic interfaces live on `_programmatic`,
 			// not the Oruga instance directly. useOruga() returns _programmatic.
 			useOruga().notification.open({
-				message: `${this.fileName} copied to clipboard`,
+				message: this.$t('gallery.copiedToClipboard', {
+					name: this.fileName,
+				}),
 				variant: 'dark',
 			});
 		},

--- a/src/renderer/views/Worker.vue
+++ b/src/renderer/views/Worker.vue
@@ -16,6 +16,10 @@ import {
 	OUTPUT_EXTENSIONS,
 } from '../../utilities/screenshot-output';
 import { createLogger } from '../../utilities/logger';
+// The module-level `t`, not `this.$t`: these are thrown Errors and log payloads
+// built outside any render, so there is nothing to keep reactive — they only need
+// to be phrased in the language that is current when the capture fails.
+import { t } from '../../utilities/i18n';
 const { ipcRenderer } = require('electron');
 const fs = require('fs');
 const path = require('path');
@@ -182,7 +186,7 @@ function createScreenshotErrorPayload(errorLike, context, meta = {}) {
 		};
 	}
 
-	const message = String(errorLike || 'Unknown screenshot error');
+	const message = String(errorLike || t('capture.unknownError'));
 	const error = errorLike instanceof Error ? errorLike : new Error(message);
 
 	return {
@@ -497,7 +501,10 @@ async function fullscreenScreenshot(callback) {
 
 		if (outputWidth < 1 || outputHeight < 1) {
 			throw new Error(
-				`Capture output is too small (${outputWidth}x${outputHeight})`
+				t('capture.outputTooSmall', {
+					width: outputWidth,
+					height: outputHeight,
+				})
 			);
 		}
 
@@ -524,9 +531,7 @@ async function fullscreenScreenshot(callback) {
 		console.timeEnd('Create OffscreenCanvas');
 
 		if (isFrameBlack(offscreen)) {
-			throw new Error(
-				'Captured frame is black — the capture source may have failed (GPU-accelerated content can fail to capture on some Windows setups)'
-			);
+			throw new Error(t('capture.blackFrame'));
 		}
 
 		console.time('To Blob');
@@ -614,9 +619,7 @@ async function fullscreenScreenshot(callback) {
 		}
 
 		if (!sourceId) {
-			throw new Error(
-				'No desktop capture source found for window ' + windowID
-			);
+			throw new Error(t('capture.noSource', { windowId: windowID }));
 		}
 
 		// The desktop-capture pipeline can briefly keep delivering the prior
@@ -690,9 +693,7 @@ async function fullscreenScreenshot(callback) {
 				};
 				const timer = setTimeout(() => {
 					cleanup();
-					reject(
-						new Error('Timed out waiting for capture video metadata')
-					);
+					reject(new Error(t('capture.metadataTimeout')));
 				}, HANDLE_STREAM_TIMEOUT_MS);
 				v.addEventListener('loadedmetadata', onReady, { once: true });
 				v.addEventListener('error', onError, { once: true });
@@ -821,7 +822,7 @@ async function fullscreenScreenshot(callback) {
 			}
 
 			if (!video) {
-				throw new Error('Capture stream did not produce a video frame');
+				throw new Error(t('capture.noVideoFrame'));
 			}
 			const finalVideo = video;
 
@@ -837,7 +838,12 @@ async function fullscreenScreenshot(callback) {
 					elapsedMs: Math.round(performance.now() - waitStart),
 				});
 				console.warn(
-					`Timed out waiting for window dimensions ${windowWidth}x${windowHeight}; proceeding with ${finalVideo.videoWidth}x${finalVideo.videoHeight}`
+					t('capture.dimensionTimeout', {
+						width: windowWidth,
+						height: windowHeight,
+						actualWidth: finalVideo.videoWidth,
+						actualHeight: finalVideo.videoHeight,
+					})
 				);
 			} else if (wantDimCheck) {
 				log.debug('Stream dim confirmed', {

--- a/src/utilities/config.ts
+++ b/src/utilities/config.ts
@@ -99,6 +99,15 @@ const schema = {
 		type: 'boolean',
 		default: true,
 	},
+	// UI language. Empty means "never resolved" — the main process detects it from
+	// the Windows UI language on first run and writes the RESOLVED code back, so
+	// this is only ever blank once. Persisting the resolved code rather than the
+	// raw OS tag means a user who later switches Windows to a language we do not
+	// ship keeps the one they were already reading.
+	locale: {
+		type: 'string',
+		default: '',
+	},
 	version: {
 		type: 'string',
 		default: '',

--- a/src/utilities/filenameFormat.ts
+++ b/src/utilities/filenameFormat.ts
@@ -3,10 +3,17 @@
 type SessionInfo = any;
 type Telemetry = any;
 
-interface FilenameField {
+import { t } from './i18n';
+
+export interface FilenameField {
 	token: string;
-	label: string;
-	category: string;
+	// Translation KEYS, not text. These are shown in Settings, so they have to
+	// follow the user's language — but this array is a module-scope const built at
+	// import time, long before a locale is resolved, so it cannot hold finished
+	// sentences. The UI resolves them through `filenameFieldLabel` /
+	// `filenameFieldCategory` below at render time.
+	labelKey: string;
+	categoryKey: string;
 	resolve: (sessionInfo: SessionInfo, telemetry: Telemetry) => string;
 }
 
@@ -30,17 +37,17 @@ function findDriver(
 /**
  * All available filename format fields, organised by category.
  * Each field exposes:
- *   token    – the placeholder string (with braces)
- *   label    – human-readable name shown in the UI
- *   category – grouping name shown in the UI
- *   resolve  – function(sessionInfo, telemetry) => string value (may return '' on missing data)
+ *   token       – the placeholder string (with braces)
+ *   labelKey    – translation key for the name shown in the UI
+ *   categoryKey – translation key for the grouping shown in the UI
+ *   resolve     – function(sessionInfo, telemetry) => string value (may return '' on missing data)
  */
 export const FILENAME_FIELDS: FilenameField[] = [
 	// ── Track ─────────────────────────────────────────────────────────────────
 	{
 		token: '{track}',
-		label: 'Track',
-		category: 'Track',
+		labelKey: 'filenameFields.track',
+		categoryKey: 'filenameFields.categories.Track',
 		resolve(sessionInfo) {
 			return (
 				(sessionInfo &&
@@ -53,8 +60,8 @@ export const FILENAME_FIELDS: FilenameField[] = [
 	},
 	{
 		token: '{trackFull}',
-		label: 'Track Full',
-		category: 'Track',
+		labelKey: 'filenameFields.trackFull',
+		categoryKey: 'filenameFields.categories.Track',
 		resolve(sessionInfo) {
 			return (
 				(sessionInfo &&
@@ -67,8 +74,8 @@ export const FILENAME_FIELDS: FilenameField[] = [
 	},
 	{
 		token: '{trackCity}',
-		label: 'City',
-		category: 'Track',
+		labelKey: 'filenameFields.trackCity',
+		categoryKey: 'filenameFields.categories.Track',
 		resolve(sessionInfo) {
 			return (
 				(sessionInfo &&
@@ -81,8 +88,8 @@ export const FILENAME_FIELDS: FilenameField[] = [
 	},
 	{
 		token: '{trackCountry}',
-		label: 'Country',
-		category: 'Track',
+		labelKey: 'filenameFields.trackCountry',
+		categoryKey: 'filenameFields.categories.Track',
 		resolve(sessionInfo) {
 			return (
 				(sessionInfo &&
@@ -95,8 +102,8 @@ export const FILENAME_FIELDS: FilenameField[] = [
 	},
 	{
 		token: '{trackType}',
-		label: 'Track Type',
-		category: 'Track',
+		labelKey: 'filenameFields.trackType',
+		categoryKey: 'filenameFields.categories.Track',
 		resolve(sessionInfo) {
 			return (
 				(sessionInfo &&
@@ -111,8 +118,8 @@ export const FILENAME_FIELDS: FilenameField[] = [
 	// ── Driver ────────────────────────────────────────────────────────────────
 	{
 		token: '{driver}',
-		label: 'Driver',
-		category: 'Driver',
+		labelKey: 'filenameFields.driver',
+		categoryKey: 'filenameFields.categories.Driver',
 		resolve(sessionInfo, telemetry) {
 			if (!sessionInfo || !sessionInfo.data) return '';
 			if (
@@ -136,8 +143,8 @@ export const FILENAME_FIELDS: FilenameField[] = [
 	},
 	{
 		token: '{driverAbbrev}',
-		label: 'Driver Abbrev',
-		category: 'Driver',
+		labelKey: 'filenameFields.driverAbbrev',
+		categoryKey: 'filenameFields.categories.Driver',
 		resolve(sessionInfo, telemetry) {
 			const d = findDriver(sessionInfo, telemetry);
 			return (d && d.AbbrevName) || '';
@@ -145,8 +152,8 @@ export const FILENAME_FIELDS: FilenameField[] = [
 	},
 	{
 		token: '{driverInitials}',
-		label: 'Initials',
-		category: 'Driver',
+		labelKey: 'filenameFields.driverInitials',
+		categoryKey: 'filenameFields.categories.Driver',
 		resolve(sessionInfo, telemetry) {
 			const d = findDriver(sessionInfo, telemetry);
 			if (!d || !d.UserName) return '';
@@ -157,8 +164,8 @@ export const FILENAME_FIELDS: FilenameField[] = [
 	},
 	{
 		token: '{team}',
-		label: 'Team',
-		category: 'Driver',
+		labelKey: 'filenameFields.team',
+		categoryKey: 'filenameFields.categories.Driver',
 		resolve(sessionInfo, telemetry) {
 			const d = findDriver(sessionInfo, telemetry);
 			return (d && d.TeamName) || '';
@@ -166,8 +173,8 @@ export const FILENAME_FIELDS: FilenameField[] = [
 	},
 	{
 		token: '{carNumber}',
-		label: 'Car #',
-		category: 'Driver',
+		labelKey: 'filenameFields.carNumber',
+		categoryKey: 'filenameFields.categories.Driver',
 		resolve(sessionInfo, telemetry) {
 			const d = findDriver(sessionInfo, telemetry);
 			return (d && d.CarNumber) || '';
@@ -175,8 +182,8 @@ export const FILENAME_FIELDS: FilenameField[] = [
 	},
 	{
 		token: '{car}',
-		label: 'Car',
-		category: 'Driver',
+		labelKey: 'filenameFields.car',
+		categoryKey: 'filenameFields.categories.Driver',
 		resolve(sessionInfo, telemetry) {
 			const d = findDriver(sessionInfo, telemetry);
 			return (d && d.CarScreenNameShort) || '';
@@ -184,8 +191,8 @@ export const FILENAME_FIELDS: FilenameField[] = [
 	},
 	{
 		token: '{carFull}',
-		label: 'Car Full',
-		category: 'Driver',
+		labelKey: 'filenameFields.carFull',
+		categoryKey: 'filenameFields.categories.Driver',
 		resolve(sessionInfo, telemetry) {
 			const d = findDriver(sessionInfo, telemetry);
 			return (d && d.CarScreenName) || '';
@@ -193,8 +200,8 @@ export const FILENAME_FIELDS: FilenameField[] = [
 	},
 	{
 		token: '{carClass}',
-		label: 'Car Class',
-		category: 'Driver',
+		labelKey: 'filenameFields.carClass',
+		categoryKey: 'filenameFields.categories.Driver',
 		resolve(sessionInfo, telemetry) {
 			const d = findDriver(sessionInfo, telemetry);
 			return (d && d.CarClassShortName) || '';
@@ -202,8 +209,8 @@ export const FILENAME_FIELDS: FilenameField[] = [
 	},
 	{
 		token: '{iRating}',
-		label: 'iRating',
-		category: 'Driver',
+		labelKey: 'filenameFields.iRating',
+		categoryKey: 'filenameFields.categories.Driver',
 		resolve(sessionInfo, telemetry) {
 			const d = findDriver(sessionInfo, telemetry);
 			return d && d.IRating !== undefined ? String(d.IRating) : '';
@@ -213,8 +220,8 @@ export const FILENAME_FIELDS: FilenameField[] = [
 	// ── Session ───────────────────────────────────────────────────────────────
 	{
 		token: '{sessionType}',
-		label: 'Session Type',
-		category: 'Session',
+		labelKey: 'filenameFields.sessionType',
+		categoryKey: 'filenameFields.categories.Session',
 		resolve(sessionInfo, telemetry) {
 			if (!sessionInfo || !sessionInfo.data || !sessionInfo.data.SessionInfo)
 				return '';
@@ -228,8 +235,8 @@ export const FILENAME_FIELDS: FilenameField[] = [
 	},
 	{
 		token: '{sessionName}',
-		label: 'Session Name',
-		category: 'Session',
+		labelKey: 'filenameFields.sessionName',
+		categoryKey: 'filenameFields.categories.Session',
 		resolve(sessionInfo, telemetry) {
 			if (!sessionInfo || !sessionInfo.data || !sessionInfo.data.SessionInfo)
 				return '';
@@ -243,8 +250,8 @@ export const FILENAME_FIELDS: FilenameField[] = [
 	},
 	{
 		token: '{lap}',
-		label: 'Lap',
-		category: 'Session',
+		labelKey: 'filenameFields.lap',
+		categoryKey: 'filenameFields.categories.Session',
 		resolve(sessionInfo, telemetry) {
 			if (!telemetry || !telemetry.values) return '';
 			return telemetry.values.Lap !== undefined
@@ -256,8 +263,8 @@ export const FILENAME_FIELDS: FilenameField[] = [
 	// ── Meta ──────────────────────────────────────────────────────────────────
 	{
 		token: '{date}',
-		label: 'Date',
-		category: 'Meta',
+		labelKey: 'filenameFields.date',
+		categoryKey: 'filenameFields.categories.Meta',
 		resolve() {
 			const now = new Date();
 			const y = now.getFullYear();
@@ -268,8 +275,8 @@ export const FILENAME_FIELDS: FilenameField[] = [
 	},
 	{
 		token: '{time}',
-		label: 'Time',
-		category: 'Meta',
+		labelKey: 'filenameFields.time',
+		categoryKey: 'filenameFields.categories.Meta',
 		resolve() {
 			const now = new Date();
 			const h = String(now.getHours()).padStart(2, '0');
@@ -280,8 +287,8 @@ export const FILENAME_FIELDS: FilenameField[] = [
 	},
 	{
 		token: '{datetime}',
-		label: 'Date+Time',
-		category: 'Meta',
+		labelKey: 'filenameFields.datetime',
+		categoryKey: 'filenameFields.categories.Meta',
 		resolve() {
 			const now = new Date();
 			const y = now.getFullYear();
@@ -295,8 +302,8 @@ export const FILENAME_FIELDS: FilenameField[] = [
 	},
 	{
 		token: '{counter}',
-		label: 'Counter',
-		category: 'Meta',
+		labelKey: 'filenameFields.counter',
+		categoryKey: 'filenameFields.categories.Meta',
 		resolve() {
 			// Intentionally left unresolved here; Worker.vue handles counter separately.
 			return '{counter}';
@@ -368,4 +375,14 @@ export function resolveFilenameFormat(
 	}
 
 	return result;
+}
+
+/** The field's name in the user's language. */
+export function filenameFieldLabel(field: FilenameField): string {
+	return t(field.labelKey);
+}
+
+/** The field's group heading in the user's language. */
+export function filenameFieldCategory(field: FilenameField): string {
+	return t(field.categoryKey);
 }

--- a/src/utilities/i18n.test.ts
+++ b/src/utilities/i18n.test.ts
@@ -1,0 +1,316 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+	detectLocale,
+	FALLBACK_LOCALE,
+	getLocale,
+	isSupportedLocale,
+	resolveLocale,
+	setLocale,
+	SUPPORTED_LOCALES,
+	t,
+	translate,
+	type MessageCatalog,
+} from './i18n';
+import { CATALOGS } from '../locales';
+import en from '../locales/en';
+
+// The ambient locale is module state, so a test that changes it has to put it
+// back or it leaks into every test that runs after it in the same file.
+afterEach(() => {
+	setLocale(FALLBACK_LOCALE);
+});
+
+describe('resolveLocale', () => {
+	it('strips the region from a BCP 47 tag', () => {
+		expect(resolveLocale('de-DE')).toBe('de');
+		expect(resolveLocale('pt-BR')).toBe('pt');
+		expect(resolveLocale('fr-CA')).toBe('fr');
+	});
+
+	it('is case- and separator-insensitive', () => {
+		expect(resolveLocale('DE')).toBe('de');
+		expect(resolveLocale('es_ES')).toBe('es');
+		expect(resolveLocale('  It-IT  ')).toBe('it');
+	});
+
+	// Windows reports Norwegian as nb/nn and essentially never as the
+	// macrolanguage `no` we ship under, so without this mapping every Norwegian
+	// machine would silently get English.
+	it('maps both written forms of Norwegian onto the shipped catalogue', () => {
+		expect(resolveLocale('nb-NO')).toBe('no');
+		expect(resolveLocale('nn')).toBe('no');
+		expect(resolveLocale('no')).toBe('no');
+	});
+
+	it('falls back to English for anything unshipped or unusable', () => {
+		expect(resolveLocale('ja')).toBe('en');
+		expect(resolveLocale('')).toBe('en');
+		expect(resolveLocale('   ')).toBe('en');
+		expect(resolveLocale(null)).toBe('en');
+		expect(resolveLocale(undefined)).toBe('en');
+		expect(resolveLocale(42)).toBe('en');
+	});
+});
+
+describe('detectLocale', () => {
+	it('takes the first supported entry, not merely the first', () => {
+		expect(detectLocale(['ja-JP', 'zh-CN', 'sv-SE', 'de-DE'])).toBe('sv');
+	});
+
+	it('falls back to English when nothing matches', () => {
+		expect(detectLocale(['ja-JP', 'ko-KR'])).toBe('en');
+		expect(detectLocale([])).toBe('en');
+	});
+
+	it('ignores non-string entries rather than throwing', () => {
+		expect(detectLocale([null, undefined, 7, 'pl-PL'])).toBe('pl');
+	});
+});
+
+describe('setLocale', () => {
+	it('returns and stores the RESOLVED code, not the raw request', () => {
+		expect(setLocale('de-DE')).toBe('de');
+		expect(getLocale()).toBe('de');
+	});
+
+	it('resolves an unsupported request to English rather than storing it', () => {
+		expect(setLocale('ja')).toBe('en');
+		expect(getLocale()).toBe('en');
+	});
+});
+
+describe('isSupportedLocale', () => {
+	it('accepts exactly the shipped codes', () => {
+		expect(isSupportedLocale('de')).toBe(true);
+		expect(isSupportedLocale('en')).toBe(true);
+		// A full tag is not itself a shipped code — resolveLocale is what narrows.
+		expect(isSupportedLocale('de-DE')).toBe(false);
+		expect(isSupportedLocale('ja')).toBe(false);
+		expect(isSupportedLocale(null)).toBe(false);
+	});
+});
+
+describe('translate', () => {
+	it('returns the message for a dot path', () => {
+		expect(translate('en', 'settings.title')).toBe('Settings');
+	});
+
+	it('substitutes named parameters', () => {
+		expect(
+			translate('en', 'gallery.copiedToClipboard', { name: 'shot' })
+		).toBe('shot copied to clipboard');
+	});
+
+	// The filename-format help talks ABOUT {track} and {counter} as literal text
+	// the user types. Blanking an unmatched placeholder would reduce the one
+	// message explaining that feature to "Use a custom pattern instead of the
+	// default (--)".
+	it('leaves a placeholder it was given no value for exactly as written', () => {
+		expect(translate('en', 'settings.customFilenameFormatDescription')).toBe(
+			'Use a custom pattern instead of the default ({track}-{driver}-{counter})'
+		);
+	});
+
+	it('returns the key itself for a message that does not exist', () => {
+		expect(translate('en', 'settings.nope')).toBe('settings.nope');
+		expect(translate('en', 'no.such.namespace.at.all')).toBe(
+			'no.such.namespace.at.all'
+		);
+	});
+
+	// A key that names a branch rather than a leaf is a caller bug, and returning
+	// "[object Object]" would hide it.
+	it('returns the key when the path lands on a namespace', () => {
+		expect(translate('en', 'settings')).toBe('settings');
+	});
+
+	it('falls back to English when a locale is missing the key', () => {
+		// Deliberately not a shipped locale: resolveLocale sends it to English.
+		expect(translate('ja', 'settings.title')).toBe('Settings');
+	});
+
+	it('selects the English plural forms by count', () => {
+		expect(
+			translate('en', 'longExposure.modified.passes', { count: 1 })
+		).toBe('1 pass');
+		expect(
+			translate('en', 'longExposure.modified.passes', { count: 4 })
+		).toBe('4 passes');
+	});
+
+	it('falls back to `other` when a plural message is asked for without a count', () => {
+		expect(translate('en', 'longExposure.modified.passes')).toContain(
+			'passes'
+		);
+	});
+});
+
+describe('t', () => {
+	it('reads the ambient locale', () => {
+		setLocale('en');
+		expect(t('settings.title')).toBe('Settings');
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Catalogue integrity. These are what stop a translation from silently rotting:
+// TypeScript already enforces the key set at compile time, but nothing there can
+// see a placeholder that was mistyped or dropped, and a dropped {version} is a
+// sentence with a hole in it.
+// ---------------------------------------------------------------------------
+
+type Leaf = { path: string; value: string };
+
+function flatten(node: unknown, prefix: string[] = []): Leaf[] {
+	if (typeof node === 'string') {
+		return [{ path: prefix.join('.'), value: node }];
+	}
+	if (!node || typeof node !== 'object') {
+		return [];
+	}
+	return Object.entries(node as Record<string, unknown>).flatMap(
+		([key, value]) => flatten(value, [...prefix, key])
+	);
+}
+
+// Plural leaves are collapsed to their parent path: English may define `one` and
+// `other` where Polish needs `one`, `few`, `many` and `other`, so comparing them
+// form-by-form would fail on correct translations.
+function isPluralNode(node: unknown): boolean {
+	return (
+		!!node &&
+		typeof node === 'object' &&
+		typeof (node as Record<string, unknown>).other === 'string'
+	);
+}
+
+function messagePaths(node: unknown, prefix: string[] = []): string[] {
+	if (typeof node === 'string') {
+		return [prefix.join('.')];
+	}
+	if (isPluralNode(node)) {
+		return [prefix.join('.')];
+	}
+	if (!node || typeof node !== 'object') {
+		return [];
+	}
+	return Object.entries(node as Record<string, unknown>).flatMap(
+		([key, value]) => messagePaths(value, [...prefix, key])
+	);
+}
+
+function placeholders(text: string): Set<string> {
+	return new Set(
+		Array.from(text.matchAll(/\{(\w+)\}/g)).map((match) => match[1])
+	);
+}
+
+const englishPaths = messagePaths(en).sort();
+const englishLeaves = new Map(
+	flatten(en).map((leaf) => [leaf.path, leaf.value])
+);
+
+describe('catalogue integrity', () => {
+	it('registers a catalogue for every locale the picker offers', () => {
+		for (const locale of SUPPORTED_LOCALES) {
+			expect(
+				CATALOGS[locale.code],
+				`no catalogue registered for ${locale.code}`
+			).toBeDefined();
+		}
+	});
+
+	it('offers a catalogue for nothing the picker does not list', () => {
+		const listed = new Set(SUPPORTED_LOCALES.map((entry) => entry.code));
+		for (const code of Object.keys(CATALOGS)) {
+			expect(listed.has(code), `${code} is registered but unlisted`).toBe(
+				true
+			);
+		}
+	});
+
+	it('names every language in its own language, not in English', () => {
+		for (const locale of SUPPORTED_LOCALES) {
+			expect(locale.name.trim().length).toBeGreaterThan(0);
+		}
+		// The endonyms have to be distinct or the picker shows two identical rows.
+		const names = SUPPORTED_LOCALES.map((entry) => entry.name);
+		expect(new Set(names).size).toBe(names.length);
+	});
+
+	for (const [code, catalog] of Object.entries(CATALOGS)) {
+		if (code === FALLBACK_LOCALE) {
+			continue;
+		}
+
+		it(`${code} has exactly the English key set`, () => {
+			const paths = messagePaths(catalog as MessageCatalog).sort();
+			const missing = englishPaths.filter((key) => !paths.includes(key));
+			const extra = paths.filter((key) => !englishPaths.includes(key));
+			expect(missing, `${code} is missing keys`).toEqual([]);
+			expect(extra, `${code} has keys English does not`).toEqual([]);
+		});
+
+		it(`${code} uses only the placeholders English defines`, () => {
+			for (const leaf of flatten(catalog as MessageCatalog)) {
+				// Plural forms live one level below the English path, so compare
+				// against the parent when the exact path is not an English leaf.
+				const source =
+					englishLeaves.get(leaf.path) ??
+					englishLeaves.get(
+						leaf.path.split('.').slice(0, -1).join('.') + '.other'
+					);
+				if (source === undefined) {
+					continue;
+				}
+				const allowed = placeholders(source);
+				for (const name of placeholders(leaf.value)) {
+					expect(
+						allowed.has(name),
+						`${code}: ${leaf.path} uses {${name}}, which English does not define`
+					).toBe(true);
+				}
+			}
+		});
+
+		it(`${code} leaves no message empty`, () => {
+			for (const leaf of flatten(catalog as MessageCatalog)) {
+				expect(
+					leaf.value.trim().length,
+					`${code}: ${leaf.path} is empty`
+				).toBeGreaterThan(0);
+			}
+		});
+
+		// CLDR guarantees `other` for every language, and the selector falls back
+		// to it when a count lands in a category the catalogue skipped.
+		it(`${code} supplies the mandatory 'other' plural form`, () => {
+			const walk = (node: unknown, prefix: string[]): void => {
+				if (!node || typeof node !== 'object') {
+					return;
+				}
+				const record = node as Record<string, unknown>;
+				const englishIsPlural = isPluralNode(
+					prefix.reduce<unknown>(
+						(acc, key) =>
+							acc && typeof acc === 'object'
+								? (acc as Record<string, unknown>)[key]
+								: undefined,
+						en
+					)
+				);
+				if (englishIsPlural) {
+					expect(
+						typeof record.other,
+						`${code}: ${prefix.join('.')} has no 'other' form`
+					).toBe('string');
+					return;
+				}
+				for (const [key, value] of Object.entries(record)) {
+					walk(value, [...prefix, key]);
+				}
+			};
+			walk(catalog, []);
+		});
+	}
+});

--- a/src/utilities/i18n.ts
+++ b/src/utilities/i18n.ts
@@ -1,0 +1,260 @@
+// The translation core, shared by BOTH processes.
+//
+// It lives in utilities/ for the same reason update-decisions.ts does: main and
+// the renderer both phrase things for the user, and a second implementation is a
+// second set of wording. Long-exposure validation warnings are written in the
+// main process and rendered in the sidebar; the WGC support sentence is decided
+// in main and shown under a Settings toggle. If those two processes translated
+// through different code they would drift, and the drift would only ever be
+// visible to users who do not speak English.
+//
+// Deliberately NOT vue-i18n. Three reasons, in order of weight:
+//   1. vue-i18n only exists in the renderer, so main would need its own engine
+//      anyway — and then the same key could interpolate differently in the two
+//      places it is read.
+//   2. Its full build compiles message strings at runtime via `new Function`,
+//      which is exactly what the CSP work deferred out of the WP-K stages will
+//      want to forbid.
+//   3. What this app actually needs from an i18n library is a dot-path lookup, a
+//      brace interpolator and CLDR plural categories. Intl provides the third,
+//      and the other two are the file below.
+//
+// No Node, no Electron, no module state beyond the current locale — so it is
+// unit-testable and loads in either process.
+
+import { CATALOGS } from '../locales';
+
+export interface LocaleDescriptor {
+	code: string;
+	// The language's ENDONYM — its own name for itself. A language picker has to
+	// show these rather than English names: someone hunting for their language in
+	// a list they cannot read still recognises "Čeština", never "Czech".
+	name: string;
+}
+
+// Ordered by endonym, because that is the order the picker renders and a user
+// scanning it is reading the endonyms, not the codes.
+export const SUPPORTED_LOCALES: readonly LocaleDescriptor[] = [
+	{ code: 'cs', name: 'Čeština' },
+	{ code: 'da', name: 'Dansk' },
+	{ code: 'de', name: 'Deutsch' },
+	{ code: 'en', name: 'English' },
+	{ code: 'es', name: 'Español' },
+	{ code: 'fr', name: 'Français' },
+	{ code: 'it', name: 'Italiano' },
+	{ code: 'nl', name: 'Nederlands' },
+	{ code: 'no', name: 'Norsk' },
+	{ code: 'pl', name: 'Polski' },
+	{ code: 'pt', name: 'Português' },
+	{ code: 'fi', name: 'Suomi' },
+	{ code: 'sv', name: 'Svenska' },
+] as const;
+
+// The source language. Every other catalogue is checked against it (see
+// i18n.test.ts) and every lookup falls back to it, so a key that is missing or
+// untranslated degrades to English rather than to nothing.
+export const FALLBACK_LOCALE = 'en';
+
+// A message is either a finished string or, where the sentence changes shape with
+// a count, one string per CLDR plural category. Only `other` is required —
+// English needs `one`/`other`, Polish needs `one`/`few`/`many`, and a language
+// that needs no distinction just supplies `other`.
+export type PluralForms = Partial<Record<Intl.LDMLPluralRule, string>>;
+export type MessageValue = string | PluralForms;
+
+export interface MessageCatalog {
+	[segment: string]: MessageValue | MessageCatalog;
+}
+
+export type TranslateParams = Record<string, string | number>;
+
+const SUPPORTED_CODES = new Set(SUPPORTED_LOCALES.map((entry) => entry.code));
+
+export function isSupportedLocale(code: unknown): boolean {
+	return typeof code === 'string' && SUPPORTED_CODES.has(code);
+}
+
+// Normalise anything a caller might hand us to a code we actually ship.
+//
+// Windows reports UI languages as BCP 47 tags ('de-DE', 'pt-BR', 'nb-NO'), so the
+// region has to be dropped before the lookup. Norwegian is the one case where
+// dropping it is not enough: Windows uses `nb` (Bokmål) or `nn` (Nynorsk) and
+// almost never the macrolanguage `no` that we ship under, so both map onto it.
+export function resolveLocale(candidate: unknown): string {
+	if (typeof candidate !== 'string') {
+		return FALLBACK_LOCALE;
+	}
+	const normalized = candidate.trim().toLowerCase().replace(/_/g, '-');
+	if (!normalized) {
+		return FALLBACK_LOCALE;
+	}
+	const base = normalized.split('-')[0];
+	if (base === 'nb' || base === 'nn') {
+		return 'no';
+	}
+	return SUPPORTED_CODES.has(base) ? base : FALLBACK_LOCALE;
+}
+
+// First supported language among the user's preferences, else English.
+//
+// Takes the list rather than reading it, because the two processes source it
+// differently (app.getPreferredSystemLanguages in main, navigator.languages in
+// the renderer) and neither belongs in a pure function.
+export function detectLocale(candidates: readonly unknown[]): string {
+	for (const candidate of candidates) {
+		if (typeof candidate !== 'string') {
+			continue;
+		}
+		const normalized = candidate.trim().toLowerCase().replace(/_/g, '-');
+		const base = normalized.split('-')[0];
+		if (base === 'nb' || base === 'nn') {
+			return 'no';
+		}
+		if (SUPPORTED_CODES.has(base)) {
+			return base;
+		}
+	}
+	return FALLBACK_LOCALE;
+}
+
+// The ambient locale. Module state on purpose: threading a locale through
+// `describeUpdate`, `validatePlan` and `decideWgcSupport` would change every
+// signature and every one of their call sites and tests, to carry a value that is
+// global to the process anyway. Each process sets it once at startup and again
+// when the setting changes.
+let currentLocale: string = FALLBACK_LOCALE;
+
+export function getLocale(): string {
+	return currentLocale;
+}
+
+// Returns the locale actually adopted, which is not necessarily what was asked
+// for — callers persist the RESOLVED value so an unsupported tag cannot sit in
+// config.json being re-resolved forever.
+export function setLocale(locale: unknown): string {
+	currentLocale = resolveLocale(locale);
+	return currentLocale;
+}
+
+function lookup(catalog: MessageCatalog, path: string[]): MessageValue | null {
+	let node: MessageValue | MessageCatalog | undefined = catalog;
+	for (const segment of path) {
+		if (typeof node !== 'object' || node === null || Array.isArray(node)) {
+			return null;
+		}
+		node = (node as MessageCatalog)[segment];
+		if (node === undefined) {
+			return null;
+		}
+	}
+	// A branch is not a message. Reaching one means the key names a namespace,
+	// which is a bug in the caller rather than a missing translation — so it is
+	// treated as a miss and falls through to English, then to the key itself.
+	if (typeof node === 'string') {
+		return node;
+	}
+	if (node && typeof node === 'object' && !Array.isArray(node)) {
+		const forms = node as PluralForms;
+		return typeof forms.other === 'string' ||
+			typeof forms.one === 'string' ||
+			typeof forms.few === 'string' ||
+			typeof forms.many === 'string' ||
+			typeof forms.two === 'string' ||
+			typeof forms.zero === 'string'
+			? forms
+			: null;
+	}
+	return null;
+}
+
+// Intl.PluralRules construction is not free and these are asked for on every
+// render of a sample count, so keep one per locale.
+const pluralRules = new Map<string, Intl.PluralRules>();
+
+function selectPluralForm(
+	forms: PluralForms,
+	locale: string,
+	count: number
+): string | null {
+	let rules = pluralRules.get(locale);
+	if (!rules) {
+		try {
+			rules = new Intl.PluralRules(locale);
+		} catch {
+			rules = new Intl.PluralRules(FALLBACK_LOCALE);
+		}
+		pluralRules.set(locale, rules);
+	}
+	const category = rules.select(count);
+	// CLDR guarantees `other` exists for every language, so it is the only
+	// mandatory form and the right last resort within a locale.
+	return forms[category] ?? forms.other ?? null;
+}
+
+// Substitute {name} from params.
+//
+// An UNKNOWN placeholder is left exactly as it was found, which is load-bearing
+// rather than merely lenient: the filename-format copy talks about
+// "{track}-{driver}-{counter}" as literal text the user types, and blanking those
+// would turn the one message explaining the feature into "--". The rule is that
+// this only ever replaces what it was given a value for.
+function interpolate(template: string, params?: TranslateParams): string {
+	if (!params) {
+		return template;
+	}
+	return template.replace(/\{(\w+)\}/g, (match, name: string) => {
+		const value = params[name];
+		// Numbers are stringified plainly, NOT through Intl.NumberFormat: most of
+		// them here are pixel dimensions, frame indices and percentages, and a
+		// French thousands separator would turn a 1920x1080 target into "1 920".
+		// A caller that wants a number formatted for a locale formats it and passes
+		// a string.
+		return value === undefined || value === null ? match : String(value);
+	});
+}
+
+// Translate `key` in the ambient locale.
+//
+// Misses degrade in three steps — requested locale, English, then the key itself.
+// Returning the key rather than an empty string is deliberate: a bare
+// "settings.language" on screen names the thing that is missing and is greppable,
+// where blank text just looks like a layout bug.
+export function t(key: string, params?: TranslateParams): string {
+	return translate(currentLocale, key, params);
+}
+
+// The same lookup with an explicit locale. Used by the tests, and by anything
+// that has to render a string in a locale other than the ambient one.
+export function translate(
+	locale: string,
+	key: string,
+	params?: TranslateParams
+): string {
+	const path = key.split('.');
+	const resolved = resolveLocale(locale);
+
+	let message = CATALOGS[resolved] ? lookup(CATALOGS[resolved], path) : null;
+	if (message === null && resolved !== FALLBACK_LOCALE) {
+		message = lookup(CATALOGS[FALLBACK_LOCALE], path);
+	}
+	if (message === null) {
+		return key;
+	}
+
+	if (typeof message !== 'string') {
+		const count = params?.count;
+		if (typeof count !== 'number') {
+			// A plural message asked for without a count cannot be selected. Fall
+			// back to `other` so it still reads as a sentence.
+			const fallbackForm = message.other ?? null;
+			return fallbackForm === null ? key : interpolate(fallbackForm, params);
+		}
+		const form = selectPluralForm(message, resolved, count);
+		if (form === null) {
+			return key;
+		}
+		return interpolate(form, params);
+	}
+
+	return interpolate(message, params);
+}

--- a/src/utilities/iracing-config-checks.ts
+++ b/src/utilities/iracing-config-checks.ts
@@ -6,6 +6,8 @@ const fs: typeof import('fs') = require('fs');
 const path: typeof import('path') = require('path');
 const os: typeof import('os') = require('os');
 
+import { t } from './i18n';
+
 const IRACING_INI_PATH = path.join(
 	os.homedir(),
 	'Documents',
@@ -61,9 +63,7 @@ export function checkIracingConfig(): string[] {
 			monitorSetup.RenderViewPerMonitor &&
 			monitorSetup.RenderViewPerMonitor !== '0'
 		) {
-			warnings.push(
-				'Disable "Render Scene Using 3 Projections" in iRacing (Display > Monitor tab) to avoid vertical bands in screenshots'
-			);
+			warnings.push(t('iracingConfig.projections'));
 		}
 	} catch {
 		// Skip check if file cannot be read

--- a/src/utilities/long-exposure/shot-recipe.ts
+++ b/src/utilities/long-exposure/shot-recipe.ts
@@ -34,6 +34,7 @@ import {
 } from './exposure-math';
 import { plannedSinkCount } from './accumulator-sinks';
 import { resolveCropTarget } from '../screenshot-output';
+import { t } from '../i18n';
 
 export const TONEMAPPERS = ['none', 'reinhard', 'aces'] as const;
 export type Tonemapper = (typeof TONEMAPPERS)[number];
@@ -232,14 +233,17 @@ export const LONG_CAPTURE_ESCALATE_SECONDS = 16;
 // have to convert yourself).
 function describeDuration(seconds: number): string {
 	if (!Number.isFinite(seconds) || seconds <= 0) {
-		return '0 seconds';
+		return t('duration.zero');
 	}
 	if (seconds < 90) {
-		return `${Math.round(seconds)} seconds`;
+		const rounded = Math.round(seconds);
+		return t('duration.seconds', { count: rounded });
 	}
 	const minutes = Math.floor(seconds / 60);
 	const rest = Math.round(seconds - minutes * 60);
-	return rest === 0 ? `${minutes} minutes` : `${minutes} min ${rest} s`;
+	return rest === 0
+		? t('duration.minutes', { count: minutes })
+		: t('duration.minutesSeconds', { minutes, seconds: rest });
 }
 
 // A recipe with everything except the anchor, session and output directory, which
@@ -656,7 +660,10 @@ export function validatePlan(opts: {
 		// safe — we never need frames after it. Only an anchor closer than the
 		// window length to the START is constrained.
 		errors.push(
-			`The exposure needs ${plan.windowFrames} replay frames before the selected moment, but it is only ${recipe.anchorFrame} frames into the replay. Pick a later moment or a faster shutter.`
+			t('validation.windowBeforeStart', {
+				frames: plan.windowFrames,
+				anchor: recipe.anchorFrame,
+			})
 		);
 	}
 
@@ -668,23 +675,21 @@ export function validatePlan(opts: {
 		replayEndFrame > 0 &&
 		recipe.anchorFrame > replayEndFrame
 	) {
-		errors.push('The selected moment is past the end of the replay.');
+		errors.push(t('validation.pastEnd'));
 	}
 
 	if (
 		typeof currentSessionNum === 'number' &&
 		currentSessionNum !== recipe.sessionNum
 	) {
-		errors.push(
-			'The replay has moved to a different session since this shot was set up. Re-select the moment.'
-		);
+		errors.push(t('validation.sessionChanged'));
 	}
 
 	if (plan.isSingleSample) {
 		warnings.push(
 			plan.passes > 1
-				? `This shutter is short enough that only about one frame lands inside it per pass, so ${plan.passes} passes collect roughly ${plan.passes} samples. A slower playback speed or a slower shutter buys far more.`
-				: 'This shutter is short enough that only one frame will land inside it, so the result has no motion blur. A slower playback speed or a slower shutter buys samples.'
+				? t('validation.singleSampleMultiPass', { passes: plan.passes })
+				: t('validation.singleSample')
 		);
 	}
 
@@ -706,7 +711,9 @@ export function validatePlan(opts: {
 	// read-modify-write per sink from values already in registers.
 	if (bracketed && recipe.interpolationFactor > 1) {
 		warnings.push(
-			`Bracket shutters and ${recipe.interpolationFactor}x frame interpolation cannot both run, so this shot will be taken without interpolation. Turn bracketing off if the in-betweens matter more to you than the extra stops.`
+			t('validation.bracketVsInterpolation', {
+				factor: recipe.interpolationFactor,
+			})
 		);
 	}
 
@@ -720,7 +727,9 @@ export function validatePlan(opts: {
 	// them looking for a setting that is no longer doing anything.
 	if (!bracketed && plan.passes > 1 && recipe.interpolationFactor > 1) {
 		warnings.push(
-			`Multi-pass and ${recipe.interpolationFactor}x interpolation are both on. They compete: interpolation slows each pass enough to cost it real frames, so the same wait buys fewer real samples than passes alone would. Turning interpolation off is usually the better shot.`
+			t('validation.passesVsInterpolation', {
+				factor: recipe.interpolationFactor,
+			})
 		);
 	}
 
@@ -729,7 +738,11 @@ export function validatePlan(opts: {
 		plan.predictedSamples < recipe.targetSamples
 	) {
 		warnings.push(
-			`Even at 1/${plan.playbackDivisor} speed this exposure reaches about ${plan.predictedSamples} samples, short of the ${recipe.targetSamples} requested. Use a longer shutter for more.`
+			t('validation.shortOfTarget', {
+				divisor: plan.playbackDivisor,
+				samples: plan.predictedSamples,
+				target: recipe.targetSamples,
+			})
 		);
 	}
 
@@ -742,19 +755,27 @@ export function validatePlan(opts: {
 	// what makes multi-pass safe to expose in the UI at all: its whole cost is time.
 	const passSuffix =
 		plan.passes > 1
-			? ` across ${plan.passes} passes over the same moment`
+			? t('validation.passSuffix', { passes: plan.passes })
 			: '';
 	if (plan.predictedTotalWallClockSeconds > LONG_CAPTURE_ESCALATE_SECONDS) {
 		warnings.push(
-			`This capture runs the replay at 1/${plan.playbackDivisor} speed for about ${describeDuration(plan.predictedTotalWallClockSeconds)} of real time${passSuffix}, and cannot be hurried once started. ${
-				plan.passes > 1
-					? 'Fewer passes finish sooner with fewer samples.'
-					: 'A faster playback speed finishes sooner with fewer samples.'
-			}`
+			t('validation.longCaptureEscalate', {
+				divisor: plan.playbackDivisor,
+				duration: describeDuration(plan.predictedTotalWallClockSeconds),
+				passSuffix,
+				advice:
+					plan.passes > 1
+						? t('validation.adviceFewerPasses')
+						: t('validation.adviceFasterPlayback'),
+			})
 		);
 	} else if (plan.predictedTotalWallClockSeconds > LONG_CAPTURE_WARN_SECONDS) {
 		warnings.push(
-			`This capture will take about ${describeDuration(plan.predictedTotalWallClockSeconds)} of real time at 1/${plan.playbackDivisor} playback speed${passSuffix}.`
+			t('validation.longCaptureWarn', {
+				duration: describeDuration(plan.predictedTotalWallClockSeconds),
+				divisor: plan.playbackDivisor,
+				passSuffix,
+			})
 		);
 	}
 
@@ -763,7 +784,11 @@ export function validatePlan(opts: {
 	// the IMAGE is unaffected, only the diagnostics describe a prefix.
 	if (plan.predictedTotalSamples > NATIVE_SAMPLE_LOG_CAP) {
 		warnings.push(
-			`This capture is predicted to collect about ${Math.round(plan.predictedTotalSamples)} samples across ${plan.passes} passes, past the ${NATIVE_SAMPLE_LOG_CAP} the diagnostic log holds. The image is unaffected — only the evenness and gap figures will describe the first part of the capture.`
+			t('validation.pastLogCap', {
+				samples: Math.round(plan.predictedTotalSamples),
+				passes: plan.passes,
+				cap: NATIVE_SAMPLE_LOG_CAP,
+			})
 		);
 	}
 
@@ -782,7 +807,9 @@ export function validatePlan(opts: {
 		const limit = opts.lossyInterpolationLoad;
 		if (typeof limit === 'number' && limit > 0 && load >= limit) {
 			warnings.push(
-				`At this size, ${recipe.interpolationFactor}x interpolation has previously cost this machine real samples. Consider a lower factor, a lower Resolution, or more passes instead.`
+				t('validation.interpolationLossy', {
+					factor: recipe.interpolationFactor,
+				})
 			);
 		}
 	}

--- a/src/utilities/update-decisions.ts
+++ b/src/utilities/update-decisions.ts
@@ -14,6 +14,8 @@
 // green arrow that clicking quit the app instantly. Each function below is one of
 // those behaviours made explicit and testable.
 
+import { t } from './i18n';
+
 // Where a pending update has got to. `idle` covers both "not checked yet" and
 // "checked, nothing newer" — `checkedAt` distinguishes them.
 export type UpdatePhase =
@@ -209,18 +211,18 @@ export function canStartDownload({
 	busy,
 }: UpdateBusyInput & { phase: UpdatePhase }): ActionVerdict {
 	if (phase === 'downloading') {
-		return { allowed: false, reason: 'The update is already downloading.' };
+		return { allowed: false, reason: t('update.alreadyDownloading') };
 	}
 	if (phase === 'downloaded') {
-		return { allowed: false, reason: 'The update is already downloaded.' };
+		return { allowed: false, reason: t('update.alreadyDownloaded') };
 	}
 	if (phase !== 'available') {
-		return { allowed: false, reason: 'There is no update to download.' };
+		return { allowed: false, reason: t('update.nothingToDownload') };
 	}
 	if (busy) {
 		return {
 			allowed: false,
-			reason: 'A capture is in progress. Try again once it finishes.',
+			reason: t('update.captureInProgress'),
 		};
 	}
 	return { allowed: true, reason: null };
@@ -233,15 +235,14 @@ export function canInstallNow({
 	busy,
 }: UpdateBusyInput & { phase: UpdatePhase }): ActionVerdict {
 	if (phase !== 'downloaded') {
-		return { allowed: false, reason: 'No update is ready to install.' };
+		return { allowed: false, reason: t('update.nothingToInstall') };
 	}
 	if (busy) {
 		return {
 			allowed: false,
 			// Accurate, not a consolation: autoInstallOnAppQuit defaults to true, so
 			// the downloaded update really does install on the next normal quit.
-			reason:
-				'A capture is in progress. The update will install by itself when you close the app.',
+			reason: t('update.captureInProgressInstall'),
 		};
 	}
 	return { allowed: true, reason: null };
@@ -255,37 +256,42 @@ export function describeUpdate(
 	currentVersion: string,
 	busy = false
 ): string {
-	const version = state.version ? `v${state.version}` : 'A new version';
+	const version = state.version ? `v${state.version}` : t('update.newVersion');
 
 	switch (state.phase) {
 		case 'checking':
-			return 'Checking for updates…';
+			return t('update.checking');
 
 		case 'available':
 			return busy
-				? `${version} is available. A capture is in progress — you can download it once that finishes.`
-				: `${version} is available. Click to download it.`;
+				? t('update.availableBusy', { version })
+				: t('update.available', { version });
 
 		case 'downloading':
 			return state.percent === null
-				? `Downloading ${version}…`
-				: `Downloading ${version} — ${state.percent}%`;
+				? t('update.downloading', { version })
+				: t('update.downloadingPercent', {
+						version,
+						percent: state.percent,
+					});
 
 		case 'downloaded':
 			return busy
-				? `${version} is ready. A capture is in progress, so it will install when you close the app.`
-				: `${version} is ready. Click to restart and install it.`;
+				? t('update.downloadedBusy', { version })
+				: t('update.downloaded', { version });
 
 		case 'error':
-			return `Update check failed: ${state.error ?? 'unknown error'}`;
+			return t('update.failed', {
+				error: state.error ?? t('update.unknownError'),
+			});
 
 		case 'idle':
 		default:
 			// Never claim freshness we have not established — before the first check
 			// resolves we genuinely do not know.
 			return state.checkedAt === null
-				? `Updates have not been checked yet (you're on v${currentVersion}).`
-				: `You're on the latest version (v${currentVersion}).`;
+				? t('update.neverChecked', { version: currentVersion })
+				: t('update.upToDate', { version: currentVersion });
 	}
 }
 


### PR DESCRIPTION
Adds multi-locale support. English plus twelve European languages: German,
French, Spanish, Italian, Portuguese, Dutch, Polish, Swedish, Czech, Danish,
Finnish and Norwegian.

Scope is everything the user can read, not just UI chrome — the sidebar, the
long-exposure panel, the Help modal's long-form prose, the gallery context
menu, every toast, and the messages the MAIN process authors and sends over IPC
as finished text (capture refusals, long-exposure validation warnings, WGC
support, the update tooltip and install dialog).

## Why not vue-i18n

Three reasons, in order of weight:

1. vue-i18n only exists in the renderer, and main authors user-facing text too.
   `validatePlan`'s warnings, `decideWgcSupport`'s sentence and every capture
   refusal are phrased in main and arrive in the renderer already-worded. A
   renderer-only engine would need a second implementation in main, and the two
   could interpolate the same key differently — a drift only ever visible to
   users who don't read English.
2. Its full build compiles messages at runtime via `new Function`, which is
   what the deferred CSP work (WP-K stage 2) will want to forbid.
3. What this app needs from an i18n library is a dot-path lookup, a brace
   interpolator and CLDR plural categories. `Intl` provides the third; the other
   two are ~200 lines in `src/utilities/i18n.ts`, shared by both processes.

## The constraint that made this reviewable

**The English strings are byte-identical to the literals they replace.**
`capture-decisions.test.ts` and `shot-recipe.test.ts` assert on the exact
sentences those modules produce, so byte-identity is what let this land without
rewriting them. All 801 pre-existing tests pass unchanged.

The flip side is worth knowing before merging: **editing English text in
`en.ts` is a translation-invalidating edit that no test can catch.** Key-parity
tests compare key *sets*; the other twelve catalogues keep the old wording and
keep showing it. Reword an English sentence and the change ships to English
speakers only unless all thirteen are updated. This is called out in the file
header.

## Detection and switching

Main reads `app.getPreferredSystemLanguages()` on first run, resolves it and
writes the **resolved** code back to config before the window is created — so
`pt-BR` settles to `pt` once rather than being re-resolved every launch, and the
first paint is already in the right language rather than flashing English. A
Language dropdown in Settings overrides it, listing each language by its own
endonym (someone hunting for their language in a list they can't read still
recognises "Čeština"; "Czech" helps nobody who needs it).

Switching re-languages both windows and the main process live. No restart, no
window reload.

## Things that would have been bugs

- **Module-scope consts holding user-facing text had to become functions**
  (`EXCLUSIVE_FULLSCREEN_MESSAGE`, `WGC_CURSOR_CAVEAT`,
  `NATIVE_CAPTURE_REQUIRED_REASON`). A const evaluates at import time — before
  `app.on('ready')` resolves the locale — so it would freeze English in
  regardless of the setting. Same reason `FILENAME_FIELDS` now carries
  `labelKey`/`categoryKey` instead of text.
- **Unmatched `{token}`s are left literal.** The filename-format help talks
  *about* `{track}` and `{counter}` as text the user types; substituting them
  would reduce that message to "(--)". Tested.
- **Windows reports Norwegian as `nb`/`nn`**, essentially never as the
  macrolanguage `no` we ship under. Both map onto it — without that, every
  Norwegian machine would silently get English. Tested.
- **Polish and Czech get their real four-category plural rules** via
  `Intl.PluralRules`. "2 przebiegów" where Polish needs "2 przebiegi" is the
  kind of wrong that reads as machine-translated.

## Testing

871 → 878 tests, all passing. 801 of them unchanged.

The catalogue type is derived from `en.ts`, so a missing or misspelled key in a
translation is a **compile** error. The tests cover what types can't see: key
parity, placeholder parity (a translation may only use placeholders English
defines), no empty messages, and the mandatory CLDR `other` form.

`src/renderer/i18n.test.ts` **mounts** the plugin rather than asserting on its
shape. This repo has been bitten before by a Vue registration that compiles,
builds and silently does nothing — passing raw Oruga components to
`oruga.use()`, which no-ops because they have no `install` method — and
`electron-vite build` cannot see that class of fault. The test that matters is
the one asserting an already-mounted component re-renders in German after
`applyLocale('de')`; without the reactive indirection it fails while everything
still compiles and builds.

Both commits are green in isolation, so the branch bisects.

`vue-tsc` clean, eslint 0 errors (31 warnings, down from 37 on the baseline),
prettier clean, `electron-vite build` succeeds for both bundles.

## Reviewer note

I wrote these translations. Terminology is consistent and deliberate —
photographic terms follow each language's own photography conventions
(*Verschlusszeit*, *pose longue*, *lukkertid*), while iRacing, ReShade, WGC,
VRAM and the format names stay untranslated so they still match what users see
in iRacing's own settings.

But twelve languages of long-form prose is a lot of surface, and a native pass
on at least the Help modal before release would be worth having. One file per
language under `src/locales/`, so that review hands out piecemeal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
