### PR TITLE
fix(release): stop two publishers racing to create the same release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,9 +78,38 @@ jobs:
             - name: Build bundles
               run: npm run pack
 
-            # Publishes as a DRAFT (build.publish.releaseType), uploading the NSIS
-            # installer, the portable exe, the .blockmap and — critically —
-            # latest.yml, which electron-updater fetches to discover new versions.
+            # Create the draft BEFORE electron-builder runs.
+            #
+            # package.json builds two targets (nsis + portable), and
+            # electron-builder starts one GitHub publisher per target. They run
+            # concurrently, each asks "is there a release for this tag?", both
+            # get no, and both CREATE one. v3.3.0 came out of this with the
+            # installer, the portable exe and latest.yml attached to one release
+            # and the .blockmap to another, and the publish step below then
+            # flipped the wrong one out of draft — shipping a release with no
+            # installer on it. v3.2.2 won the same race by luck.
+            #
+            # With the draft already there, both publishers find it and upload
+            # into it. Idempotent on purpose: a re-run after a failed build
+            # reuses the existing draft rather than failing on "already exists".
+            - name: Create draft release
+              shell: bash
+              env:
+                  GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              run: |
+                  tag="$GITHUB_REF_NAME"
+                  if gh release view "$tag" >/dev/null 2>&1; then
+                    echo "Release $tag already exists — reusing it."
+                  else
+                    gh release create "$tag" \
+                      --draft \
+                      --title "$tag" \
+                      --notes "Build in progress — this text is replaced when the release is published."
+                  fi
+
+            # Uploads the NSIS installer, the portable exe, the .blockmap and —
+            # critically — latest.yml, which electron-updater fetches to discover
+            # new versions. Attaches to the draft created above.
             - name: Package and upload artifacts
               run: npx electron-builder --publish always
               env:
@@ -94,7 +123,52 @@ jobs:
                   GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
               run: |
                   tag="$GITHUB_REF_NAME"
+                  version="${tag#v}"
                   notes="RELEASE-NOTES-${tag}.md"
+
+                  # Two guards, both learned from v3.3.0.
+                  #
+                  # The first catches the duplicate-release race directly: if the
+                  # step above ever fails to prevent it, `gh release edit` picks
+                  # one of the candidates arbitrarily and there is a 50% chance
+                  # of publishing the empty one. Fail loudly instead.
+                  count="$(gh api "repos/${GITHUB_REPOSITORY}/releases" --paginate \
+                    --jq "[.[] | select(.tag_name == \"${tag}\")] | length")"
+                  if [ "$count" != "1" ]; then
+                    echo "::error::Expected exactly 1 release for ${tag}, found ${count}. Refusing to publish."
+                    exit 1
+                  fi
+
+                  # The second is the check that would have caught v3.3.0 whatever
+                  # the cause: nothing goes public until the artifacts users
+                  # actually need are attached. latest.yml is the one that fails
+                  # silently — a release without it breaks auto-update for
+                  # everyone while looking perfectly fine on the releases page.
+                  #
+                  # Deliberately NOT matching exact filenames. The artifact naming
+                  # has already changed once (v3.1.1 shipped
+                  # "iRacing.Screenshot.Tool.Setup.3.1.1.exe", dot-separated), and
+                  # a guard pinned to today's convention would fail every release
+                  # after the next rename — turning a safety net into a tripwire.
+                  # latest.yml is safe to match exactly: electron-updater fixes
+                  # that name, artifactName cannot change it.
+                  assets="$(gh release view "$tag" --json assets --jq '.assets[].name')"
+                  exe_count="$(printf '%s\n' "$assets" | grep -c '\.exe$' || true)"
+
+                  if ! printf '%s\n' "$assets" | grep -qxF 'latest.yml'; then
+                    echo "::error::Release ${tag} has no latest.yml — auto-update would be broken for every user. Refusing to publish."
+                    echo "Attached assets were:"; printf '  %s\n' $assets
+                    exit 1
+                  fi
+
+                  # nsis + portable, so two. Fewer means a publisher dropped one.
+                  if [ "$exe_count" -lt 2 ]; then
+                    echo "::error::Release ${tag} has ${exe_count} .exe asset(s); expected the installer and the portable build. Refusing to publish."
+                    echo "Attached assets were:"; printf '  %s\n' $assets
+                    exit 1
+                  fi
+
+                  echo "Artifacts verified: ${exe_count} .exe + latest.yml"
 
                   if [ -f "$notes" ]; then
                     echo "Using curated notes: $notes"


### PR DESCRIPTION
**v3.3.0 shipped with no installer on it.** This fixes the cause and adds the
checks that would have caught it. The release itself has already been repaired
by hand — details at the bottom.

## What happened

`package.json` builds two targets (`nsis` + `portable`), and electron-builder
starts **one GitHub publisher per target**. They run concurrently, each asks
"is there a release for this tag?", both get no, and both **create one**.

The build log shows it plainly — two `publishing` lines 0.3 ms apart:

```
22:33:53.7725305Z  • publishing publisher=Github (... version=3.3.0)
22:33:53.7728538Z  • publishing publisher=Github (... version=3.3.0)
```

and the API showed releases `367038444` and `367038445` — consecutive ids, same
tag. The artifacts split across them:

| release | assets |
| --- | --- |
| `367038444` (got published) | `…Setup-3.3.0.exe.blockmap` |
| `367038445` (left as draft) | installer, portable, **`latest.yml`** |

`gh release edit "$tag"` then resolved the tag to whichever it found first and
flipped **that** out of draft. It lost the coin toss: the public release held a
120 KB blockmap and nothing else, while every artifact users needed sat in a
draft they couldn't see.

This has always been a race. v3.2.2 won it. Nothing in the app caused it, and
nothing about it is new — it just finally came up tails.

## The fix

**Create the draft before electron-builder runs.** Both publishers then find an
existing release and upload into it, so only one can exist. Idempotent, so a
re-run after a failed build reuses the draft instead of failing on "already
exists".

**Two guards before anything goes public**, because prevention that fails
silently isn't worth much:

1. **Exactly one release must exist for the tag.** If the race ever returns, the
   publish step stops instead of picking arbitrarily between candidates.
2. **`latest.yml` and at least two `.exe` assets must be attached.** This is the
   check that would have caught v3.3.0 regardless of cause. `latest.yml` is the
   one that fails silently — a release without it breaks auto-update for every
   user while looking completely normal on the releases page.

The asset guard deliberately **does not match exact filenames**. The naming has
already changed once (v3.1.1 shipped `iRacing.Screenshot.Tool.Setup.3.1.1.exe`,
dot-separated), and a guard pinned to today's convention would fail every
release after the next rename — turning a safety net into a tripwire.
`latest.yml` is safe to match exactly because electron-updater fixes that name;
`artifactName` cannot change it.

## Testing

The guards were **run against live releases** rather than shipped unexercised:

```
v3.3.0 → Artifacts verified: 2 .exe + latest.yml            exit=0
v3.1.1 → ::error:: Release v3.1.1 has no latest.yml…        exit=1
```

v3.1.1 is a genuine negative — it predates the `latest.yml` upload entirely.

The draft-creation step itself can only be exercised by cutting a release, so it
gets its first real run on whatever ships next. If it misbehaves, guard 1 stops
the release rather than publishing the wrong one — the failure mode is a red
build, not a broken download.

## v3.3.0 has been repaired

- Deleted the empty published release.
- Moved the blockmap onto the release holding the real artifacts.
- Published that one with the curated notes, `--prerelease=false --latest`.

Verified after: one release for the tag, all four assets attached,
`/releases/latest` resolves to v3.3.0, and
`/releases/latest/download/latest.yml` returns `version: 3.3.0` pointing at an
installer whose size matches the attached asset.

**No asset had been downloaded before the repair** (download count 0 across
both releases), so no user ever saw the broken state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
