### PR TITLE
Help FAQ: vertical bands on triple screens

### DIFF
--- a/src/locales/ar.ts
+++ b/src/locales/ar.ts
@@ -341,6 +341,12 @@ const ar: Catalog = {
 				'هذا هو اختيار اللقطات التلقائي الخاص بـ iRacing، وليس هذه الأداة. فما دام مفعّلًا يستمر iRacing في اختيار الكاميرات لنفسه وسيعود إلى تأطير افتراضي لحظة بدء الالتقاط، فتحصل على غير اللقطة التي أعددتها.',
 			cameraResetFixBody:
 				'أوقفه من أداة الكاميرات في iRacing (Ctrl+F12)، ضمن <b>Camera &gt; Config &gt; Preferences</b>: مفتاح <b>Shot Selection</b> المسمى <b>Automatic</b>. وعند إيقافه تبقى الكاميرا حيث وضعتها تمامًا، في لقطات الشاشة العادية وفي التعريض الطويل على حد سواء.',
+
+			tripleBands: 'There are vertical bands in my triple-screen shots',
+			tripleBandsBody:
+				'They are a side effect of two iRacing settings working together: multi-projection (the SMP setting) and bezel correction. On the monitors themselves the picture looks right — the correction exists to line the scene up across the physical frames — but in the captured image the corrected regions show up as vertical bands where one screen meets the next.',
+			tripleBandsFixBody:
+				"Either change fixes it: set the <b>bezel width</b> to <b>0 mm</b> in iRacing's graphics options, which takes effect immediately, or turn off <b>multi-projection (SMP)</b>, which takes effect after an iRacing restart.",
 		},
 	},
 

--- a/src/locales/cs.ts
+++ b/src/locales/cs.ts
@@ -322,6 +322,12 @@ const cs: Catalog = {
 				'To je vlastní automatický výběr záběrů iRacingu, ne tento nástroj. Dokud je zapnutý, iRacing si kamery vybírá sám a ve chvíli, kdy zachycení začne, se vrátí k výchozímu záběru, takže nedostanete snímek, který jste si připravili.',
 			cameraResetFixBody:
 				'Vypněte jej v nástroji kamer iRacingu (Ctrl+F12) v <b>Camera &gt; Config &gt; Preferences</b>: přepínač <b>Shot Selection</b> označený <b>Automatic</b>. Když je vypnutý, kamera zůstane přesně tam, kam jste ji dali — u běžných snímků obrazovky i u dlouhých expozic.',
+
+			tripleBands: 'There are vertical bands in my triple-screen shots',
+			tripleBandsBody:
+				'They are a side effect of two iRacing settings working together: multi-projection (the SMP setting) and bezel correction. On the monitors themselves the picture looks right — the correction exists to line the scene up across the physical frames — but in the captured image the corrected regions show up as vertical bands where one screen meets the next.',
+			tripleBandsFixBody:
+				"Either change fixes it: set the <b>bezel width</b> to <b>0 mm</b> in iRacing's graphics options, which takes effect immediately, or turn off <b>multi-projection (SMP)</b>, which takes effect after an iRacing restart.",
 		},
 	},
 

--- a/src/locales/da.ts
+++ b/src/locales/da.ts
@@ -312,6 +312,12 @@ const da: Catalog = {
 				'Det er iRacings egen automatiske billedvalg, ikke dette værktøj. Så længe det er slået til, bliver iRacing ved med selv at vælge kameraer og skifter tilbage til en standardindstilling i det øjeblik, optagelsen starter, så du ikke får det billede, du havde sat op.',
 			cameraResetFixBody:
 				'Slå det fra i iRacings kameraværktøj (Ctrl+F12) under <b>Camera &gt; Config &gt; Preferences</b>: kontakten <b>Shot Selection</b> med teksten <b>Automatic</b>. Når den er slået fra, bliver kameraet præcis, hvor du satte det — både til almindelige skærmbilleder og til lange eksponeringer.',
+
+			tripleBands: 'There are vertical bands in my triple-screen shots',
+			tripleBandsBody:
+				'They are a side effect of two iRacing settings working together: multi-projection (the SMP setting) and bezel correction. On the monitors themselves the picture looks right — the correction exists to line the scene up across the physical frames — but in the captured image the corrected regions show up as vertical bands where one screen meets the next.',
+			tripleBandsFixBody:
+				"Either change fixes it: set the <b>bezel width</b> to <b>0 mm</b> in iRacing's graphics options, which takes effect immediately, or turn off <b>multi-projection (SMP)</b>, which takes effect after an iRacing restart.",
 		},
 	},
 

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -317,6 +317,12 @@ const de: Catalog = {
 				'Das ist iRacings eigene automatische Kameraauswahl, nicht dieses Tool. Solange sie aktiv ist, wählt iRacing die Kameras weiterhin selbst und springt im Moment des Auslösens auf eine Standardeinstellung zurück, sodass du nicht die Aufnahme bekommst, die du eingerichtet hast.',
 			cameraResetFixBody:
 				'Schalte sie im Kamerawerkzeug von iRacing (Strg+F12) unter <b>Camera &gt; Config &gt; Preferences</b> aus: der Schalter <b>Shot Selection</b> mit der Beschriftung <b>Automatic</b>. Ist er aus, bleibt die Kamera genau dort, wo du sie hingestellt hast — bei normalen Screenshots wie bei Langzeitbelichtungen.',
+
+			tripleBands: 'There are vertical bands in my triple-screen shots',
+			tripleBandsBody:
+				'They are a side effect of two iRacing settings working together: multi-projection (the SMP setting) and bezel correction. On the monitors themselves the picture looks right — the correction exists to line the scene up across the physical frames — but in the captured image the corrected regions show up as vertical bands where one screen meets the next.',
+			tripleBandsFixBody:
+				"Either change fixes it: set the <b>bezel width</b> to <b>0 mm</b> in iRacing's graphics options, which takes effect immediately, or turn off <b>multi-projection (SMP)</b>, which takes effect after an iRacing restart.",
 		},
 	},
 

--- a/src/locales/el.ts
+++ b/src/locales/el.ts
@@ -338,6 +338,12 @@ const el: Catalog = {
 				'Αυτή είναι η δική του αυτόματη επιλογή πλάνων του iRacing, όχι αυτού του εργαλείου. Όσο είναι ενεργή, το iRacing συνεχίζει να επιλέγει κάμερες μόνο του και θα επιστρέψει σε ένα προεπιλεγμένο πλάνο τη στιγμή που ξεκινά η λήψη, οπότε αυτό που παίρνετε δεν είναι το πλάνο που είχατε ρυθμίσει.',
 			cameraResetFixBody:
 				'Απενεργοποιήστε το από το εργαλείο κάμερας του iRacing (Ctrl+F12), στο <b>Camera &gt; Config &gt; Preferences</b>: ο διακόπτης <b>Shot Selection</b> με την ετικέτα <b>Automatic</b>. Με αυτόν απενεργοποιημένο, η κάμερα παραμένει ακριβώς εκεί που την τοποθετήσατε, τόσο για κανονικά στιγμιότυπα όσο και για μεγάλες εκθέσεις.',
+
+			tripleBands: 'There are vertical bands in my triple-screen shots',
+			tripleBandsBody:
+				'They are a side effect of two iRacing settings working together: multi-projection (the SMP setting) and bezel correction. On the monitors themselves the picture looks right — the correction exists to line the scene up across the physical frames — but in the captured image the corrected regions show up as vertical bands where one screen meets the next.',
+			tripleBandsFixBody:
+				"Either change fixes it: set the <b>bezel width</b> to <b>0 mm</b> in iRacing's graphics options, which takes effect immediately, or turn off <b>multi-projection (SMP)</b>, which takes effect after an iRacing restart.",
 		},
 	},
 

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -336,6 +336,12 @@ export default {
 				"That is iRacing's own automatic shot selection, not this tool. While it is on, iRacing keeps picking cameras for itself and will cut back to a default framing at the moment the capture starts, so what you get is not the shot you set up.",
 			cameraResetFixBody:
 				"Turn it off in iRacing's camera tool (Ctrl+F12), under <b>Camera &gt; Config &gt; Preferences</b>: the <b>Shot Selection</b> toggle labelled <b>Automatic</b>. With it off the camera stays exactly where you put it, for normal screenshots and long exposures alike.",
+
+			tripleBands: 'There are vertical bands in my triple-screen shots',
+			tripleBandsBody:
+				'They are a side effect of two iRacing settings working together: multi-projection (the SMP setting) and bezel correction. On the monitors themselves the picture looks right — the correction exists to line the scene up across the physical frames — but in the captured image the corrected regions show up as vertical bands where one screen meets the next.',
+			tripleBandsFixBody:
+				"Either change fixes it: set the <b>bezel width</b> to <b>0 mm</b> in iRacing's graphics options, which takes effect immediately, or turn off <b>multi-projection (SMP)</b>, which takes effect after an iRacing restart.",
 		},
 	},
 

--- a/src/locales/es.ts
+++ b/src/locales/es.ts
@@ -313,6 +313,12 @@ const es: Catalog = {
 				'Es la selección automática de planos del propio iRacing, no esta herramienta. Mientras está activada, iRacing sigue eligiendo las cámaras por su cuenta y vuelve a un encuadre por defecto justo cuando arranca la captura, así que lo que obtienes no es la toma que habías preparado.',
 			cameraResetFixBody:
 				'Desactívala en la herramienta de cámaras de iRacing (Ctrl+F12), en <b>Camera &gt; Config &gt; Preferences</b>: el interruptor <b>Shot Selection</b> etiquetado como <b>Automatic</b>. Con él apagado la cámara se queda exactamente donde la pusiste, tanto en capturas normales como en exposiciones largas.',
+
+			tripleBands: 'There are vertical bands in my triple-screen shots',
+			tripleBandsBody:
+				'They are a side effect of two iRacing settings working together: multi-projection (the SMP setting) and bezel correction. On the monitors themselves the picture looks right — the correction exists to line the scene up across the physical frames — but in the captured image the corrected regions show up as vertical bands where one screen meets the next.',
+			tripleBandsFixBody:
+				"Either change fixes it: set the <b>bezel width</b> to <b>0 mm</b> in iRacing's graphics options, which takes effect immediately, or turn off <b>multi-projection (SMP)</b>, which takes effect after an iRacing restart.",
 		},
 	},
 

--- a/src/locales/fi.ts
+++ b/src/locales/fi.ts
@@ -316,6 +316,12 @@ const fi: Catalog = {
 				'Kyse on iRacingin omasta automaattisesta kuvavalinnasta, ei tästä työkalusta. Niin kauan kuin se on päällä, iRacing valitsee kamerat itse ja palaa oletusrajaukseen juuri sillä hetkellä, kun kaappaus alkaa, joten et saa sitä otosta, jonka asettelit.',
 			cameraResetFixBody:
 				'Kytke se pois iRacingin kameratyökalussa (Ctrl+F12) kohdassa <b>Camera &gt; Config &gt; Preferences</b>: kytkin <b>Shot Selection</b>, jonka nimenä on <b>Automatic</b>. Kun se on pois päältä, kamera pysyy täsmälleen siinä mihin sen asetit — sekä tavallisissa kuvakaappauksissa että pitkissä valotuksissa.',
+
+			tripleBands: 'There are vertical bands in my triple-screen shots',
+			tripleBandsBody:
+				'They are a side effect of two iRacing settings working together: multi-projection (the SMP setting) and bezel correction. On the monitors themselves the picture looks right — the correction exists to line the scene up across the physical frames — but in the captured image the corrected regions show up as vertical bands where one screen meets the next.',
+			tripleBandsFixBody:
+				"Either change fixes it: set the <b>bezel width</b> to <b>0 mm</b> in iRacing's graphics options, which takes effect immediately, or turn off <b>multi-projection (SMP)</b>, which takes effect after an iRacing restart.",
 		},
 	},
 

--- a/src/locales/fr.ts
+++ b/src/locales/fr.ts
@@ -317,6 +317,12 @@ const fr: Catalog = {
 				'C’est la sélection automatique des plans propre à iRacing, pas cet outil. Tant qu’elle est active, iRacing continue de choisir les caméras lui-même et revient à un cadrage par défaut à l’instant où la capture démarre : vous n’obtenez donc pas la vue que vous aviez préparée.',
 			cameraResetFixBody:
 				'Désactivez-la dans l’outil caméra d’iRacing (Ctrl+F12), sous <b>Camera &gt; Config &gt; Preferences</b> : l’interrupteur <b>Shot Selection</b> intitulé <b>Automatic</b>. Une fois désactivé, la caméra reste exactement là où vous l’avez placée, pour les captures normales comme pour les poses longues.',
+
+			tripleBands: 'There are vertical bands in my triple-screen shots',
+			tripleBandsBody:
+				'They are a side effect of two iRacing settings working together: multi-projection (the SMP setting) and bezel correction. On the monitors themselves the picture looks right — the correction exists to line the scene up across the physical frames — but in the captured image the corrected regions show up as vertical bands where one screen meets the next.',
+			tripleBandsFixBody:
+				"Either change fixes it: set the <b>bezel width</b> to <b>0 mm</b> in iRacing's graphics options, which takes effect immediately, or turn off <b>multi-projection (SMP)</b>, which takes effect after an iRacing restart.",
 		},
 	},
 

--- a/src/locales/it.ts
+++ b/src/locales/it.ts
@@ -313,6 +313,12 @@ const it: Catalog = {
 				'È la selezione automatica delle inquadrature di iRacing, non questo strumento. Finché è attiva, iRacing continua a scegliere le telecamere da sé e torna a un’inquadratura predefinita nell’istante in cui parte la cattura, così quello che ottieni non è lo scatto che avevi preparato.',
 			cameraResetFixBody:
 				'Disattivala nello strumento telecamere di iRacing (Ctrl+F12), in <b>Camera &gt; Config &gt; Preferences</b>: l’interruttore <b>Shot Selection</b> etichettato <b>Automatic</b>. Con quello spento la telecamera resta esattamente dove l’hai messa, sia per gli screenshot normali sia per le lunghe esposizioni.',
+
+			tripleBands: 'There are vertical bands in my triple-screen shots',
+			tripleBandsBody:
+				'They are a side effect of two iRacing settings working together: multi-projection (the SMP setting) and bezel correction. On the monitors themselves the picture looks right — the correction exists to line the scene up across the physical frames — but in the captured image the corrected regions show up as vertical bands where one screen meets the next.',
+			tripleBandsFixBody:
+				"Either change fixes it: set the <b>bezel width</b> to <b>0 mm</b> in iRacing's graphics options, which takes effect immediately, or turn off <b>multi-projection (SMP)</b>, which takes effect after an iRacing restart.",
 		},
 	},
 

--- a/src/locales/ja.ts
+++ b/src/locales/ja.ts
@@ -321,6 +321,12 @@ const ja: Catalog = {
 				'それはこのツールではなく、iRacing 自身の自動ショット選択です。オンになっている間、iRacing は自分でカメラを選び続け、キャプチャが始まる瞬間に既定の構図へ戻してしまうため、用意した構図とは違う写真になります。',
 			cameraResetFixBody:
 				'iRacing のカメラツール（Ctrl+F12）の <b>Camera &gt; Config &gt; Preferences</b> にある、<b>Shot Selection</b> の <b>Automatic</b> スイッチでオフにできます。オフにすれば、通常のスクリーンショットでも長時間露光でも、カメラは設定した位置のままになります。',
+
+			tripleBands: 'There are vertical bands in my triple-screen shots',
+			tripleBandsBody:
+				'They are a side effect of two iRacing settings working together: multi-projection (the SMP setting) and bezel correction. On the monitors themselves the picture looks right — the correction exists to line the scene up across the physical frames — but in the captured image the corrected regions show up as vertical bands where one screen meets the next.',
+			tripleBandsFixBody:
+				"Either change fixes it: set the <b>bezel width</b> to <b>0 mm</b> in iRacing's graphics options, which takes effect immediately, or turn off <b>multi-projection (SMP)</b>, which takes effect after an iRacing restart.",
 		},
 	},
 

--- a/src/locales/ko.ts
+++ b/src/locales/ko.ts
@@ -317,6 +317,12 @@ const ko: Catalog = {
 				'이 도구가 아니라 iRacing 자체의 자동 샷 선택 기능 때문입니다. 켜져 있는 동안 iRacing은 스스로 카메라를 계속 고르며, 캡처가 시작되는 순간 기본 구도로 되돌아갑니다. 그래서 준비해 둔 장면이 아닌 다른 장면이 찍힙니다.',
 			cameraResetFixBody:
 				'iRacing의 카메라 도구(Ctrl+F12)에서 <b>Camera &gt; Config &gt; Preferences</b>에 있는 <b>Shot Selection</b>의 <b>Automatic</b> 토글을 끄세요. 끄고 나면 일반 스크린샷이든 장노출이든 카메라가 설정해 둔 자리에 그대로 머무릅니다.',
+
+			tripleBands: 'There are vertical bands in my triple-screen shots',
+			tripleBandsBody:
+				'They are a side effect of two iRacing settings working together: multi-projection (the SMP setting) and bezel correction. On the monitors themselves the picture looks right — the correction exists to line the scene up across the physical frames — but in the captured image the corrected regions show up as vertical bands where one screen meets the next.',
+			tripleBandsFixBody:
+				"Either change fixes it: set the <b>bezel width</b> to <b>0 mm</b> in iRacing's graphics options, which takes effect immediately, or turn off <b>multi-projection (SMP)</b>, which takes effect after an iRacing restart.",
 		},
 	},
 

--- a/src/locales/nl.ts
+++ b/src/locales/nl.ts
@@ -312,6 +312,12 @@ const nl: Catalog = {
 				'Dat is iRacings eigen automatische shotkeuze, niet deze tool. Zolang die aanstaat, kiest iRacing zelf camera’s en springt het op het moment dat de opname begint terug naar een standaardkadrering, dus krijg je niet het beeld dat je had opgezet.',
 			cameraResetFixBody:
 				'Zet die uit in het camerascherm van iRacing (Ctrl+F12), onder <b>Camera &gt; Config &gt; Preferences</b>: de schakelaar <b>Shot Selection</b> met het label <b>Automatic</b>. Staat die uit, dan blijft de camera precies waar je hem hebt gezet — bij gewone screenshots én bij lange sluitertijden.',
+
+			tripleBands: 'There are vertical bands in my triple-screen shots',
+			tripleBandsBody:
+				'They are a side effect of two iRacing settings working together: multi-projection (the SMP setting) and bezel correction. On the monitors themselves the picture looks right — the correction exists to line the scene up across the physical frames — but in the captured image the corrected regions show up as vertical bands where one screen meets the next.',
+			tripleBandsFixBody:
+				"Either change fixes it: set the <b>bezel width</b> to <b>0 mm</b> in iRacing's graphics options, which takes effect immediately, or turn off <b>multi-projection (SMP)</b>, which takes effect after an iRacing restart.",
 		},
 	},
 

--- a/src/locales/no.ts
+++ b/src/locales/no.ts
@@ -318,6 +318,12 @@ const no: Catalog = {
 				'Det er iRacings egen automatiske bildevalg, ikke dette verktøyet. Så lenge det er på, fortsetter iRacing å velge kameraer selv og går tilbake til et standardutsnitt i det øyeblikket opptaket starter, så du får ikke bildet du satte opp.',
 			cameraResetFixBody:
 				'Slå det av i kameraverktøyet i iRacing (Ctrl+F12), under <b>Camera &gt; Config &gt; Preferences</b>: bryteren <b>Shot Selection</b> merket <b>Automatic</b>. Når den er av, blir kameraet nøyaktig der du satte det — både for vanlige skjermbilder og for lange eksponeringer.',
+
+			tripleBands: 'There are vertical bands in my triple-screen shots',
+			tripleBandsBody:
+				'They are a side effect of two iRacing settings working together: multi-projection (the SMP setting) and bezel correction. On the monitors themselves the picture looks right — the correction exists to line the scene up across the physical frames — but in the captured image the corrected regions show up as vertical bands where one screen meets the next.',
+			tripleBandsFixBody:
+				"Either change fixes it: set the <b>bezel width</b> to <b>0 mm</b> in iRacing's graphics options, which takes effect immediately, or turn off <b>multi-projection (SMP)</b>, which takes effect after an iRacing restart.",
 		},
 	},
 

--- a/src/locales/pl.ts
+++ b/src/locales/pl.ts
@@ -323,6 +323,12 @@ const pl: Catalog = {
 				'To własny automatyczny dobór ujęć iRacinga, a nie to narzędzie. Dopóki jest włączony, iRacing sam wybiera kamery i w chwili rozpoczęcia przechwytywania wraca do domyślnego kadru, więc zamiast przygotowanego ujęcia dostajesz inne.',
 			cameraResetFixBody:
 				'Wyłącz go w narzędziu kamer iRacinga (Ctrl+F12), w <b>Camera &gt; Config &gt; Preferences</b>: przełącznik <b>Shot Selection</b> z etykietą <b>Automatic</b>. Gdy jest wyłączony, kamera zostaje dokładnie tam, gdzie ją ustawisz — zarówno przy zwykłych zrzutach, jak i przy długim naświetlaniu.',
+
+			tripleBands: 'There are vertical bands in my triple-screen shots',
+			tripleBandsBody:
+				'They are a side effect of two iRacing settings working together: multi-projection (the SMP setting) and bezel correction. On the monitors themselves the picture looks right — the correction exists to line the scene up across the physical frames — but in the captured image the corrected regions show up as vertical bands where one screen meets the next.',
+			tripleBandsFixBody:
+				"Either change fixes it: set the <b>bezel width</b> to <b>0 mm</b> in iRacing's graphics options, which takes effect immediately, or turn off <b>multi-projection (SMP)</b>, which takes effect after an iRacing restart.",
 		},
 	},
 

--- a/src/locales/pt.ts
+++ b/src/locales/pt.ts
@@ -314,6 +314,12 @@ const pt: Catalog = {
 				'É a seleção automática de planos do próprio iRacing, não esta ferramenta. Enquanto estiver ligada, o iRacing continua a escolher as câmaras sozinho e volta a um enquadramento predefinido no instante em que a captura começa, pelo que o que recebes não é a captura que tinhas preparado.',
 			cameraResetFixBody:
 				'Desliga-a na ferramenta de câmaras do iRacing (Ctrl+F12), em <b>Camera &gt; Config &gt; Preferences</b>: o interruptor <b>Shot Selection</b> com a etiqueta <b>Automatic</b>. Com ele desligado a câmara fica exatamente onde a puseste, tanto nas capturas normais como nas longas exposições.',
+
+			tripleBands: 'There are vertical bands in my triple-screen shots',
+			tripleBandsBody:
+				'They are a side effect of two iRacing settings working together: multi-projection (the SMP setting) and bezel correction. On the monitors themselves the picture looks right — the correction exists to line the scene up across the physical frames — but in the captured image the corrected regions show up as vertical bands where one screen meets the next.',
+			tripleBandsFixBody:
+				"Either change fixes it: set the <b>bezel width</b> to <b>0 mm</b> in iRacing's graphics options, which takes effect immediately, or turn off <b>multi-projection (SMP)</b>, which takes effect after an iRacing restart.",
 		},
 	},
 

--- a/src/locales/ru.ts
+++ b/src/locales/ru.ts
@@ -328,6 +328,12 @@ const ru: Catalog = {
 				'Это собственный автоматический выбор ракурсов iRacing, а не эта программа. Пока он включён, iRacing сам выбирает камеры и в момент начала захвата возвращается к кадрированию по умолчанию, поэтому вы получаете не тот снимок, который настроили.',
 			cameraResetFixBody:
 				'Выключите его в инструменте камер iRacing (Ctrl+F12), в разделе <b>Camera &gt; Config &gt; Preferences</b>: переключатель <b>Shot Selection</b> с меткой <b>Automatic</b>. Когда он выключен, камера остаётся ровно там, где вы её поставили, — и для обычных снимков, и для длинных выдержек.',
+
+			tripleBands: 'There are vertical bands in my triple-screen shots',
+			tripleBandsBody:
+				'They are a side effect of two iRacing settings working together: multi-projection (the SMP setting) and bezel correction. On the monitors themselves the picture looks right — the correction exists to line the scene up across the physical frames — but in the captured image the corrected regions show up as vertical bands where one screen meets the next.',
+			tripleBandsFixBody:
+				"Either change fixes it: set the <b>bezel width</b> to <b>0 mm</b> in iRacing's graphics options, which takes effect immediately, or turn off <b>multi-projection (SMP)</b>, which takes effect after an iRacing restart.",
 		},
 	},
 

--- a/src/locales/sv.ts
+++ b/src/locales/sv.ts
@@ -313,6 +313,12 @@ const sv: Catalog = {
 				'Det är iRacings eget automatiska bildval, inte det här verktyget. Så länge det är på fortsätter iRacing att välja kameror själv och hoppar tillbaka till en standardbildvinkel i samma ögonblick som tagningen startar, så du får inte den bild du ställt i ordning.',
 			cameraResetFixBody:
 				'Stäng av det i iRacings kameraverktyg (Ctrl+F12), under <b>Camera &gt; Config &gt; Preferences</b>: reglaget <b>Shot Selection</b> märkt <b>Automatic</b>. Med det avstängt stannar kameran exakt där du satte den — både för vanliga skärmbilder och för långtidsexponeringar.',
+
+			tripleBands: 'There are vertical bands in my triple-screen shots',
+			tripleBandsBody:
+				'They are a side effect of two iRacing settings working together: multi-projection (the SMP setting) and bezel correction. On the monitors themselves the picture looks right — the correction exists to line the scene up across the physical frames — but in the captured image the corrected regions show up as vertical bands where one screen meets the next.',
+			tripleBandsFixBody:
+				"Either change fixes it: set the <b>bezel width</b> to <b>0 mm</b> in iRacing's graphics options, which takes effect immediately, or turn off <b>multi-projection (SMP)</b>, which takes effect after an iRacing restart.",
 		},
 	},
 

--- a/src/locales/tr.ts
+++ b/src/locales/tr.ts
@@ -326,6 +326,12 @@ const tr: Catalog = {
 				"Bu, bu uygulamanın değil, iRacing'in kendi otomatik çekim seçimidir. Açıkken iRacing kameraları kendi başına seçmeye devam eder ve yakalama başladığı anda varsayılan bir kadraja geri döner, bu yüzden elde ettiğiniz, kurduğunuz çekim olmaz.",
 			cameraResetFixBody:
 				"Bunu iRacing'in kamera aracında (Ctrl+F12), <b>Camera &gt; Config &gt; Preferences</b> altında kapatın: <b>Shot Selection</b> anahtarı (<b>Automatic</b> etiketli). Kapalıyken kamera tam olarak koyduğunuz yerde kalır — hem normal ekran görüntüleri hem de uzun pozlamalar için.",
+
+			tripleBands: 'There are vertical bands in my triple-screen shots',
+			tripleBandsBody:
+				'They are a side effect of two iRacing settings working together: multi-projection (the SMP setting) and bezel correction. On the monitors themselves the picture looks right — the correction exists to line the scene up across the physical frames — but in the captured image the corrected regions show up as vertical bands where one screen meets the next.',
+			tripleBandsFixBody:
+				"Either change fixes it: set the <b>bezel width</b> to <b>0 mm</b> in iRacing's graphics options, which takes effect immediately, or turn off <b>multi-projection (SMP)</b>, which takes effect after an iRacing restart.",
 		},
 	},
 

--- a/src/locales/zh-tw.ts
+++ b/src/locales/zh-tw.ts
@@ -317,6 +317,12 @@ const zhTW: Catalog = {
 				'那是 iRacing 自己的自動選鏡功能，不是本工具。只要它開著，iRacing 就會不斷替自己挑選攝影機，並在擷取開始的那一刻切回預設構圖，所以拍到的並不是您原本設好的畫面。',
 			cameraResetFixBody:
 				'請到 iRacing 的攝影機工具（Ctrl+F12）中關閉它，位置在 <b>Camera &gt; Config &gt; Preferences</b>：標示為 <b>Automatic</b> 的 <b>Shot Selection</b> 開關。關閉之後，攝影機就會完全停在您擺放的位置，一般截圖和長時間曝光都一樣。',
+
+			tripleBands: 'There are vertical bands in my triple-screen shots',
+			tripleBandsBody:
+				'They are a side effect of two iRacing settings working together: multi-projection (the SMP setting) and bezel correction. On the monitors themselves the picture looks right — the correction exists to line the scene up across the physical frames — but in the captured image the corrected regions show up as vertical bands where one screen meets the next.',
+			tripleBandsFixBody:
+				"Either change fixes it: set the <b>bezel width</b> to <b>0 mm</b> in iRacing's graphics options, which takes effect immediately, or turn off <b>multi-projection (SMP)</b>, which takes effect after an iRacing restart.",
 		},
 	},
 

--- a/src/renderer/views/Help.vue
+++ b/src/renderer/views/Help.vue
@@ -131,6 +131,15 @@
 						<p v-html="$t('help.faq.cameraResetFixBody')"></p>
 					</div>
 				</details>
+				<details class="help-faq" name="help-faq">
+					<summary class="help-faq__question">
+						{{ $t('help.faq.tripleBands') }}
+					</summary>
+					<div class="help-faq__answer">
+						<p>{{ $t('help.faq.tripleBandsBody') }}</p>
+						<p v-html="$t('help.faq.tripleBandsFixBody')"></p>
+					</div>
+				</details>
 			</section>
 		</div>
 


### PR DESCRIPTION
## What

A third item in the Help page's FAQ (General tab), answering a triple-screen report: vertical bands in captured shots.

- **Question** — "There are vertical bands in my triple-screen shots"
- **Cause** — multi-projection (the SMP setting) combined with bezel correction: the picture is right on the monitors, but in the captured image the corrected regions show up as vertical bands where one screen meets the next.
- **Fix** — set the bezel width to 0 mm in iRacing's graphics options (takes effect immediately), or turn off multi-projection/SMP (takes effect after an iRacing restart).
- **Strings** — English-only per the project's i18n workflow: authored in `en.ts` (`help.faq.tripleBands*`), copied verbatim into the other nineteen catalogues; their translation is a later pass. The insertion into the already-translated catalogues was done with a structure-anchored script (anchored on the `faq` block, not on translated text), with exact-match assertions.

## Verification

- `npx prettier --check` clean on all touched files
- `npm run type-check` green (this is what enforces catalogue key parity)
- Both i18n suites pass — 145 tests, including the per-locale "exactly the English key set" checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)