### PR TITLE
Filename counter offset: {counter+n}

### DIFF
--- a/RELEASE-NOTES-v3.3.1.md
+++ b/RELEASE-NOTES-v3.3.1.md
@@ -36,6 +36,12 @@ save a black image and call it a success.
   (iRacing, ReShade, WGC, VRAM, and the menu paths Help points you to) are
   left in English so they still match what you see in the sim.
 
+- **An offset for the filename counter.** `{counter+5}` numbers files
+  starting at 5 instead of 0 — useful for continuing a sequence from a
+  previous session instead of restarting it. Works alongside a plain
+  `{counter}` in the same format, and the filename preview in Settings
+  shows exactly what the first file will be named.
+
 - **A new FAQ tab in Help**, for the two things people report as "the tool
   is broken" most often, neither of which is a bug in the tool: a long
   exposure that comes back black except for the iRacing UI (a handful of

--- a/src/renderer/components/SettingsModal.vue
+++ b/src/renderer/components/SettingsModal.vue
@@ -369,6 +369,7 @@ import { version } from '../../../package.json';
 import {
 	FILENAME_FIELDS,
 	DEFAULT_FORMAT,
+	fillCounterTokens,
 	type FilenameField,
 } from '../../utilities/filenameFormat';
 import { getLocale, SUPPORTED_LOCALES } from '../../utilities/i18n';
@@ -463,12 +464,14 @@ export default {
 				'{date}': '2026-04-03',
 				'{time}': '14-30-00',
 				'{datetime}': '2026-04-03_14-30-00',
-				'{counter}': '0',
 			};
 			let preview = this.filenameFormat || '';
 			for (const [token, value] of Object.entries(examples)) {
 				preview = preview.split(token).join(value);
 			}
+			// Counter tokens go through the real engine so the preview shows what
+			// the first file will actually be named: {counter} → 0, {counter+n} → n.
+			preview = fillCounterTokens(preview, 0);
 			const extMap = { jpeg: '.jpg', png: '.png', webp: '.webp' };
 			return preview + (extMap[this.outputFormat] || '.jpg');
 		},

--- a/src/utilities/filenameFormat.test.ts
+++ b/src/utilities/filenameFormat.test.ts
@@ -70,6 +70,16 @@ describe('resolveFilenameFormat', () => {
 			).toBe('Autodromo Nazionale Monza-Smith, B-7-{counter}');
 		});
 
+		it('leaves {counter+n} in place for the caller, like {counter}', () => {
+			expect(
+				resolveFilenameFormat(
+					'{track}-{counter+12}',
+					sessionInfo,
+					telemetry
+				)
+			).toBe('Monza-{counter+12}');
+		});
+
 		it('strips diacritics for filesystem safety', () => {
 			const trackSession = {
 				data: {
@@ -156,6 +166,14 @@ describe('resolveFilenameFormat', () => {
 					values: {},
 				})
 			).toBe('{counter}');
+		});
+
+		it('preserves an explicit bare {counter+n} format (no fallback)', () => {
+			expect(
+				resolveFilenameFormat('{counter+5}', trackSession('Monza'), {
+					values: {},
+				})
+			).toBe('{counter+5}');
 		});
 
 		it('preserves a non-Latin (CJK) name instead of falling back', () => {

--- a/src/utilities/filenameFormat.ts
+++ b/src/utilities/filenameFormat.ts
@@ -316,8 +316,8 @@ export const DEFAULT_FORMAT = '{track}-{driver}-{counter}';
 
 /**
  * Resolves a format string against session data, replacing all known tokens
- * with their corresponding values EXCEPT {counter}, which is left in place
- * for the caller (Worker.vue) to handle.
+ * with their corresponding values EXCEPT counter tokens ({counter} and
+ * {counter+n}), which are left in place for the caller (Worker.vue) to handle.
  *
  * After token replacement, characters that are invalid in Windows filenames
  * (\ / : * ? " < > |) are replaced with underscores.
@@ -325,6 +325,29 @@ export const DEFAULT_FORMAT = '{track}-{driver}-{counter}';
 /** Fallback name used when no session info is available — every session-derived
  *  token would resolve to '', producing degenerate filenames like '--0'. */
 export const FALLBACK_FORMAT = 'iRacingScreenshotTool-{counter}';
+
+// {counter} or {counter+n}: n is a non-negative offset added to the counter, so
+// {counter+5} numbers files 5, 6, 7… instead of 0, 1, 2… Digits are capped at 9
+// so a pathological offset can't push past Number's integer precision; a longer
+// one is left in the name as literal text, like any other unknown token.
+const COUNTER_TOKEN = /\{counter(?:\+(\d{1,9}))?\}/;
+const COUNTER_TOKEN_ALL = new RegExp(COUNTER_TOKEN.source, 'g');
+
+/** Whether the string contains {counter} or any {counter+n} variant. */
+export function hasCounterToken(formatString: string): boolean {
+	return COUNTER_TOKEN.test(formatString);
+}
+
+/** Every counter token filled from `count`: {counter} → count, {counter+n} → count+n. */
+export function fillCounterTokens(formatString: string, count: number): string {
+	return formatString.replace(COUNTER_TOKEN_ALL, (_match, offset) =>
+		String(count + (offset ? Number(offset) : 0))
+	);
+}
+
+function stripCounterTokens(formatString: string): string {
+	return formatString.replace(COUNTER_TOKEN_ALL, '');
+}
 
 export function resolveFilenameFormat(
 	formatString: string,
@@ -359,11 +382,13 @@ export function resolveFilenameFormat(
 	result = result.replace(/[\\/:*?"<>|]/g, '_');
 
 	// All-empty fallback (cq-utilities#2): if every session-derived token resolved
-	// empty AND the user didn't ask for a bare {counter}, fall back rather than emit
-	// a degenerate '.jpg'. Unicode-aware — a purely CJK/Cyrillic name (no Latin
-	// a-z0-9) is legitimate content and must be preserved, so test \p{L}/\p{N}.
-	const withoutCounter = result.split('{counter}').join('');
-	if (!/[\p{L}\p{N}]/u.test(withoutCounter) && !result.includes('{counter}')) {
+	// empty AND the user didn't ask for a bare counter ({counter} or {counter+n}),
+	// fall back rather than emit a degenerate '.jpg'. Unicode-aware — a purely
+	// CJK/Cyrillic name (no Latin a-z0-9) is legitimate content and must be
+	// preserved, so test \p{L}/\p{N}. Counter tokens are stripped first so a
+	// {counter+5} offset digit can't pass as name content.
+	const withoutCounter = stripCounterTokens(result);
+	if (!/[\p{L}\p{N}]/u.test(withoutCounter) && !hasCounterToken(result)) {
 		return FALLBACK_FORMAT;
 	}
 

--- a/src/utilities/screenshot-output.test.ts
+++ b/src/utilities/screenshot-output.test.ts
@@ -78,6 +78,60 @@ describe('buildUniqueScreenshotName', () => {
 		expect(name).toBe('Daytona-0-0');
 	});
 
+	test('starts {counter+n} numbering at n', () => {
+		const name = buildUniqueScreenshotName({
+			formatString: '{track}-{counter+5}',
+			sessionInfo,
+			telemetry,
+			exists: () => false,
+		});
+		expect(name).toBe('Daytona-5');
+	});
+
+	test('advances {counter+n} past collisions from the offset', () => {
+		// counter=0 → '5' taken, counter=1 → '6' taken, counter=2 → '7' free.
+		const taken = new Set(['Daytona-5', 'Daytona-6']);
+		const name = buildUniqueScreenshotName({
+			formatString: '{track}-{counter+5}',
+			sessionInfo,
+			telemetry,
+			exists: (n) => taken.has(n),
+		});
+		expect(name).toBe('Daytona-7');
+	});
+
+	test('fills mixed {counter} and {counter+n} from the same counter', () => {
+		const name = buildUniqueScreenshotName({
+			formatString: '{track}-{counter}-{counter+3}',
+			sessionInfo,
+			telemetry,
+			exists: () => false,
+		});
+		expect(name).toBe('Daytona-0-3');
+	});
+
+	test('leaves a malformed counter expression as literal text', () => {
+		// Not a counter token, so it also gets no uniqueness handling — it is
+		// ordinary (if odd) filename text, like any other unknown {token}.
+		const name = buildUniqueScreenshotName({
+			formatString: '{track}-{counter+x}',
+			sessionInfo,
+			telemetry,
+			exists: () => false,
+		});
+		expect(name).toBe('Daytona-{counter+x}');
+	});
+
+	test('leaves an over-long counter offset (10+ digits) as literal text', () => {
+		const name = buildUniqueScreenshotName({
+			formatString: '{track}-{counter+1234567890}',
+			sessionInfo,
+			telemetry,
+			exists: () => false,
+		});
+		expect(name).toBe('Daytona-{counter+1234567890}');
+	});
+
 	test('appends -N to a counter-less format on collision', () => {
 		const taken = new Set(['Daytona', 'Daytona-1']);
 		const name = buildUniqueScreenshotName({

--- a/src/utilities/screenshot-output.ts
+++ b/src/utilities/screenshot-output.ts
@@ -9,7 +9,11 @@
 // Everything here is pure except buildUniqueScreenshotName, whose only side
 // channel is an injected `exists` probe (fs.existsSync in production) — so it is
 // fully unit-testable without a filesystem.
-import { resolveFilenameFormat } from './filenameFormat';
+import {
+	resolveFilenameFormat,
+	hasCounterToken,
+	fillCounterTokens,
+} from './filenameFormat';
 
 // config 'outputFormat' key -> saved-file extension. Single source of truth for
 // the extension across both save paths (Worker.vue's FORMAT_MAP derives its
@@ -31,10 +35,11 @@ export function getOutputExtension(formatKey: unknown): string {
 
 // Resolve a filename format string against session/telemetry data to a UNIQUE
 // base name (no extension). {counter} is expanded to the first integer that
-// doesn't collide; a format without {counter} gets a `-N` suffix on collision.
-// `exists(baseName)` must report whether a file for that base name already
-// exists (the caller appends the extension + directory) — matching Worker.vue's
-// getScreenshotPath-based check exactly.
+// doesn't collide, and {counter+n} to that integer plus the offset n (so the
+// numbering starts at n); a format without a counter token gets a `-N` suffix
+// on collision. `exists(baseName)` must report whether a file for that base
+// name already exists (the caller appends the extension + directory) —
+// matching Worker.vue's getScreenshotPath-based check exactly.
 export function buildUniqueScreenshotName(opts: {
 	formatString: string;
 	// irsdk session/telemetry shapes are untyped upstream (see filenameFormat.ts)
@@ -47,23 +52,22 @@ export function buildUniqueScreenshotName(opts: {
 	const { formatString, sessionInfo, telemetry, exists } = opts;
 	const resolved = resolveFilenameFormat(formatString, sessionInfo, telemetry);
 
-	// {counter}: first non-colliding integer starting at 0. Use split/join so EVERY
-	// {counter} occurrence is expanded — String.replace hits only the first, leaving
-	// a literal '{counter}' behind in a two-counter format (cq-utilities#4).
-	if (resolved.includes('{counter}')) {
-		const fillCounter = (n: number): string =>
-			resolved.split('{counter}').join(String(n));
+	// Counter tokens: first non-colliding integer starting at 0, with each
+	// {counter+n} rendering that integer plus its offset. fillCounterTokens
+	// expands EVERY occurrence (cq-utilities#4: a single String.replace hit only
+	// the first, leaving a literal '{counter}' behind in a two-counter format).
+	if (hasCounterToken(resolved)) {
 		let count = 0;
-		let name = fillCounter(count);
+		let name = fillCounterTokens(resolved, count);
 		while (exists(name)) {
 			count += 1;
-			name = fillCounter(count);
+			name = fillCounterTokens(resolved, count);
 		}
 		return name;
 	}
 
-	// No {counter}: keep the resolved name, but disambiguate a collision with a
-	// `-N` suffix starting at 1.
+	// No counter token: keep the resolved name, but disambiguate a collision
+	// with a `-N` suffix starting at 1.
 	if (exists(resolved)) {
 		let count = 1;
 		while (exists(`${resolved}-${count}`)) {


### PR DESCRIPTION
## What

An offset variant of the filename counter token: `{counter+5}` numbers files starting at 5 instead of 0 — for continuing a sequence from a previous session rather than restarting it.

- **Engine** (`utilities/filenameFormat.ts`) — one token regex covers `{counter}` and `{counter+n}`; new `hasCounterToken`/`fillCounterTokens` helpers replace the scattered `'{counter}'` string checks. Offsets are capped at 9 digits so a pathological one can't push past integer precision — anything longer stays in the name as literal text like any other unknown token. The all-empty fallback check now strips counter tokens first, so an offset digit can't pass as name content.
- **Collision loop** (`utilities/screenshot-output.ts`) — `buildUniqueScreenshotName` fills every counter token from the first non-colliding integer, each offset added on top. Both save paths (Worker.vue stills and long-exposure output) already route through it, so the token works everywhere without touching them.
- **Preview** (`SettingsModal.vue`) — the filename preview now runs counter tokens through the real `fillCounterTokens` engine instead of a hardcoded `'{counter}' → '0'` mapping, so `{counter+5}` previews as 5.
- **Release notes** — a bullet in `RELEASE-NOTES-v3.3.1.md`.

## Verification

- Colocated suites cover the new behaviour: offset fill, mixed `{counter}`+`{counter+n}` formats, every-occurrence expansion, the 9-digit cap, and the fallback interaction (34 tests in the two files).
- Full suite green: 1264 tests across 46 files; `vue-tsc` clean; prettier clean on the touched code files (`RELEASE-NOTES-v3.3.1.md` was already unclean on master and is left alone — curated notes are consumed by release.js); eslint 0 errors (6 pre-existing warnings in untouched lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)