### PR TITLE
ci(release): split build, signing and publishing for SignPath production signing

### DIFF
--- a/.github/workflows/build-sign.yml
+++ b/.github/workflows/build-sign.yml
@@ -1,0 +1,217 @@
+name: Build & sign
+
+# Builds the installers and submits them to SignPath. Deliberately does NOT
+# publish anything — the caller decides what happens to the signed artifact.
+#
+# Two entry points, one implementation:
+#   * workflow_call     — release.yml calls this for every tagged release.
+#   * workflow_dispatch — a signing rehearsal you can run by hand off any
+#                         branch, normally against test-signing, to prove the
+#                         pipeline without cutting a release.
+#
+# The signing policy is an input rather than a constant, so there is exactly
+# one copy of the build here and the caller picks the certificate.
+on:
+    workflow_call:
+        inputs:
+            signing-policy-slug:
+                description: SignPath signing policy to sign with.
+                required: true
+                type: string
+        secrets:
+            SIGNPATH_API_TOKEN:
+                description: SignPath REST API token with submitter permission.
+                required: true
+    workflow_dispatch:
+        inputs:
+            signing-policy-slug:
+                description: SignPath signing policy to sign with.
+                required: true
+                type: choice
+                default: test-signing
+                options:
+                    - test-signing
+                    - release-signing
+
+jobs:
+    # ---------------------------------------------------------------------
+    # Everything that compiles. Ends by parking the unsigned executables in a
+    # workflow artifact — which is how SignPath receives them: it pulls the
+    # artifact from GitHub itself rather than trusting anything this job says.
+    # ---------------------------------------------------------------------
+    build:
+        # Pinned to windows-2022, NOT windows-latest — see the note in ci.yml.
+        # VS 2026 (the windows-latest default since June 2026) hits a C1001
+        # internal compiler error on node-addon-api while building
+        # @irsdk-node/native, which fails `npm ci`. This must stay in step with
+        # the runner ci.yml uses, so the release builds what CI tested.
+        runs-on: windows-2022
+        timeout-minutes: 60
+
+        permissions:
+            contents: read
+
+        outputs:
+            unsigned-artifact-id: ${{ steps.unsigned.outputs.artifact-id }}
+
+        steps:
+            - uses: actions/checkout@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 24
+                  cache: npm
+
+            - uses: dtolnay/rust-toolchain@stable
+
+            - uses: Swatinem/rust-cache@v2
+              with:
+                  workspaces: native/wgc-capture
+
+            # native/wgc-capture.node is committed for contributors' local
+            # `npm run dev`, but a release must never ship a binary older than
+            # src/lib.rs. Rebuild and overwrite it before electron-builder
+            # packages it in.
+            - name: Build native WGC addon
+              shell: bash
+              run: |
+                  cargo build --release --manifest-path native/wgc-capture/Cargo.toml
+                  cp native/wgc-capture/target/release/wgc_capture.dll native/wgc-capture.node
+
+            # postinstall rebuilds irsdk-node and sharp against Electron's headers.
+            - name: Install dependencies
+              run: npm ci
+
+            - name: Test
+              run: npm test
+
+            - name: Build bundles
+              run: npm run pack
+
+            # Produces the NSIS installer, the portable exe, the .blockmap and
+            # latest.yml in build/ WITHOUT publishing. Signing has to happen
+            # between packaging and upload, so the electron-builder publishers
+            # are out of the loop entirely — the publish job uploads the
+            # finished assets with gh.
+            - name: Package installers
+              run: npx electron-builder --publish never
+
+            # The unsigned executables travel to SignPath as a workflow
+            # artifact. GitHub delivers those as a ZIP, which is why the
+            # SignPath project's artifact configuration must have a <zip-file>
+            # root containing the pe-file entries for both executables.
+            - name: Stage unsigned executables
+              id: unsigned
+              uses: actions/upload-artifact@v4
+              with:
+                  name: unsigned-executables
+                  path: build/*.exe
+                  if-no-files-found: error
+                  overwrite: true
+
+            # latest.yml is produced here but consumed by the publish job on a
+            # different runner, so it has to travel too. The .blockmap files
+            # electron-builder wrote are deliberately NOT carried across: they
+            # describe unsigned bytes and are rebuilt after signing.
+            - name: Stage update manifest
+              uses: actions/upload-artifact@v4
+              with:
+                  name: release-metadata
+                  path: build/latest.yml
+                  if-no-files-found: error
+                  overwrite: true
+
+    # ---------------------------------------------------------------------
+    # Signing is a separate job, and that split is the whole point of this
+    # file.
+    #
+    # The production (release-signing) certificate requires a SignPath
+    # reviewer to approve every request by hand in the SignPath web UI, which
+    # can take hours or days. The test-signing certificate signs automatically
+    # with no human involved.
+    #
+    # Keeping signing out of the build job means:
+    #   * the ~40 minute build is finished and banked in an artifact before
+    #     anyone is asked to approve anything;
+    #   * if the wait below runs out, "Re-run failed jobs" resubmits from the
+    #     EXISTING unsigned artifact — no rebuild, roughly two minutes.
+    #
+    # That re-run only works because everything stays inside ONE workflow run.
+    # The signing request is bound to the run id the action reads from the
+    # environment, and SignPath checks the submitted artifact against it, so a
+    # separate workflow triggered later cannot submit this build's artifact.
+    # A re-run keeps the run id; a fresh run would not.
+    #
+    # Note the ceiling: GitHub kills any single job at 6 hours, so no timeout
+    # value can survive an approval that lands the next day. If that happens,
+    # approve the request anyway and re-run the failed jobs.
+    # ---------------------------------------------------------------------
+    sign:
+        needs: build
+        # Nothing here compiles — it is an HTTP call and a wait — so this job
+        # is not pinned to the build runner. It must still be GitHub-hosted:
+        # SignPath Foundation requires that for open-source projects.
+        runs-on: ubuntu-latest
+        # 5h30m, just inside GitHub's 6-hour hard cap on a single job.
+        timeout-minutes: 330
+
+        permissions:
+            # actions:read is what lets SignPath download the artifact using
+            # the workflow's own token; contents:read is for reading the
+            # repository. Nothing in this job writes.
+            actions: read
+            contents: read
+
+        steps:
+            - name: Submit signing request
+              id: signing
+              uses: signpath/github-action-submit-signing-request@v2
+              with:
+                  api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+                  organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+                  project-slug: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+                  signing-policy-slug: ${{ inputs.signing-policy-slug }}
+                  # An unset variable resolves to an empty string, which the
+                  # action treats exactly like an omitted input — SignPath then
+                  # applies the project's default artifact configuration. Set
+                  # the variable to pin a named configuration instead.
+                  artifact-configuration-slug: ${{ vars.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
+                  github-artifact-id: ${{ needs.build.outputs.unsigned-artifact-id }}
+                  # Blocks until the request reaches a final state. Under
+                  # release-signing that means blocking until a human approves.
+                  wait-for-completion: true
+                  # 5 hours, leaving the job timeout above enough headroom to
+                  # report the failure rather than being killed mid-step.
+                  wait-for-completion-timeout-in-seconds: 18000
+                  output-artifact-directory: signed
+
+            # Runs even when the wait times out — that is precisely when a link
+            # to the pending request is worth having.
+            - name: Record signing request
+              if: always()
+              shell: bash
+              run: |
+                  {
+                    echo "### SignPath signing request"
+                    echo
+                    echo "| | |"
+                    echo "|---|---|"
+                    echo "| Policy | \`${{ inputs.signing-policy-slug }}\` |"
+                    echo "| Request id | \`${{ steps.signing.outputs.signing-request-id }}\` |"
+                    echo "| Request | ${{ steps.signing.outputs.signing-request-web-url }} |"
+                    echo
+                    if [ "${{ steps.signing.outcome }}" != "success" ]; then
+                      echo "The signing request did not reach a final state within the"
+                      echo "wait window. Approve it at the link above, then use"
+                      echo "**Re-run failed jobs** on this run — it resubmits from the"
+                      echo "existing unsigned artifact and does not rebuild."
+                    fi
+                  } >> "$GITHUB_STEP_SUMMARY"
+
+            - name: Stage signed executables
+              uses: actions/upload-artifact@v4
+              with:
+                  name: signed-executables
+                  path: signed/*.exe
+                  if-no-files-found: error
+                  overwrite: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,18 @@ name: Release
 # `npm run release <major|minor|patch>` bumps, commits and tags locally, then
 # pushes the tag — which lands here. Everything from "build the installer"
 # onward is this workflow's job; release.js no longer builds or uploads.
+#
+# The run is three stages, and the split exists because of code signing:
+#
+#   prepare    guards the tag, picks the signing policy, opens a draft release
+#   build_sign build-sign.yml — compiles, then submits to SignPath in a
+#              SEPARATE job, because the production certificate needs a human
+#              at SignPath to approve every request
+#   publish    only ever sees SIGNED executables; publishes the draft
+#
+# Nothing unsigned can reach a public release: the release is created as a
+# draft before the build starts and is only taken out of draft in the last
+# step, by which point the assets attached to it came out of SignPath.
 on:
     push:
         tags:
@@ -10,44 +22,33 @@ on:
 
 # The workflow creates a draft release, uploads the signed assets into it with
 # gh, and the final step flips it out of draft. All need write access.
+#
+# actions:read is granted for the signing job: SignPath downloads the unsigned
+# artifact from GitHub itself, using this workflow's token. A permissions block
+# sets every scope it does not name to none, and a called workflow can only ask
+# for scopes the caller already holds — so omitting it here would silently
+# starve build-sign.yml's sign job.
 permissions:
     contents: write
+    actions: read
 
 concurrency:
     group: release-${{ github.ref }}
     cancel-in-progress: false
 
 jobs:
-    release:
-        # Pinned to windows-2022, NOT windows-latest — see the note in ci.yml.
-        # VS 2026 (the windows-latest default since June 2026) hits a C1001
-        # internal compiler error on node-addon-api while building
-        # @irsdk-node/native, which fails `npm ci`. This must stay in step with
-        # the runner ci.yml uses, so the release builds what CI tested.
-        runs-on: windows-2022
-        # ~40 minutes of build plus up to 30 minutes waiting for a signing
-        # approval (see the SignPath step).
-        timeout-minutes: 90
+    # ---------------------------------------------------------------------
+    # Cheap checks and the draft, all before the expensive build.
+    # ---------------------------------------------------------------------
+    prepare:
+        runs-on: ubuntu-latest
+        timeout-minutes: 10
 
-        env:
-            # Which SignPath policy signs this release.
-            #
-            # test-signing uses the self-signed test certificate: it proves the
-            # pipeline end to end but Windows does not trust it, so releases
-            # signed with it must not ship to users. Flip to release-signing
-            # once the Foundation's release certificate shows VALID in SignPath
-            # — and in the SAME change add
-            #     "publisherName": ["SignPath Foundation"]
-            # to package.json's build.win, so electron-updater starts verifying
-            # the signature of every downloaded update.
-            SIGNPATH_SIGNING_POLICY: test-signing
+        outputs:
+            signing-policy-slug: ${{ steps.policy.outputs.slug }}
 
         steps:
             - uses: actions/checkout@v4
-              with:
-                  # Release notes fall back to `git log <prevTag>..<tag>`, which
-                  # needs real history — the default shallow clone has none.
-                  fetch-depth: 0
 
             # A tag whose semver disagrees with package.json produces an installer
             # named for one version published under another. Fail before the
@@ -63,35 +64,62 @@ jobs:
                   fi
                   echo "Releasing $GITHUB_REF_NAME"
 
-            - uses: actions/setup-node@v4
-              with:
-                  node-version: 24
-                  cache: npm
+            # A missing variable would surface as "Input required and not
+            # supplied" inside the signing job — after the ~40 minute build.
+            # Check it here instead, where failing costs half a minute.
+            - name: Verify SignPath configuration
+              shell: bash
+              env:
+                  ORG_ID: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
+                  PROJECT_SLUG: ${{ vars.SIGNPATH_PROJECT_SLUG }}
+                  # Comparing in the expression keeps the token itself out of
+                  # the job environment; only the boolean crosses over.
+                  HAS_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN != '' }}
+              run: |
+                  ok=true
+                  if [ -z "$ORG_ID" ]; then
+                    echo "Missing repository variable SIGNPATH_ORGANIZATION_ID"
+                    ok=false
+                  fi
+                  if [ -z "$PROJECT_SLUG" ]; then
+                    echo "Missing repository variable SIGNPATH_PROJECT_SLUG"
+                    ok=false
+                  fi
+                  if [ "$HAS_TOKEN" != "true" ]; then
+                    echo "Missing repository secret SIGNPATH_API_TOKEN"
+                    ok=false
+                  fi
+                  if [ "$ok" != "true" ]; then
+                    echo "::error::SignPath is not fully configured for this repository — see the missing entries above."
+                    exit 1
+                  fi
+                  echo "SignPath configuration present."
 
-            - uses: dtolnay/rust-toolchain@stable
-
-            - uses: Swatinem/rust-cache@v2
-              with:
-                  workspaces: native/wgc-capture
-
-            # native/wgc-capture.node is committed for contributors' `npm run dev`,
-            # but a release must never ship a binary older than src/lib.rs.
-            # Rebuild and overwrite it before electron-builder packages it in.
-            - name: Build native WGC addon
+            # Which certificate signs this build.
+            #
+            # release-signing is the SignPath Foundation production certificate:
+            # Windows trusts it, and every single request against it has to be
+            # approved by hand by a SignPath reviewer, which may take hours.
+            #
+            # test-signing is the self-signed test certificate: it signs
+            # automatically with nobody in the loop, but Windows does not trust
+            # it, so anything signed with it must never ship to users. A
+            # prerelease-suffixed tag (v3.4.0-signing.1) is a pipeline
+            # rehearsal, and the publish step below already refuses to take
+            # those out of draft — so they get the test certificate and the
+            # rehearsal costs no reviewer's attention.
+            - name: Select signing policy
+              id: policy
               shell: bash
               run: |
-                  cargo build --release --manifest-path native/wgc-capture/Cargo.toml
-                  cp native/wgc-capture/target/release/wgc_capture.dll native/wgc-capture.node
-
-            # postinstall rebuilds irsdk-node and sharp against Electron's headers.
-            - name: Install dependencies
-              run: npm ci
-
-            - name: Test
-              run: npm test
-
-            - name: Build bundles
-              run: npm run pack
+                  version="${GITHUB_REF_NAME#v}"
+                  if [[ "$version" == *-* ]]; then
+                    slug=test-signing
+                  else
+                    slug=release-signing
+                  fi
+                  echo "slug=$slug" >> "$GITHUB_OUTPUT"
+                  echo "Signing $GITHUB_REF_NAME with the $slug policy"
 
             # Create the draft BEFORE anything uploads, and flip it public only
             # at the very end, so a failed run never leaves a half-populated
@@ -120,43 +148,121 @@ jobs:
                       --notes "Build in progress — this text is replaced when the release is published."
                   fi
 
-            # Produces the NSIS installer, the portable exe, the .blockmap and
-            # latest.yml in build/ WITHOUT publishing. Signing has to happen
-            # between packaging and upload, so the electron-builder publishers
-            # are out of the loop entirely — gh uploads the finished assets
-            # below.
-            - name: Package installers
-              run: npx electron-builder --publish never
+    # ---------------------------------------------------------------------
+    # Compile, then sign. Two jobs inside build-sign.yml; see the commentary
+    # there for why signing is not part of the build job.
+    # ---------------------------------------------------------------------
+    build_sign:
+        needs: prepare
+        uses: ./.github/workflows/build-sign.yml
+        with:
+            signing-policy-slug: ${{ needs.prepare.outputs.signing-policy-slug }}
+        secrets:
+            SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
 
-            # The unsigned executables travel to SignPath as a workflow
-            # artifact. GitHub delivers those as a ZIP, which is why the
-            # SignPath project's artifact configuration must have a <zip-file>
-            # root containing the pe-file entries for both executables.
-            - name: Stage unsigned executables
-              id: unsigned
-              uses: actions/upload-artifact@v4
-              with:
-                  name: unsigned-executables
-                  path: build/*.exe
-                  if-no-files-found: error
+    # ---------------------------------------------------------------------
+    # Everything here operates on the executables that came back from
+    # SignPath. `needs: build_sign` is what guarantees that: the job cannot
+    # start until the signed artifact exists.
+    # ---------------------------------------------------------------------
+    publish:
+        needs: [prepare, build_sign]
+        # Windows because the Authenticode check below uses
+        # Get-AuthenticodeSignature, which is the OS doing the parsing rather
+        # than us trusting a hand-rolled PE reader.
+        runs-on: windows-2022
+        timeout-minutes: 30
 
-            # Submits the signing request and waits for the signed artifact.
-            #
-            # Under release-signing this PAUSES mid-run until someone approves
-            # the request in the SignPath UI — approve within the timeout below
-            # or the job fails. A re-run rebuilds and resubmits; the draft
-            # release is reused.
-            - name: Sign executables
-              uses: signpath/github-action-submit-signing-request@v2
+        permissions:
+            contents: write
+            # Same-run artifact downloads use the Actions runtime token rather
+            # than this one, but naming the scope keeps the job honest about
+            # what it touches.
+            actions: read
+
+        steps:
+            - uses: actions/checkout@v4
               with:
-                  api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
-                  organization-id: ${{ vars.SIGNPATH_ORGANIZATION_ID }}
-                  project-slug: iracing-screenshot-tool
-                  signing-policy-slug: ${{ env.SIGNPATH_SIGNING_POLICY }}
-                  github-artifact-id: ${{ steps.unsigned.outputs.artifact-id }}
-                  wait-for-completion: true
-                  wait-for-completion-timeout-in-seconds: 1800
-                  output-artifact-directory: build/signed
+                  # Release notes fall back to `git log <prevTag>..<tag>`, which
+                  # needs real history — the default shallow clone has none.
+                  fetch-depth: 0
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: 24
+                  cache: npm
+
+            # --ignore-scripts skips the postinstall that rebuilds irsdk-node
+            # and sharp against Electron — several minutes of native compilation
+            # this job has no use for. finalize-signed-artifacts.js only needs
+            # js-yaml and app-builder-lib's blockmap module, and that module
+            # pulls nothing but crypto, fs, zlib and @noble/hashes.
+            - name: Install dependencies
+              run: npm ci --ignore-scripts
+
+            - name: Download signed executables
+              uses: actions/download-artifact@v4
+              with:
+                  name: signed-executables
+                  path: build
+
+            - name: Download update manifest
+              uses: actions/download-artifact@v4
+              with:
+                  name: release-metadata
+                  path: build
+
+            # The last line of defence before anything is attached to a release.
+            # The steps above cannot really deliver an unsigned binary, but this
+            # is cheap and it catches the failure that would be worst to miss:
+            # a real tag that got signed with the untrusted test certificate.
+            - name: Verify Authenticode signatures
+              shell: pwsh
+              env:
+                  SIGNING_POLICY: ${{ needs.prepare.outputs.signing-policy-slug }}
+                  # The subject the SignPath Foundation certificate signs under.
+                  # Overridable as a repo variable so a certificate reissue with
+                  # a different subject does not need a code change.
+                  EXPECTED_PUBLISHER: ${{ vars.SIGNPATH_EXPECTED_PUBLISHER }}
+              run: |
+                  $expected = $env:EXPECTED_PUBLISHER
+                  if (-not $expected) { $expected = 'SignPath Foundation' }
+
+                  # Only the production certificate carries a meaningful
+                  # publisher name; the test certificate is self-signed and its
+                  # subject is whatever the SignPath test CA issued.
+                  $requirePublisher = $env:SIGNING_POLICY -eq 'release-signing'
+
+                  $exes = @(Get-ChildItem -Path build -Filter *.exe)
+                  if ($exes.Count -lt 2) {
+                      throw "Expected the installer and the portable build in build/, found $($exes.Count) .exe file(s)."
+                  }
+
+                  $failed = $false
+                  foreach ($exe in $exes) {
+                      $sig = Get-AuthenticodeSignature -FilePath $exe.FullName
+                      $subject = if ($sig.SignerCertificate) { $sig.SignerCertificate.Subject } else { '<none>' }
+                      Write-Host "$($exe.Name): status=$($sig.Status) subject=$subject"
+
+                      # Status is deliberately not asserted. A test-signed
+                      # binary reports UnknownError because the runner does not
+                      # trust the self-signed chain, which is expected and not a
+                      # defect — the presence of a signer certificate is what
+                      # tells us SignPath actually signed the file.
+                      if (-not $sig.SignerCertificate) {
+                          Write-Host "::error::$($exe.Name) carries no Authenticode signature."
+                          $failed = $true
+                          continue
+                      }
+
+                      if ($requirePublisher -and $subject -notlike "*$expected*") {
+                          Write-Host "::error::$($exe.Name) is signed by '$subject', which does not contain '$expected'. Refusing to publish a release signed with the wrong certificate."
+                          $failed = $true
+                      }
+                  }
+
+                  if ($failed) { exit 1 }
+                  Write-Host "All $($exes.Count) executables are signed$(if ($requirePublisher) { " by $expected" })."
 
             # Signing changed every byte electron-builder hashed, so the
             # update manifest and blockmap must be rebuilt from the SIGNED
@@ -168,9 +274,7 @@ jobs:
             # the space-named files).
             - name: Rebuild update manifest from signed executables
               shell: bash
-              run: |
-                  cp build/signed/*.exe build/
-                  node _scripts/finalize-signed-artifacts.js build
+              run: node _scripts/finalize-signed-artifacts.js build
 
             - name: Upload artifacts
               shell: bash
@@ -256,7 +360,7 @@ jobs:
                   # rehearsal, not a release: run every guard above, then STOP,
                   # leaving the draft in place for inspection and deletion.
                   # Flipping it public with --latest would offer the build to
-                  # every auto-updating user — which for a rehearsal may be a
+                  # every auto-updating user — which for a rehearsal is a
                   # test-signed binary Windows does not trust.
                   if [[ "$version" == *-* ]]; then
                     echo "Prerelease tag ${tag}: all checks passed. Leaving the release as a draft."

--- a/README.md
+++ b/README.md
@@ -45,6 +45,16 @@ Updated 2026-08-17 · refresh with `npm run stats:downloads`.</sub>
 
 <!-- download-stats:end -->
 
+# Code signing policy
+The Windows installer and the portable executable are digitally signed, so Windows shows a verified publisher instead of an unknown-publisher warning.
+
+Free code signing provided by [SignPath.io](https://about.signpath.io), certificate by [SignPath Foundation](https://signpath.org).
+
+* **Committers and reviewers:** [project contributors](https://github.com/svglol/iracing-screenshot-tool/graphs/contributors)
+* **Approvers:** [@svglol](https://github.com/svglol)
+
+**Privacy policy:** this program does not transfer any information to other networked systems, with one exception — it contacts GitHub to check this repository's releases for a newer version and to show you what changed in it. An update is downloaded and installed only after you confirm it. No analytics, usage data or personal information is collected or sent.
+
 # Support
 Please go to our Discord server and report any issues you are having. [![Discord](https://img.shields.io/discord/626921718442754048.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/GX2kSgN)
 

--- a/package.json
+++ b/package.json
@@ -40,7 +40,10 @@
                 "nsis",
                 "portable"
             ],
-            "signAndEditExecutable": false
+            "signAndEditExecutable": false,
+            "publisherName": [
+                "SignPath Foundation"
+            ]
         },
         "nsis": {
             "include": "_scripts/installer.nsh"


### PR DESCRIPTION
Restructures the release pipeline for the switch from the self-signed test
certificate to the SignPath Foundation production certificate.

The test certificate signs automatically. The production one requires a
SignPath reviewer to approve **every** signing request by hand in the SignPath
web UI, which can take hours. With signing inside the build job, a ~40 minute
build would sit blocking on that.

## What changed

`release.yml` becomes three stages, and the compile plus the SignPath
submission move into a new reusable `build-sign.yml`:

```
prepare      tag guard · SignPath config guard · policy selection · draft release
build_sign   build-sign.yml
             ├─ build   cargo · npm ci · test · pack · electron-builder
             │          uploads unsigned-executables (zip) + release-metadata
             └─ sign    submits to SignPath and waits
publish      downloads the SIGNED artifact · verifies signatures · finalize · publish
```

The build logic itself is unchanged — the steps moved verbatim.

## Why the split

The build finishes and is banked in an artifact before anyone is asked to
approve anything. When the wait runs out, **Re-run failed jobs** resubmits from
the existing artifact in ~2 minutes instead of rebuilding.

Everything stays inside one workflow run on purpose: the action posts
`GITHUB_RUN_ID` alongside the artifact id and SignPath validates the pair, so a
separate `workflow_run` workflow *cannot* submit an earlier run's artifact.
That is also why the wait is capped at GitHub's six-hour job limit — no timeout
value gets around it, so the re-run path above is the recovery, and the sign job
prints the signing-request link to the job summary on failure so it is one click
away.

## Signing policy is now selected, not pinned

`SIGNPATH_SIGNING_POLICY` in an `env:` block is gone. `prepare` picks:

| Trigger | Policy |
|---|---|
| plain tag (`v3.4.0`) | `release-signing` |
| prerelease tag (`v3.4.0-signing.1`) | `test-signing` — already stops at draft |
| manual run of `build-sign.yml` | dropdown, defaults to `test-signing` |

**This arms production signing.** Previously the flip needed a code change;
now any plain `vX.Y.Z` tag submits against the production certificate.

## Guards added

- `prepare` fails in ~30s if a SignPath variable or the secret is missing,
  rather than letting the sign job discover it after the build.
- `publish` requires every exe to carry an Authenticode signature, and under
  `release-signing` that the signer subject matches the expected publisher —
  which catches a real tag accidentally signed with the untrusted test cert.
- `actions: read` added at workflow level. A `permissions` block sets unnamed
  scopes to `none`, and a called workflow can only request what the caller
  holds, so without it the sign job could not let SignPath fetch the artifact.

## Also here

- `win.publisherName` so electron-updater verifies the publisher of each
  downloaded update. Must match the certificate subject CN exactly; the publish
  job prints each subject, and a repo variable overrides it without a code
  change. Existing unsigned installs are unaffected.
- README `Code signing policy` section — required by the Foundation's terms
  (attribution, roles, privacy statement). The privacy paragraph is written
  from what the app actually does, since it does contact `api.github.com` on
  its own for update checks.

## Repository configuration

`SIGNPATH_PROJECT_SLUG` has been created; `SIGNPATH_ORGANIZATION_ID` and the
`SIGNPATH_API_TOKEN` secret already existed. Optional:
`SIGNPATH_ARTIFACT_CONFIGURATION_SLUG` (unset = project default, as today) and
`SIGNPATH_EXPECTED_PUBLISHER` (unset = `SignPath Foundation`).

## Before merging / first production release

Not verifiable from CI — needs the SignPath UI:

- [ ] release certificate shows VALID
- [ ] `release-signing` policy is bound to it
- [ ] **the API token has Submitter permission on `release-signing`**, not just
      `test-signing` — the token predates that policy and this is the likeliest
      first-run failure
- [ ] the certificate's subject CN matches `publisherName`

A prerelease tag rehearses the plumbing but routes to `test-signing`, so it
does not exercise the production policy or token permission. To prove those,
run `build-sign.yml` manually with the policy dropdown on `release-signing`: it
builds, submits a real request to approve, and stops without touching a release.

## Testing

`npm test` — 46 files, 1264 passed. All three workflows parse. The pipeline was
last proven end-to-end by the `v3.3.1-signing.1` rehearsal on 2026-08-14, which
this restructures rather than replaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PnCd93fVGKyPPrrohP8wj9
